### PR TITLE
Removing default integtest.sh (1.x).

### DIFF
--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: 'opensearch-project/OpenSearch'
-          ref: '1.0'
+          ref: '1.x'
           path: OpenSearch
       - name: Build OpenSearch
         working-directory: ./OpenSearch

--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ The sample extension plugin takes an index name as input and logs the index shar
 logs according to the specified Schedule. And it also exposes a REST endpoint for end users to
 create/delete jobs.
 
+## Contributing
+
+See [developer guide](DEVELOPER_GUIDE.md) and [how to contribute to this project](CONTRIBUTING.md).
+
+## Getting Help
+
+If you find a bug, or have a feature request, please don't hesitate to open an issue in this repository.
+
+For more information, see [project website](https://opensearch.org/) and [documentation](https://opensearch.org/docs/). If you need help and are unsure where to open an issue, try [forums](https://discuss.opendistrocommunity.dev/).
+
 ## Code of Conduct
 
 This project has adopted an [Open Source Code of Conduct](https://www.opensearch.org/codeofconduct.html).

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "1.0.0")
+        opensearch_version = System.getProperty("opensearch.version", "1.1.0")
     }
 
     repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,4 @@
 #   permissions and limitations under the License.
 #
 
-version = 1.0.0
+version = 1.1.0


### PR DESCRIPTION
Coming from https://github.com/opensearch-project/opensearch-build/issues/497, removing default integtest.sh on the 1.x brach.