### PR TITLE
Rename remaining identifiers from 'opendistro' or 'elasticsearch' to 'OpenSearch'

### DIFF
--- a/.github/draft-release-notes-config.yml
+++ b/.github/draft-release-notes-config.yml
@@ -1,6 +1,6 @@
 # The overall template of the release notes
 template: |
-  Compatible with Elasticsearch (**set version here**).
+  Compatible with OpenSearch (**set version here**).
   $CHANGES
 
 # Setting the formatting and sorting for the release notes body

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -1,5 +1,5 @@
 name: Release workflow
-# This workflow is triggered on creating tags to main or an opendistro release branch
+# This workflow is triggered on creating tags to main or an OpenSearch release branch
 on:
   push:
     tags:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ create/delete jobs.
 
 ## Code of Conduct
 
-This project has adopted an [Open Source Code of Conduct](https://opendistro.github.io/for-elasticsearch/codeofconduct.html).
+This project has adopted an [Open Source Code of Conduct](https://www.opensearch.org/codeofconduct.html).
 
 
 ## Security issue notifications

--- a/build.gradle
+++ b/build.gradle
@@ -131,18 +131,18 @@ afterEvaluate {
         fileMode 0644
         dirMode 0755
 
-        requires('opensearch-oss', versions.elasticsearch, EQUAL)
+        requires('opensearch', versions.opensearch, EQUAL)
         packager = 'Amazon'
         vendor = 'Amazon'
         os = 'LINUX'
         prefix '/usr'
 
         license 'ASL-2.0'
-        maintainer 'OpenDistro for Elasticsearch Team <opendistro@amazon.com>'
-        url 'https://opendistro.github.io/for-elasticsearch/downloads.html'
+        maintainer 'OpenSearch Team <opensearch@amazon.com>'
+        url 'https://opensearch.org/downloads.html'
         summary '''
-         JobScheduler plugin for OpenDistro for Elasticsearch. 
-         Reference documentation can be found at https://opendistro.github.io/for-elasticsearch-docs/.
+         JobScheduler plugin for OpenSearch. 
+         Reference documentation can be found at https://docs-beta.opensearch.org/.
     '''.stripIndent().replace('\n', ' ').trim()
     }
 

--- a/spi/build.gradle
+++ b/spi/build.gradle
@@ -120,14 +120,14 @@ publishing {
             artifact javadocJar
 
             pom {
-              name = "ElasticSearch Job Scheduler SPI"
+              name = "OpenSearch Job Scheduler SPI"
               packaging = "jar"
-              url = "https://github.com/opendistro-for-elasticsearch/job-scheduler"
-              description = "Open Distro for Elasticsearch Job Scheduler"
+              url = "https://github.com/opensearch-project/job-scheduler"
+              description = "OpenSearch Job Scheduler"
               scm {
-                connection = "scm:git@github.com:opendistro-for-elasticsearch/job-scheduler.git"
-                developerConnection = "scm:git@github.com:opendistro-for-elasticsearch/job-scheduler.git"
-                url = "git@github.com:opendistro-for-elasticsearch/job-scheduler.git"
+                connection = "scm:git@github.com:opensearch-project/job-scheduler.git"
+                developerConnection = "scm:git@github.com:opensearch-project/job-scheduler.git"
+                url = "git@github.com:opensearch-project/job-scheduler.git"
               }
               licenses {
                 license {


### PR DESCRIPTION
### Description

- Rename remaining identifiers from "opendistro" or "elasticsearch" to "OpenSearch", in template, CI workflow, and package info.

Reference: https://github.com/opensearch-project/k-NN/pull/21 and https://github.com/opensearch-project/common-utils/pull/23
Note: the artifacts uploading location in the CI workflow is not changed.
 
### Issues Resolved
a part of #22 
 
### Check List
~~- [ ] New functionality includes testing.~~
  - [x] All tests pass
~~- [ ] New functionality has been documented.~~
  ~~- [ ] New functionality has javadoc added~~
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
