### PR TITLE
Rename settings from OpenDistro and OpenSearch, with backwards compatibility, using fallback

### DIFF
--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -30,20 +30,20 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: 'opensearch-project/OpenSearch'
-          ref: '1.0.0-beta1'
+          ref: '1.x'
           path: OpenSearch
       - name: Build OpenSearch
         working-directory: ./OpenSearch
-        run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=beta1 -Dbuild.snapshot=false
+        run: ./gradlew publishToMavenLocal -Dbuild.snapshot=false
         
       # job-scheduler
       - name: Build and Test
         run: |
-          ./gradlew build -Dopensearch.version=1.0.0-beta1 -Dbuild.snapshot=false
+          ./gradlew build -Dopensearch.version=1.0.0 -Dbuild.snapshot=false
 
       - name: Publish to Maven Local
         run: |
-          ./gradlew publishToMavenLocal -Dopensearch.version=1.0.0-beta1 -Dbuild.snapshot=false
+          ./gradlew publishToMavenLocal -Dopensearch.version=1.0.0 -Dbuild.snapshot=false
           
       - name: Upload Coverage Report
         uses: codecov/codecov-action@v1

--- a/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/JobSchedulerPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/JobSchedulerPlugin.java
@@ -105,6 +105,12 @@ public class JobSchedulerPlugin extends Plugin implements ExtensiblePlugin {
     @Override
     public List<Setting<?>> getSettings() {
         List<Setting<?>> settingList = new ArrayList<>();
+        settingList.add(LegacyOpenDistroJobSchedulerSettings.SWEEP_PAGE_SIZE);
+        settingList.add(LegacyOpenDistroJobSchedulerSettings.REQUEST_TIMEOUT);
+        settingList.add(LegacyOpenDistroJobSchedulerSettings.SWEEP_BACKOFF_MILLIS);
+        settingList.add(LegacyOpenDistroJobSchedulerSettings.SWEEP_BACKOFF_RETRY_COUNT);
+        settingList.add(LegacyOpenDistroJobSchedulerSettings.SWEEP_PERIOD);
+        settingList.add(LegacyOpenDistroJobSchedulerSettings.JITTER_LIMIT);
         settingList.add(JobSchedulerSettings.SWEEP_PAGE_SIZE);
         settingList.add(JobSchedulerSettings.REQUEST_TIMEOUT);
         settingList.add(JobSchedulerSettings.SWEEP_BACKOFF_MILLIS);

--- a/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/LegacyOpenDistroJobSchedulerSettings.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/LegacyOpenDistroJobSchedulerSettings.java
@@ -33,30 +33,30 @@ public class LegacyOpenDistroJobSchedulerSettings {
     public static final Setting<TimeValue> REQUEST_TIMEOUT = Setting.positiveTimeSetting(
             "opendistro.jobscheduler.request_timeout",
             TimeValue.timeValueSeconds(10),
-            Setting.Property.NodeScope, Setting.Property.Dynamic, Setting.Property.Deprecated);
+            Setting.Property.NodeScope, Setting.Property.Dynamic);
 
     public static final Setting<TimeValue> SWEEP_BACKOFF_MILLIS = Setting.positiveTimeSetting(
             "opendistro.jobscheduler.sweeper.backoff_millis",
             TimeValue.timeValueMillis(50),
-            Setting.Property.NodeScope, Setting.Property.Dynamic, Setting.Property.Deprecated);
+            Setting.Property.NodeScope, Setting.Property.Dynamic);
 
     public static final Setting<Integer> SWEEP_BACKOFF_RETRY_COUNT = Setting.intSetting(
             "opendistro.jobscheduler.retry_count",
             3,
-            Setting.Property.NodeScope, Setting.Property.Dynamic, Setting.Property.Deprecated);
+            Setting.Property.NodeScope, Setting.Property.Dynamic);
 
     public static final Setting<TimeValue> SWEEP_PERIOD = Setting.positiveTimeSetting(
             "opendistro.jobscheduler.sweeper.period",
             TimeValue.timeValueMinutes(5),
-            Setting.Property.NodeScope, Setting.Property.Dynamic, Setting.Property.Deprecated);
+            Setting.Property.NodeScope, Setting.Property.Dynamic);
 
     public static final Setting<Integer> SWEEP_PAGE_SIZE = Setting.intSetting(
             "opendistro.jobscheduler.sweeper.page_size",
             100,
-            Setting.Property.NodeScope, Setting.Property.Dynamic, Setting.Property.Deprecated);
+            Setting.Property.NodeScope, Setting.Property.Dynamic);
 
     public static final Setting<Double> JITTER_LIMIT = Setting.doubleSetting(
             "opendistro.jobscheduler.jitter_limit",
             0.60, 0, 0.95,
-            Setting.Property.NodeScope, Setting.Property.Dynamic, Setting.Property.Deprecated);
+            Setting.Property.NodeScope, Setting.Property.Dynamic);
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/LegacyOpenDistroJobSchedulerSettings.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/LegacyOpenDistroJobSchedulerSettings.java
@@ -29,34 +29,34 @@ package com.amazon.opendistroforelasticsearch.jobscheduler;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.unit.TimeValue;
 
-public class JobSchedulerSettings {
+public class LegacyOpenDistroJobSchedulerSettings {
     public static final Setting<TimeValue> REQUEST_TIMEOUT = Setting.positiveTimeSetting(
-            "opensearch.jobscheduler.request_timeout",
-            LegacyOpenDistroJobSchedulerSettings.REQUEST_TIMEOUT,
-            Setting.Property.NodeScope, Setting.Property.Dynamic);
+            "opendistro.jobscheduler.request_timeout",
+            TimeValue.timeValueSeconds(10),
+            Setting.Property.NodeScope, Setting.Property.Dynamic, Setting.Property.Deprecated);
 
     public static final Setting<TimeValue> SWEEP_BACKOFF_MILLIS = Setting.positiveTimeSetting(
-            "opensearch.jobscheduler.sweeper.backoff_millis",
-            LegacyOpenDistroJobSchedulerSettings.SWEEP_BACKOFF_MILLIS,
-            Setting.Property.NodeScope, Setting.Property.Dynamic);
+            "opendistro.jobscheduler.sweeper.backoff_millis",
+            TimeValue.timeValueMillis(50),
+            Setting.Property.NodeScope, Setting.Property.Dynamic, Setting.Property.Deprecated);
 
     public static final Setting<Integer> SWEEP_BACKOFF_RETRY_COUNT = Setting.intSetting(
-            "opensearch.jobscheduler.retry_count",
-            LegacyOpenDistroJobSchedulerSettings.SWEEP_BACKOFF_RETRY_COUNT,
-            Setting.Property.NodeScope, Setting.Property.Dynamic);
+            "opendistro.jobscheduler.retry_count",
+            3,
+            Setting.Property.NodeScope, Setting.Property.Dynamic, Setting.Property.Deprecated);
 
     public static final Setting<TimeValue> SWEEP_PERIOD = Setting.positiveTimeSetting(
-            "opensearch.jobscheduler.sweeper.period",
-            LegacyOpenDistroJobSchedulerSettings.SWEEP_PERIOD,
-            Setting.Property.NodeScope, Setting.Property.Dynamic);
+            "opendistro.jobscheduler.sweeper.period",
+            TimeValue.timeValueMinutes(5),
+            Setting.Property.NodeScope, Setting.Property.Dynamic, Setting.Property.Deprecated);
 
     public static final Setting<Integer> SWEEP_PAGE_SIZE = Setting.intSetting(
-            "opensearch.jobscheduler.sweeper.page_size",
-            LegacyOpenDistroJobSchedulerSettings.SWEEP_PAGE_SIZE,
-            Setting.Property.NodeScope, Setting.Property.Dynamic);
+            "opendistro.jobscheduler.sweeper.page_size",
+            100,
+            Setting.Property.NodeScope, Setting.Property.Dynamic, Setting.Property.Deprecated);
 
     public static final Setting<Double> JITTER_LIMIT = Setting.doubleSetting(
-            "opensearch.jobscheduler.jitter_limit",
-            LegacyOpenDistroJobSchedulerSettings.JITTER_LIMIT,
-            Setting.Property.NodeScope, Setting.Property.Dynamic);
+            "opendistro.jobscheduler.jitter_limit",
+            0.60, 0, 0.95,
+            Setting.Property.NodeScope, Setting.Property.Dynamic, Setting.Property.Deprecated);
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/LegacyOpenDistroJobSchedulerSettings.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/LegacyOpenDistroJobSchedulerSettings.java
@@ -33,30 +33,30 @@ public class LegacyOpenDistroJobSchedulerSettings {
     public static final Setting<TimeValue> REQUEST_TIMEOUT = Setting.positiveTimeSetting(
             "opendistro.jobscheduler.request_timeout",
             TimeValue.timeValueSeconds(10),
-            Setting.Property.NodeScope, Setting.Property.Dynamic);
+            Setting.Property.NodeScope, Setting.Property.Dynamic, Setting.Property.Deprecated);
 
     public static final Setting<TimeValue> SWEEP_BACKOFF_MILLIS = Setting.positiveTimeSetting(
             "opendistro.jobscheduler.sweeper.backoff_millis",
             TimeValue.timeValueMillis(50),
-            Setting.Property.NodeScope, Setting.Property.Dynamic);
+            Setting.Property.NodeScope, Setting.Property.Dynamic, Setting.Property.Deprecated);
 
     public static final Setting<Integer> SWEEP_BACKOFF_RETRY_COUNT = Setting.intSetting(
             "opendistro.jobscheduler.retry_count",
             3,
-            Setting.Property.NodeScope, Setting.Property.Dynamic);
+            Setting.Property.NodeScope, Setting.Property.Dynamic, Setting.Property.Deprecated);
 
     public static final Setting<TimeValue> SWEEP_PERIOD = Setting.positiveTimeSetting(
             "opendistro.jobscheduler.sweeper.period",
             TimeValue.timeValueMinutes(5),
-            Setting.Property.NodeScope, Setting.Property.Dynamic);
+            Setting.Property.NodeScope, Setting.Property.Dynamic, Setting.Property.Deprecated);
 
     public static final Setting<Integer> SWEEP_PAGE_SIZE = Setting.intSetting(
             "opendistro.jobscheduler.sweeper.page_size",
             100,
-            Setting.Property.NodeScope, Setting.Property.Dynamic);
+            Setting.Property.NodeScope, Setting.Property.Dynamic, Setting.Property.Deprecated);
 
     public static final Setting<Double> JITTER_LIMIT = Setting.doubleSetting(
             "opendistro.jobscheduler.jitter_limit",
             0.60, 0, 0.95,
-            Setting.Property.NodeScope, Setting.Property.Dynamic);
+            Setting.Property.NodeScope, Setting.Property.Dynamic, Setting.Property.Deprecated);
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/sweeper/JobSweeper.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/sweeper/JobSweeper.java
@@ -136,11 +136,17 @@ public class JobSweeper extends LifecycleListener implements IndexingOperationLi
 
     private void loadSettings(Settings settings) {
         this.sweepPeriod = JobSchedulerSettings.SWEEP_PERIOD.get(settings);
+        log.info("Background full sweep with period: " + this.sweepPeriod.getMinutes());
         this.sweepPageMaxSize = JobSchedulerSettings.SWEEP_PAGE_SIZE.get(settings);
+        log.info("Background sweep page size: " + this.sweepPageMaxSize);
         this.sweepSearchTimeout = JobSchedulerSettings.REQUEST_TIMEOUT.get(settings);
+        log.info("Background sweep search timeout: " + this.sweepSearchTimeout.getMinutes());
         this.sweepSearchBackoffMillis = JobSchedulerSettings.SWEEP_BACKOFF_MILLIS.get(settings);
+        log.info("Background sweep search backoff: " + this.sweepSearchBackoffMillis.getMillis());
         this.sweepSearchBackoffRetryCount = JobSchedulerSettings.SWEEP_BACKOFF_RETRY_COUNT.get(settings);
+        log.info("Background sweep search backoff retry count: " + this.sweepSearchBackoffRetryCount);
         this.jitterLimit = JobSchedulerSettings.JITTER_LIMIT.get(settings);
+        log.info("Background sweep jitter limit: " + this.jitterLimit);
         this.sweepSearchBackoff = this.updateRetryPolicy();
     }
 
@@ -148,25 +154,36 @@ public class JobSweeper extends LifecycleListener implements IndexingOperationLi
         clusterService.getClusterSettings().addSettingsUpdateConsumer(JobSchedulerSettings.SWEEP_PERIOD,
                 timeValue -> {
                     sweepPeriod = timeValue;
-                    log.debug("Reinitializing background full sweep with period: " + sweepPeriod.getMinutes());
+                    log.debug("Reinitializing background full sweep with period: " + this.sweepPeriod.getMinutes());
                     initBackgroundSweep();
                 });
         clusterService.getClusterSettings().addSettingsUpdateConsumer(JobSchedulerSettings.SWEEP_PAGE_SIZE,
-                intValue -> sweepPageMaxSize = intValue);
+                intValue -> {
+                    sweepPageMaxSize = intValue;
+                    log.debug("Setting background sweep page size: " + this.sweepPageMaxSize);
+                });
         clusterService.getClusterSettings().addSettingsUpdateConsumer(JobSchedulerSettings.REQUEST_TIMEOUT,
-                timeValue -> this.sweepSearchTimeout = timeValue);
+                timeValue -> {
+                    this.sweepSearchTimeout = timeValue;
+                    log.debug("Setting background sweep search timeout: " + this.sweepSearchTimeout.getMinutes());
+                });
         clusterService.getClusterSettings().addSettingsUpdateConsumer(JobSchedulerSettings.SWEEP_BACKOFF_MILLIS,
                 timeValue -> {
                     this.sweepSearchBackoffMillis = timeValue;
                     this.sweepSearchBackoff = this.updateRetryPolicy();
+                    log.debug("Setting background sweep search backoff: " + this.sweepSearchBackoffMillis.getMillis());
                 });
         clusterService.getClusterSettings().addSettingsUpdateConsumer(JobSchedulerSettings.SWEEP_BACKOFF_RETRY_COUNT,
                 intValue -> {
                     this.sweepSearchBackoffRetryCount = intValue;
                     this.sweepSearchBackoff = this.updateRetryPolicy();
+                    log.debug("Setting background sweep search backoff retry count: " + this.sweepSearchBackoffRetryCount);
                 });
         clusterService.getClusterSettings().addSettingsUpdateConsumer(JobSchedulerSettings.JITTER_LIMIT,
-                doubleValue -> this.jitterLimit = doubleValue);
+                doubleValue -> {
+                    this.jitterLimit = doubleValue;
+                    log.debug("Setting background sweep jitter limit: " + this.jitterLimit);
+                });
     }
 
     private BackoffPolicy updateRetryPolicy() {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/sweeper/JobSweeper.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/sweeper/JobSweeper.java
@@ -136,17 +136,11 @@ public class JobSweeper extends LifecycleListener implements IndexingOperationLi
 
     private void loadSettings(Settings settings) {
         this.sweepPeriod = JobSchedulerSettings.SWEEP_PERIOD.get(settings);
-        log.info("Background full sweep with period: " + this.sweepPeriod.getMinutes());
         this.sweepPageMaxSize = JobSchedulerSettings.SWEEP_PAGE_SIZE.get(settings);
-        log.info("Background sweep page size: " + this.sweepPageMaxSize);
         this.sweepSearchTimeout = JobSchedulerSettings.REQUEST_TIMEOUT.get(settings);
-        log.info("Background sweep search timeout: " + this.sweepSearchTimeout.getMinutes());
         this.sweepSearchBackoffMillis = JobSchedulerSettings.SWEEP_BACKOFF_MILLIS.get(settings);
-        log.info("Background sweep search backoff: " + this.sweepSearchBackoffMillis.getMillis());
         this.sweepSearchBackoffRetryCount = JobSchedulerSettings.SWEEP_BACKOFF_RETRY_COUNT.get(settings);
-        log.info("Background sweep search backoff retry count: " + this.sweepSearchBackoffRetryCount);
         this.jitterLimit = JobSchedulerSettings.JITTER_LIMIT.get(settings);
-        log.info("Background sweep jitter limit: " + this.jitterLimit);
         this.sweepSearchBackoff = this.updateRetryPolicy();
     }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/sweeper/JobSweeper.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/sweeper/JobSweeper.java
@@ -148,35 +148,35 @@ public class JobSweeper extends LifecycleListener implements IndexingOperationLi
         clusterService.getClusterSettings().addSettingsUpdateConsumer(JobSchedulerSettings.SWEEP_PERIOD,
                 timeValue -> {
                     sweepPeriod = timeValue;
-                    log.debug("Reinitializing background full sweep with period: " + this.sweepPeriod.getMinutes());
+                    log.debug("Reinitializing background full sweep with period: {}", this.sweepPeriod.getMinutes());
                     initBackgroundSweep();
                 });
         clusterService.getClusterSettings().addSettingsUpdateConsumer(JobSchedulerSettings.SWEEP_PAGE_SIZE,
                 intValue -> {
                     sweepPageMaxSize = intValue;
-                    log.debug("Setting background sweep page size: " + this.sweepPageMaxSize);
+                    log.debug("Setting background sweep page size: {}", this.sweepPageMaxSize);
                 });
         clusterService.getClusterSettings().addSettingsUpdateConsumer(JobSchedulerSettings.REQUEST_TIMEOUT,
                 timeValue -> {
                     this.sweepSearchTimeout = timeValue;
-                    log.debug("Setting background sweep search timeout: " + this.sweepSearchTimeout.getMinutes());
+                    log.debug("Setting background sweep search timeout: {}", this.sweepSearchTimeout.getMinutes());
                 });
         clusterService.getClusterSettings().addSettingsUpdateConsumer(JobSchedulerSettings.SWEEP_BACKOFF_MILLIS,
                 timeValue -> {
                     this.sweepSearchBackoffMillis = timeValue;
                     this.sweepSearchBackoff = this.updateRetryPolicy();
-                    log.debug("Setting background sweep search backoff: " + this.sweepSearchBackoffMillis.getMillis());
+                    log.debug("Setting background sweep search backoff: {}", this.sweepSearchBackoffMillis.getMillis());
                 });
         clusterService.getClusterSettings().addSettingsUpdateConsumer(JobSchedulerSettings.SWEEP_BACKOFF_RETRY_COUNT,
                 intValue -> {
                     this.sweepSearchBackoffRetryCount = intValue;
                     this.sweepSearchBackoff = this.updateRetryPolicy();
-                    log.debug("Setting background sweep search backoff retry count: " + this.sweepSearchBackoffRetryCount);
+                    log.debug("Setting background sweep search backoff retry count: {}", this.sweepSearchBackoffRetryCount);
                 });
         clusterService.getClusterSettings().addSettingsUpdateConsumer(JobSchedulerSettings.JITTER_LIMIT,
                 doubleValue -> {
                     this.jitterLimit = doubleValue;
-                    log.debug("Setting background sweep jitter limit: " + this.jitterLimit);
+                    log.debug("Setting background sweep jitter limit: {}", this.jitterLimit);
                 });
     }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/jobscheduler/JobSchedulerSettingsTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/jobscheduler/JobSchedulerSettingsTests.java
@@ -38,7 +38,7 @@ import org.opensearch.test.OpenSearchTestCase;
 @SuppressWarnings({"rawtypes"})
 public class JobSchedulerSettingsTests extends OpenSearchTestCase {
 
-    JobSchedulerPlugin plugin = null;
+    JobSchedulerPlugin plugin;
     
     @Before
     public void setup() {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/jobscheduler/JobSchedulerSettingsTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/jobscheduler/JobSchedulerSettingsTests.java
@@ -1,0 +1,119 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.jobscheduler;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Before;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.test.OpenSearchTestCase;
+
+@SuppressWarnings({"rawtypes"})
+public class JobSchedulerSettingsTests extends OpenSearchTestCase {
+
+    JobSchedulerPlugin plugin = null;
+    
+    @Before
+    public void setup() {
+        this.plugin = new JobSchedulerPlugin();
+    }
+
+    public void testAllLegacyOpenDistroSettingsReturned() {
+        List<Setting<?>> settings = plugin.getSettings();
+        assertTrue("legacy setting must be returned from settings", 
+            settings.containsAll(
+                Arrays.asList(
+                    LegacyOpenDistroJobSchedulerSettings.JITTER_LIMIT,
+                    LegacyOpenDistroJobSchedulerSettings.REQUEST_TIMEOUT,
+                    LegacyOpenDistroJobSchedulerSettings.SWEEP_BACKOFF_MILLIS,
+                    LegacyOpenDistroJobSchedulerSettings.SWEEP_BACKOFF_RETRY_COUNT,
+                    LegacyOpenDistroJobSchedulerSettings.SWEEP_PAGE_SIZE,
+                    LegacyOpenDistroJobSchedulerSettings.SWEEP_PERIOD
+                )
+            )
+        );
+    }
+
+    public void testAllOpenSearchSettingsReturned() {
+        List<Setting<?>> settings = plugin.getSettings();
+        assertTrue("legacy setting must be returned from settings", 
+            settings.containsAll(
+                Arrays.asList(
+                    JobSchedulerSettings.JITTER_LIMIT,
+                    JobSchedulerSettings.REQUEST_TIMEOUT,
+                    JobSchedulerSettings.SWEEP_BACKOFF_MILLIS,
+                    JobSchedulerSettings.SWEEP_BACKOFF_RETRY_COUNT,
+                    JobSchedulerSettings.SWEEP_PAGE_SIZE,
+                    JobSchedulerSettings.SWEEP_PERIOD
+                )
+            )
+        );
+    }
+
+    public void testLegacyOpenDistroSettingsFallback() {
+        assertEquals(
+            JobSchedulerSettings.REQUEST_TIMEOUT.get(Settings.EMPTY), 
+            LegacyOpenDistroJobSchedulerSettings.REQUEST_TIMEOUT.get(Settings.EMPTY)
+        );
+    }
+
+    public void testSettingsGetValue() {
+        Settings settings = Settings.builder().put("opensearch.jobscheduler.request_timeout", "42s").build();
+        assertEquals(JobSchedulerSettings.REQUEST_TIMEOUT.get(settings), TimeValue.timeValueSeconds(42)); 
+        assertEquals(LegacyOpenDistroJobSchedulerSettings.REQUEST_TIMEOUT.get(settings), TimeValue.timeValueSeconds(10)); 
+    }
+
+    public void testSettingsGetValueWithLegacyFallback() {
+        Settings settings = Settings.builder()
+            .put("opendistro.jobscheduler.request_timeout", "1s")
+            .put("opendistro.jobscheduler.sweeper.backoff_millis", "2ms")
+            .put("opendistro.jobscheduler.retry_count", 3)
+            .put("opendistro.jobscheduler.sweeper.period", "4s")
+            .put("opendistro.jobscheduler.sweeper.page_size", 5)
+            .put("opendistro.jobscheduler.jitter_limit", 6)
+        .build();
+        
+        assertEquals(JobSchedulerSettings.REQUEST_TIMEOUT.get(settings), TimeValue.timeValueSeconds(1)); 
+        assertEquals(JobSchedulerSettings.SWEEP_BACKOFF_MILLIS.get(settings), TimeValue.timeValueMillis(2)); 
+        assertEquals(JobSchedulerSettings.SWEEP_BACKOFF_RETRY_COUNT.get(settings), Integer.valueOf(3)); 
+        assertEquals(JobSchedulerSettings.SWEEP_PERIOD.get(settings), TimeValue.timeValueSeconds(4)); 
+        assertEquals(JobSchedulerSettings.SWEEP_PAGE_SIZE.get(settings), Integer.valueOf(5)); 
+        assertEquals(JobSchedulerSettings.JITTER_LIMIT.get(settings), Double.valueOf(6.0)); 
+
+        assertSettingDeprecationsAndWarnings(new Setting[]{
+            LegacyOpenDistroJobSchedulerSettings.REQUEST_TIMEOUT,
+            LegacyOpenDistroJobSchedulerSettings.SWEEP_BACKOFF_MILLIS,
+            LegacyOpenDistroJobSchedulerSettings.SWEEP_BACKOFF_RETRY_COUNT,
+            LegacyOpenDistroJobSchedulerSettings.SWEEP_PERIOD,
+            LegacyOpenDistroJobSchedulerSettings.SWEEP_PAGE_SIZE,
+            LegacyOpenDistroJobSchedulerSettings.JITTER_LIMIT
+        });
+    }
+}


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

1. Rename setting from opendistro to opensearch.
2. Use opendistro settings as fallback.
 
An alternative to #19, depends on https://github.com/opensearch-project/OpenSearch/pull/665.

### opensearch.yml Settings

Manually testing upgrade path from `config/opensearch.yml` settings:

Set `opendistro.jobscheduler.retry_count: 6` in `config./opensearch.yml`.

```
tar vfxz opensearch-1.0.0-beta1-linux-x64.tar.gz 
cd opensearch-1.0.0-beta1
./bin/opensearch-plugin install opensearch-job-scheduler-1.0.0.0-beta1.zip 
```

Run `./bin/opensearch`, it will show the value for this setting at 7.

### Node Settings (and upgrade from OpenDistro)

Install OpenDistro

```
wget https://d3g5vo6xdbdb9a.cloudfront.net/tarball/opendistro-elasticsearch/opendistroforelasticsearch-1.13.2-linux-x64.tar.gz
tar vfxz opendistroforelasticsearch-1.13.2-linux-x64.tar.gz
cd opendistroforelasticsearch-1.13.2
./bin/elasticsearch
```

Set `opendistro.jobscheduler.retry_count: 6`.

```
curl -X PUT "localhost:9200/_cluster/settings?pretty" -H 'Content-Type: application/json' -d'{"persistent":{"opendistro.jobscheduler.retry_count":6}}'
```

Stop OpenDistro, install OpenSearch on top (or copy data). I built just the minimal engine + job-scheduler from source with these changes.

```
tar vfxz opensearch-1.0.0-beta1-linux-x64.tar.gz 
cd opensearch-1.0.0-beta1
./bin/opensearch-plugin install opensearch-job-scheduler-1.0.0.0-beta1.zip 
rm -rf data
cp -R ../opendistroforelasticsearch-1.13.2/data .
```

At start the default values are used before settings are read.

```
[2021-05-06T19:55:17,649][INFO ][c.a.o.j.s.JobSweeper     ] [ip-172-31-41-248] Background sweep search backoff retry count: 3
```

I thought this was a bug, but both old and new are just defaulted before they are read from the node configuration when it joins the cluster (with some debugging code).

```
[2021-05-06T19:55:17,651][INFO ][c.a.o.j.s.JobSweeper     ] [ip-172-31-41-248] JobSchedulerSettings.SWEEP_BACKOFF_RETRY_COUNT: 3
[2021-05-06T19:55:17,651][INFO ][c.a.o.j.s.JobSweeper     ] [ip-172-31-41-248] LegacyOpenDistroJobSchedulerSettings.SWEEP_BACKOFF_RETRY_COUNT: 3
```

As the node joins the cluster, it updates the value from the node configuration.

```
[2021-05-06T19:55:18,696][INFO ][o.o.c.s.ClusterSettings  ] [ip-172-31-41-248] updating [opensearch.jobscheduler.retry_count] from [3] to [6]
```

### Check List

- [x] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Passing build, needs changes in OpenSearch 
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
