### PR TITLE
Change plugin setting name from 'opensearch.' to 'pluigns.'

### DIFF
--- a/src/main/java/org/opensearch/jobscheduler/JobSchedulerSettings.java
+++ b/src/main/java/org/opensearch/jobscheduler/JobSchedulerSettings.java
@@ -31,32 +31,32 @@ import org.opensearch.common.unit.TimeValue;
 
 public class JobSchedulerSettings {
     public static final Setting<TimeValue> REQUEST_TIMEOUT = Setting.positiveTimeSetting(
-            "opensearch.jobscheduler.request_timeout",
+            "plugins.jobscheduler.request_timeout",
             LegacyOpenDistroJobSchedulerSettings.REQUEST_TIMEOUT,
             Setting.Property.NodeScope, Setting.Property.Dynamic);
 
     public static final Setting<TimeValue> SWEEP_BACKOFF_MILLIS = Setting.positiveTimeSetting(
-            "opensearch.jobscheduler.sweeper.backoff_millis",
+            "plugins.jobscheduler.sweeper.backoff_millis",
             LegacyOpenDistroJobSchedulerSettings.SWEEP_BACKOFF_MILLIS,
             Setting.Property.NodeScope, Setting.Property.Dynamic);
 
     public static final Setting<Integer> SWEEP_BACKOFF_RETRY_COUNT = Setting.intSetting(
-            "opensearch.jobscheduler.retry_count",
+            "plugins.jobscheduler.retry_count",
             LegacyOpenDistroJobSchedulerSettings.SWEEP_BACKOFF_RETRY_COUNT,
             Setting.Property.NodeScope, Setting.Property.Dynamic);
 
     public static final Setting<TimeValue> SWEEP_PERIOD = Setting.positiveTimeSetting(
-            "opensearch.jobscheduler.sweeper.period",
+            "plugins.jobscheduler.sweeper.period",
             LegacyOpenDistroJobSchedulerSettings.SWEEP_PERIOD,
             Setting.Property.NodeScope, Setting.Property.Dynamic);
 
     public static final Setting<Integer> SWEEP_PAGE_SIZE = Setting.intSetting(
-            "opensearch.jobscheduler.sweeper.page_size",
+            "plugins.jobscheduler.sweeper.page_size",
             LegacyOpenDistroJobSchedulerSettings.SWEEP_PAGE_SIZE,
             Setting.Property.NodeScope, Setting.Property.Dynamic);
 
     public static final Setting<Double> JITTER_LIMIT = Setting.doubleSetting(
-            "opensearch.jobscheduler.jitter_limit",
+            "plugins.jobscheduler.jitter_limit",
             LegacyOpenDistroJobSchedulerSettings.JITTER_LIMIT,
             Setting.Property.NodeScope, Setting.Property.Dynamic);
 }

--- a/src/test/java/org/opensearch/jobscheduler/JobSchedulerSettingsTests.java
+++ b/src/test/java/org/opensearch/jobscheduler/JobSchedulerSettingsTests.java
@@ -85,7 +85,7 @@ public class JobSchedulerSettingsTests extends OpenSearchTestCase {
     }
 
     public void testSettingsGetValue() {
-        Settings settings = Settings.builder().put("opensearch.jobscheduler.request_timeout", "42s").build();
+        Settings settings = Settings.builder().put("plugins.jobscheduler.request_timeout", "42s").build();
         assertEquals(JobSchedulerSettings.REQUEST_TIMEOUT.get(settings), TimeValue.timeValueSeconds(42)); 
         assertEquals(LegacyOpenDistroJobSchedulerSettings.REQUEST_TIMEOUT.get(settings), TimeValue.timeValueSeconds(10)); 
     }


### PR DESCRIPTION
### Description
- Change the setting names from `opensearch.` to `plugins.`, according to the description of https://github.com/opensearch-project/job-scheduler/pull/20
 
### Issues Resolved
a part of #22 
 
### Check List
~~- [ ] New functionality includes testing.~~
  - [x] All tests pass
~~- [ ] New functionality has been documented.~~
  ~~- [ ] New functionality has javadoc added~~
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
