### PR TITLE
[1.x] Bumping job-scheduler to build with OpenSearch(1.x) 1.1.0 (#44)

### DIFF
--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: 'opensearch-project/OpenSearch'
-          ref: '1.0'
+          ref: '1.x'
           path: OpenSearch
       - name: Build OpenSearch
         working-directory: ./OpenSearch

--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ The sample extension plugin takes an index name as input and logs the index shar
 logs according to the specified Schedule. And it also exposes a REST endpoint for end users to
 create/delete jobs.
 
+## Contributing
+
+See [developer guide](DEVELOPER_GUIDE.md) and [how to contribute to this project](CONTRIBUTING.md).
+
+## Getting Help
+
+If you find a bug, or have a feature request, please don't hesitate to open an issue in this repository.
+
+For more information, see [project website](https://opensearch.org/) and [documentation](https://opensearch.org/docs/). If you need help and are unsure where to open an issue, try [forums](https://discuss.opendistrocommunity.dev/).
+
 ## Code of Conduct
 
 This project has adopted an [Open Source Code of Conduct](https://www.opensearch.org/codeofconduct.html).

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "1.0.0")
+        opensearch_version = System.getProperty("opensearch.version", "1.1.0")
     }
 
     repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,4 @@
 #   permissions and limitations under the License.
 #
 
-version = 1.0.0
+version = 1.1.0


### PR DESCRIPTION
Signed-off-by: Sarat Vemulapalli <vemulapallisarat@gmail.com>

### Description
Bumping up job-scheduler to build with OpenSearch `main` which is 1.1.0.
As with the branching and release strategy for the project https://github.com/opensearch-project/.github/issues/13
Here is how it should look like:
1. Plugin/library `main` builds out of OpenSearch `main`. 
2. Plugin/library `1.x` builds out of OpenSearch `1.x`.
3. Plugin/library `1.0` builds out of OpenSearch `1.0`.

This allows us to fail fast and get ready for release.

As part of adding backwards compatibility test framework, we are developing tests as an example in Anomaly Detection which needs job-scheduler. 
Ref: https://github.com/opensearch-project/OpenSearch/issues/1002
Meta issue: https://github.com/opensearch-project/opensearch-build/issues/90
 
### Issues Resolved
#43 
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
