### PR TITLE
Using 1.1 snapshot version for OpenSearch

### DIFF
--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -34,7 +34,7 @@ jobs:
           path: OpenSearch
       - name: Build OpenSearch
         working-directory: ./OpenSearch
-        run: ./gradlew publishToMavenLocal -Dbuild.snapshot=false
+        run: ./gradlew publishToMavenLocal
         
       # job-scheduler
       - name: Build and Test

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "1.1.0")
+        opensearch_version = System.getProperty("opensearch.version", "1.1.0-SNAPSHOT")
     }
 
     repositories {


### PR DESCRIPTION
Signed-off-by: Vacha <vachshah@amazon.com>

### Description
Consuming OpenSearch 1.1 version snapshot instead of 1.1. This is required since AD consumes the 1.1 snapshot artifact (details in PR opensearch-project/anomaly-detection#175).
 
### Issues Resolved
As part of closed issue #43 
 
### Check List
- [ ] New functionality includes testing.
  - [X] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
