### PR TITLE
Enabled automated license header checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-.idea
+.idea/*
+!.idea/copyright
 *.iml
 .gradle
 out

--- a/.idea/copyright/SPDX_ALv2.xml
+++ b/.idea/copyright/SPDX_ALv2.xml
@@ -1,0 +1,6 @@
+<component name="CopyrightManager">
+  <copyright>
+    <option name="notice" value="SPDX-License-Identifier: Apache-2.0&#10;&#10;The OpenSearch Contributors require contributions made to&#10;this file be licensed under the Apache-2.0 license or a&#10;compatible open source license.&#10;&#10;Modifications Copyright OpenSearch Contributors. See&#10;GitHub history for details." />
+    <option name="myName" value="SPDX-ALv2" />
+  </copyright>
+</component>

--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,0 +1,3 @@
+<component name="CopyrightManager">
+  <settings default="SPDX-ALv2" />
+</component>

--- a/build.gradle
+++ b/build.gradle
@@ -59,8 +59,7 @@ ext {
     noticeFile = rootProject.file('NOTICE')
 }
 
-// TODO: enable
-licenseHeaders.enabled = false
+licenseHeaders.enabled = true
 testingConventions.enabled = false
 forbiddenApis.ignoreFailures = false
 

--- a/sample-extension-plugin/build.gradle
+++ b/sample-extension-plugin/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     compileOnly project(path: ":${rootProject.name}-spi", configuration: 'shadow')
 }
 
-licenseHeaders.enabled = false
+licenseHeaders.enabled = true
 validateNebulaPom.enabled = false
 testingConventions.enabled = false
 loggerUsageCheck.enabled = false


### PR DESCRIPTION
### Description
1. Re-enabled the 'licenseHeaders' check in the build.gradle file.
2. Added an IntelliJ copyright profile to auto-generate the SPDX license header.
 
### Issues Resolved
Related to - opensearch-project/opensearch-plugins#49
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Ketan Verma <ketan9495@gmail.com>