### PR TITLE
Testing integration tests in CI

### DIFF
--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -36,10 +36,10 @@ jobs:
         working-directory: ./OpenSearch
         run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=alpha1 -Dbuild.snapshot=false
         
-      # common-utils
+      # job-scheduler
       - name: Build and Test
         run: |
-          ./gradlew test -Dopensearch.version=1.0.0-alpha1 -Dbuild.snapshot=false
+          ./gradlew build -Dopensearch.version=1.0.0-alpha1 -Dbuild.snapshot=false
 
       - name: Publish to Maven Local
         run: |


### PR DESCRIPTION
Signed-off-by: Mohammad Qureshi <qreshi@amazon.com>

### Description

Use the `build` target that runs integration tests.
This PR is a duplicate of #12 but will be used for testing since the integ failures are happening on the GitHub Action workflow but not locally.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
