### PR TITLE
Rename settings from OpenDistro and OpenSearch, with backwards compatibility, using upgraders

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/JobSchedulerPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/JobSchedulerPlugin.java
@@ -42,6 +42,8 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.ParseField;
 import org.opensearch.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.SettingUpgrader;
+import org.opensearch.common.settings.GenericSettingUpgrader;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.OpenSearchExecutors;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
@@ -66,7 +68,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
-
 
 public class JobSchedulerPlugin extends Plugin implements ExtensiblePlugin {
 
@@ -111,7 +112,33 @@ public class JobSchedulerPlugin extends Plugin implements ExtensiblePlugin {
         settingList.add(JobSchedulerSettings.SWEEP_BACKOFF_RETRY_COUNT);
         settingList.add(JobSchedulerSettings.SWEEP_PERIOD);
         settingList.add(JobSchedulerSettings.JITTER_LIMIT);
+        // legacy OpenDistro settings
+        settingList.add(JobSchedulerSettings.LEGACY_OPENDISTRO_SWEEP_PAGE_SIZE);
+        settingList.add(JobSchedulerSettings.LEGACY_OPENDISTRO_REQUEST_TIMEOUT);
+        settingList.add(JobSchedulerSettings.LEGACY_OPENDISTRO_SWEEP_BACKOFF_MILLIS);
+        settingList.add(JobSchedulerSettings.LEGACY_OPENDISTRO_SWEEP_BACKOFF_RETRY_COUNT);
+        settingList.add(JobSchedulerSettings.LEGACY_OPENDISTRO_SWEEP_PERIOD);
+        settingList.add(JobSchedulerSettings.LEGACY_OPENDISTRO_JITTER_LIMIT);
         return settingList;
+    }
+
+
+    
+    public List<SettingUpgrader<?>> getSettingUpgraders() {
+        List<SettingUpgrader<?>> settingUpgraders = new ArrayList<>();
+        settingUpgraders.add(new GenericSettingUpgrader<>(JobSchedulerSettings.LEGACY_OPENDISTRO_SWEEP_PAGE_SIZE, 
+            JobSchedulerSettings.SWEEP_PAGE_SIZE));
+        settingUpgraders.add(new GenericSettingUpgrader<>(JobSchedulerSettings.LEGACY_OPENDISTRO_REQUEST_TIMEOUT, 
+            JobSchedulerSettings.REQUEST_TIMEOUT));
+        settingUpgraders.add(new GenericSettingUpgrader<>(JobSchedulerSettings.LEGACY_OPENDISTRO_SWEEP_BACKOFF_MILLIS, 
+            JobSchedulerSettings.SWEEP_BACKOFF_MILLIS));
+        settingUpgraders.add(new GenericSettingUpgrader<>(JobSchedulerSettings.LEGACY_OPENDISTRO_SWEEP_BACKOFF_RETRY_COUNT, 
+            JobSchedulerSettings.SWEEP_BACKOFF_RETRY_COUNT));
+        settingUpgraders.add(new GenericSettingUpgrader<>(JobSchedulerSettings.LEGACY_OPENDISTRO_SWEEP_PERIOD, 
+            JobSchedulerSettings.SWEEP_PERIOD));
+        settingUpgraders.add(new GenericSettingUpgrader<>(JobSchedulerSettings.LEGACY_OPENDISTRO_JITTER_LIMIT, 
+            JobSchedulerSettings.JITTER_LIMIT));
+        return settingUpgraders;
     }
 
     @Override

--- a/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/JobSchedulerSettings.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/JobSchedulerSettings.java
@@ -31,34 +31,52 @@ import org.opensearch.common.unit.TimeValue;
 
 public class JobSchedulerSettings {
     public static final Setting<TimeValue> REQUEST_TIMEOUT = Setting.positiveTimeSetting(
-            "opendistro.jobscheduler.request_timeout",
+            "opensearch.jobscheduler.request_timeout",
             TimeValue.timeValueSeconds(10),
             Setting.Property.NodeScope, Setting.Property.Dynamic);
 
     public static final Setting<TimeValue> SWEEP_BACKOFF_MILLIS = Setting.positiveTimeSetting(
-            "opendistro.jobscheduler.sweeper.backoff_millis",
+            "opensearch.jobscheduler.sweeper.backoff_millis",
             TimeValue.timeValueMillis(50),
             Setting.Property.NodeScope, Setting.Property.Dynamic);
 
     public static final Setting<Integer> SWEEP_BACKOFF_RETRY_COUNT = Setting.intSetting(
-            "opendistro.jobscheduler.retry_count",
-            3,
+            "opensearch.jobscheduler.retry_count",
+            3, 
             Setting.Property.NodeScope, Setting.Property.Dynamic);
 
     public static final Setting<TimeValue> SWEEP_PERIOD = Setting.positiveTimeSetting(
-            "opendistro.jobscheduler.sweeper.period",
+            "opensearch.jobscheduler.sweeper.period",
             TimeValue.timeValueMinutes(5),
             Setting.Property.NodeScope, Setting.Property.Dynamic);
 
     public static final Setting<Integer> SWEEP_PAGE_SIZE = Setting.intSetting(
-            "opendistro.jobscheduler.sweeper.page_size",
-            100,
+            "opensearch.jobscheduler.sweeper.page_size",
+            100, 
             Setting.Property.NodeScope, Setting.Property.Dynamic);
 
     public static final Setting<Double> JITTER_LIMIT = Setting.doubleSetting(
-            "opendistro.jobscheduler.jitter_limit",
-            0.60, 0, 0.95,
+            "opensearch.jobscheduler.jitter_limit",
+            0.60, 0, 0.95, 
             Setting.Property.NodeScope, Setting.Property.Dynamic);
 
+    // legacy settings from OpenDistro
+    
+    public static final Setting<TimeValue> LEGACY_OPENDISTRO_REQUEST_TIMEOUT = REQUEST_TIMEOUT.withKey(
+            "opendistro.jobscheduler.request_timeout");
 
+    public static final Setting<TimeValue> LEGACY_OPENDISTRO_SWEEP_BACKOFF_MILLIS = SWEEP_BACKOFF_MILLIS.withKey(
+            "opendistro.jobscheduler.sweeper.backoff_millis");
+
+    public static final Setting<Integer> LEGACY_OPENDISTRO_SWEEP_BACKOFF_RETRY_COUNT = SWEEP_BACKOFF_RETRY_COUNT.withKey(
+            "opendistro.jobscheduler.retry_count");
+
+    public static final Setting<TimeValue> LEGACY_OPENDISTRO_SWEEP_PERIOD = SWEEP_PERIOD.withKey(
+            "opendistro.jobscheduler.sweeper.period");
+
+    public static final Setting<Integer> LEGACY_OPENDISTRO_SWEEP_PAGE_SIZE = SWEEP_PAGE_SIZE.withKey(
+            "opendistro.jobscheduler.sweeper.page_size");
+
+    public static final Setting<Double> LEGACY_OPENDISTRO_JITTER_LIMIT = JITTER_LIMIT.withKey(
+            "opendistro.jobscheduler.jitter_limit");
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/sweeper/JobSweeper.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/sweeper/JobSweeper.java
@@ -148,25 +148,36 @@ public class JobSweeper extends LifecycleListener implements IndexingOperationLi
         clusterService.getClusterSettings().addSettingsUpdateConsumer(JobSchedulerSettings.SWEEP_PERIOD,
                 timeValue -> {
                     sweepPeriod = timeValue;
-                    log.debug("Reinitializing background full sweep with period: " + sweepPeriod.getMinutes());
+                    log.debug("Reinitializing background full sweep with period: " + this.sweepPeriod.getMinutes());
                     initBackgroundSweep();
                 });
         clusterService.getClusterSettings().addSettingsUpdateConsumer(JobSchedulerSettings.SWEEP_PAGE_SIZE,
-                intValue -> sweepPageMaxSize = intValue);
+                intValue -> {
+                    sweepPageMaxSize = intValue;
+                    log.debug("Setting background sweep page size: " + this.sweepPageMaxSize);
+                });
         clusterService.getClusterSettings().addSettingsUpdateConsumer(JobSchedulerSettings.REQUEST_TIMEOUT,
-                timeValue -> this.sweepSearchTimeout = timeValue);
+                timeValue -> {
+                    this.sweepSearchTimeout = timeValue;
+                    log.debug("Setting background sweep search timeout: " + this.sweepSearchTimeout.getMinutes());
+                });
         clusterService.getClusterSettings().addSettingsUpdateConsumer(JobSchedulerSettings.SWEEP_BACKOFF_MILLIS,
                 timeValue -> {
                     this.sweepSearchBackoffMillis = timeValue;
                     this.sweepSearchBackoff = this.updateRetryPolicy();
+                    log.debug("Setting background sweep search backoff: " + this.sweepSearchBackoffMillis.getMillis());
                 });
         clusterService.getClusterSettings().addSettingsUpdateConsumer(JobSchedulerSettings.SWEEP_BACKOFF_RETRY_COUNT,
                 intValue -> {
                     this.sweepSearchBackoffRetryCount = intValue;
                     this.sweepSearchBackoff = this.updateRetryPolicy();
+                    log.debug("Setting background sweep search backoff retry count: " + this.sweepSearchBackoffRetryCount);
                 });
         clusterService.getClusterSettings().addSettingsUpdateConsumer(JobSchedulerSettings.JITTER_LIMIT,
-                doubleValue -> this.jitterLimit = doubleValue);
+                doubleValue -> {
+                    this.jitterLimit = doubleValue;
+                    log.debug("Setting background sweep jitter limit: " + this.jitterLimit);
+                });
     }
 
     private BackoffPolicy updateRetryPolicy() {


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

1. Rename setting from opendistro to opensearch.
2. Provide backwards compatibility for opendistro settings.
3. TODO: tests
 
Depends on https://github.com/opensearch-project/OpenSearch/pull/643

Manually testing this:

Install OpenDistro

```
wget https://d3g5vo6xdbdb9a.cloudfront.net/tarball/opendistro-elasticsearch/opendistroforelasticsearch-1.13.2-linux-x64.tar.gz
tar vfxz opendistroforelasticsearch-1.13.2-linux-x64.tar.gz
cd opendistroforelasticsearch-1.13.2
./bin/elasticsearch
```

Set `opendistro.jobscheduler.retry_count: 6`.

```
curl -X PUT "localhost:9200/_cluster/settings?pretty" -H 'Content-Type: application/json' -d'{"persistent":{"opendistro.jobscheduler.retry_count":6}}'
```

Stop OpenDistro, install OpenSearch on top (or copy data). I built just the minimal engine + job-scheduler from source with these changes.

```
tar vfxz opensearch-1.0.0-beta1-linux-x64.tar.gz 
cd opensearch-1.0.0-beta1
./bin/opensearch-plugin install opensearch-job-scheduler-1.0.0.0-beta1.zip 
rm -rf data
cp -R ../opendistroforelasticsearch-1.13.2/data .
```

See it.

```
[2021-05-04T19:54:40,637][INFO ][o.o.c.s.ClusterSettings  ] [ip-172-31-41-248] updating [opensearch.jobscheduler.retry_count] from [3] to [6]
[2021-05-04T19:54:40,637][INFO ][c.a.o.j.s.JobSweeper     ] [ip-172-31-41-248] Setting background sweep search backoff retry count: 6
```
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
