### PR TITLE
Add build qualifier 'rc1' in the CI workflow for building OpenSearch

### DIFF
--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -34,16 +34,16 @@ jobs:
           path: OpenSearch
       - name: Build OpenSearch
         working-directory: ./OpenSearch
-        run: ./gradlew publishToMavenLocal -Dbuild.snapshot=false
+        run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=rc1 -Dbuild.snapshot=false
         
       # job-scheduler
       - name: Build and Test
         run: |
-          ./gradlew build -Dopensearch.version=1.0.0 -Dbuild.snapshot=false
+          ./gradlew build -Dbuild.snapshot=false
 
       - name: Publish to Maven Local
         run: |
-          ./gradlew publishToMavenLocal -Dopensearch.version=1.0.0 -Dbuild.snapshot=false
+          ./gradlew publishToMavenLocal -Dbuild.snapshot=false
           
       - name: Upload Coverage Report
         uses: codecov/codecov-action@v1


### PR DESCRIPTION
### Description
- Correct the OpenSearch version In the CI workflow to be corresponding with the targeted version in the gradle build script
https://github.com/opensearch-project/job-scheduler/blob/67ec362748e298dd24249a7c03759ec5a010234c/build.gradle#L29
 
### Issues Resolved
Resolve #32
 
### Check List
~~- [ ] New functionality includes testing.~~
  - [x] All tests pass
~~- [ ] New functionality has been documented.~~
  ~~- [ ] New functionality has javadoc added~~
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
