### PR TITLE
Adds a delay parameter to the job scheduler (#61)

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -49,7 +49,7 @@ Then you will find the built artifact located at `build/distributions` directory
 ## Install
 Once you have built the plugin from source code, run
 ```bash
-opensearch-plugin install file://${PLUGIN_ZIP_FILE_PATH}
+opensearch-plugin install file:///path/to/target/releases/opensearch-job-scheduler-<version>.zip
 ```
 to install the JobScheduler plugin to your OpenSearch.
 

--- a/spi/src/main/java/org/opensearch/jobscheduler/spi/schedule/Schedule.java
+++ b/spi/src/main/java/org/opensearch/jobscheduler/spi/schedule/Schedule.java
@@ -34,12 +34,13 @@ import java.time.Duration;
 import java.time.Instant;
 
 public interface Schedule extends Writeable, ToXContentObject {
+    static final String DELAY_FIELD = "schedule_delay";
 
     /**
-     * Gets next job execution time of give time parameter.
+     * Gets next job execution time of given time parameter.
      *
      * @param time base time point
-     * @return next exection time since time parameter.
+     * @return next execution time since time parameter.
      */
     Instant getNextExecutionTime(Instant time);
 
@@ -65,4 +66,12 @@ public interface Schedule extends Writeable, ToXContentObject {
      * @return true if the job executes on time, otherwise false.
      */
     Boolean runningOnTime(Instant lastExecutionTime);
+
+    /**
+     * Gets the delay parameter of the schedule.
+     *
+     * @return the delay parameter of the schedule as a Long.
+     */
+    Long getDelay();
+
 }

--- a/spi/src/main/java/org/opensearch/jobscheduler/spi/schedule/ScheduleParser.java
+++ b/spi/src/main/java/org/opensearch/jobscheduler/spi/schedule/ScheduleParser.java
@@ -49,6 +49,7 @@ public class ScheduleParser {
                 case CronSchedule.CRON_FIELD:
                     String expression = null;
                     ZoneId timezone = null;
+                    Long cronDelay = null;
                     while (!XContentParser.Token.END_OBJECT.equals(parser.nextToken())) {
                         String cronField = parser.currentName();
                         parser.nextToken();
@@ -56,6 +57,8 @@ public class ScheduleParser {
                             case CronSchedule.EXPRESSION_FIELD: expression = parser.text();
                                 break;
                             case CronSchedule.TIMEZONE_FIELD: timezone = ZoneId.of(parser.text());
+                                break;
+                            case Schedule.DELAY_FIELD: cronDelay = parser.longValue();
                                 break;
                             default:
                                 throw new IllegalArgumentException(
@@ -65,11 +68,12 @@ public class ScheduleParser {
                     XContentParserUtils.ensureExpectedToken(XContentParser.Token.END_OBJECT, parser.currentToken(),
                             parser);
                     parser.nextToken();
-                    return new CronSchedule(expression, timezone);
+                    return cronDelay == null ? new CronSchedule(expression, timezone) : new CronSchedule(expression, timezone, cronDelay);
                 case IntervalSchedule.INTERVAL_FIELD:
                     Instant startTime = null;
                     int period = 0;
                     ChronoUnit unit = null;
+                    Long intervalDelay = null;
                     while (!XContentParser.Token.END_OBJECT.equals(parser.nextToken())) {
                         String intervalField = parser.currentName();
                         parser.nextToken();
@@ -83,6 +87,9 @@ public class ScheduleParser {
                             case IntervalSchedule.UNIT_FIELD:
                                 unit = ChronoUnit.valueOf(parser.text().toUpperCase(Locale.ROOT));
                                 break;
+                            case Schedule.DELAY_FIELD:
+                                intervalDelay = parser.longValue();
+                                break;
                             default:
                                 throw new IllegalArgumentException(
                                         String.format(Locale.ROOT, "Unknown interval field %s", intervalField));
@@ -91,7 +98,7 @@ public class ScheduleParser {
                     XContentParserUtils.ensureExpectedToken(XContentParser.Token.END_OBJECT, parser.currentToken(),
                             parser);
                     parser.nextToken();
-                    return new IntervalSchedule(startTime, period, unit);
+                    return intervalDelay == null ? new IntervalSchedule(startTime, period, unit) : new IntervalSchedule(startTime, period, unit, intervalDelay);
                 default:
                     throw new IllegalArgumentException(
                             String.format(Locale.ROOT, "Unknown schedule type %s", fieldName));

--- a/spi/src/test/java/org/opensearch/jobscheduler/spi/schedule/CronScheduleTests.java
+++ b/spi/src/test/java/org/opensearch/jobscheduler/spi/schedule/CronScheduleTests.java
@@ -49,23 +49,36 @@ import java.util.Optional;
 public class CronScheduleTests extends OpenSearchTestCase {
 
     private CronSchedule cronSchedule;
+    private CronSchedule cronScheduleDelay;
+    private final long DELAY = 15000;
 
     @Before
     public void setup() {
         this.cronSchedule = new CronSchedule("* * * * *", ZoneId.systemDefault());
+        this.cronScheduleDelay = new CronSchedule("* * * * *", ZoneId.systemDefault(), DELAY);
     }
 
     public void testNextTimeToExecute() {
         Instant now = Instant.now();
         Clock testClock = Clock.fixed(now, ZoneId.systemDefault());
         this.cronSchedule.setClock(testClock);
+        this.cronScheduleDelay.setClock(testClock);
 
         Instant nextMinute = Instant.ofEpochSecond(now.getEpochSecond() / 60 * 60 + 60);
+        Instant nextMinuteDelay = Instant.ofEpochSecond((now.minusMillis(DELAY)).getEpochSecond() / 60 * 60 + 60).plusMillis(DELAY);
 
         Duration expected = Duration.between(now, nextMinute);
         Duration duration = this.cronSchedule.nextTimeToExecute();
+        Duration expectedDelay = Duration.between(now, nextMinuteDelay);
+        Duration durationDelay = this.cronScheduleDelay.nextTimeToExecute();
 
         Assert.assertEquals(expected, duration);
+        Assert.assertEquals(expectedDelay, durationDelay);
+
+        Assert.assertEquals(this.cronSchedule.nextTimeToExecute(),
+                Duration.between(now, this.cronSchedule.getNextExecutionTime(now)));
+        Assert.assertEquals(this.cronScheduleDelay.nextTimeToExecute(),
+                Duration.between(now, this.cronScheduleDelay.getNextExecutionTime(now)));
     }
 
     public void testGetPeriodStartingAt() {
@@ -74,6 +87,18 @@ public class CronScheduleTests extends OpenSearchTestCase {
         Instant nextMinute = currentMinute.plus(1L, ChronoUnit.MINUTES);
 
         Tuple<Instant, Instant> period = this.cronSchedule.getPeriodStartingAt(currentMinute);
+
+        Assert.assertEquals(currentMinute, period.v1());
+        Assert.assertEquals(nextMinute, period.v2());
+    }
+
+    public void testGetPeriodStartingAtWithDelay() {
+        Instant now = Instant.now();
+        // If it is 10:01:07 with a delay of 15 seconds, we want the current minute to be 10:00:15 and next to be 10:01:15
+        Instant currentMinute = Instant.ofEpochSecond(now.minusMillis(DELAY).getEpochSecond() / 60 * 60).plusMillis(DELAY);
+        Instant nextMinute = currentMinute.plus(1L, ChronoUnit.MINUTES);
+
+        Tuple<Instant, Instant> period = this.cronScheduleDelay.getPeriodStartingAt(currentMinute);
 
         Assert.assertEquals(currentMinute, period.v1());
         Assert.assertEquals(nextMinute, period.v2());
@@ -89,6 +114,21 @@ public class CronScheduleTests extends OpenSearchTestCase {
         Instant nextMinute = currentMinute.plus(1L, ChronoUnit.MINUTES);
 
         Tuple<Instant, Instant> period = this.cronSchedule.getPeriodStartingAt(null);
+
+        Assert.assertEquals(currentMinute, period.v1());
+        Assert.assertEquals(nextMinute, period.v2());
+    }
+
+    public void testGetPeriodStartingAtWithDelay_nullStartTime() {
+        Instant now = Instant.now();
+
+        Clock testClock = Clock.fixed(now, ZoneId.systemDefault());
+        this.cronScheduleDelay.setClock(testClock);
+
+        Instant currentMinute = Instant.ofEpochSecond(now.minusMillis(DELAY).getEpochSecond() / 60 * 60).plusMillis(DELAY);
+        Instant nextMinute = currentMinute.plus(1L, ChronoUnit.MINUTES);
+
+        Tuple<Instant, Instant> period = this.cronScheduleDelay.getPeriodStartingAt(null);
 
         Assert.assertEquals(currentMinute, period.v1());
         Assert.assertEquals(nextMinute, period.v2());
@@ -131,21 +171,49 @@ public class CronScheduleTests extends OpenSearchTestCase {
         Assert.assertFalse(this.cronSchedule.runningOnTime(lastExecutionTime));
     }
 
+    public void testRunningOnTimeWithDelay() {
+        Instant now = Instant.now();
+
+        Clock testClock = Clock.fixed(now, ZoneId.systemDefault());
+        this.cronScheduleDelay.setClock(testClock);
+
+        // Subtract by delay first in case that goes to the previous minute/iteration
+        Instant currentMinutePlusDelay = Instant.ofEpochSecond((now.minusMillis(DELAY)).getEpochSecond() / 60 * 60).plusMillis(DELAY);
+
+        Instant lastExecutionTime = currentMinutePlusDelay.minus(10, ChronoUnit.MILLIS);
+        Assert.assertTrue(this.cronScheduleDelay.runningOnTime(lastExecutionTime));
+
+        lastExecutionTime = currentMinutePlusDelay.plus(10, ChronoUnit.MILLIS);
+        Assert.assertTrue(this.cronScheduleDelay.runningOnTime(lastExecutionTime));
+
+        lastExecutionTime = currentMinutePlusDelay.plus(10, ChronoUnit.SECONDS);
+        Assert.assertFalse(this.cronScheduleDelay.runningOnTime(lastExecutionTime));
+
+        lastExecutionTime = currentMinutePlusDelay.minus(10, ChronoUnit.SECONDS);
+        Assert.assertFalse(this.cronScheduleDelay.runningOnTime(lastExecutionTime));
+    }
+
     public void testRunningOnTime_nullParam() {
         Assert.assertTrue(this.cronSchedule.runningOnTime(null));
+        Assert.assertTrue(this.cronScheduleDelay.runningOnTime(null));
     }
 
     public void testRunningOnTime_noLastExecution() {
         Instant now = Instant.now();
         Clock testClock = Clock.fixed(now, ZoneId.systemDefault());
         this.cronSchedule.setClock(testClock);
+        this.cronScheduleDelay.setClock(testClock);
         ExecutionTime mockExecutionTime = Mockito.mock(ExecutionTime.class);
         this.cronSchedule.setExecutionTime(mockExecutionTime);
+        this.cronScheduleDelay.setExecutionTime(mockExecutionTime);
 
         Mockito.when(mockExecutionTime.lastExecution(ZonedDateTime.ofInstant(now, ZoneId.systemDefault())))
                 .thenReturn(Optional.empty());
+        Mockito.when(mockExecutionTime.lastExecution(ZonedDateTime.ofInstant(now.minusMillis(DELAY), ZoneId.systemDefault())))
+                .thenReturn(Optional.empty());
 
         Assert.assertFalse(this.cronSchedule.runningOnTime(now));
+        Assert.assertFalse(this.cronScheduleDelay.runningOnTime(now));
     }
 
     public void testToXContent() throws IOException {
@@ -153,16 +221,27 @@ public class CronScheduleTests extends OpenSearchTestCase {
         String expectedJsonStr = "{\"cron\":{\"expression\":\"* * * * *\",\"timezone\":\"PST8PDT\"}}";
         Assert.assertEquals(expectedJsonStr,
                 XContentHelper.toXContent(schedule, XContentType.JSON, false).utf8ToString());
+
+        CronSchedule scheduleDelay = new CronSchedule("* * * * *", ZoneId.of("PST8PDT"), 1234);
+        String expectedJsonStrDelay = "{\"cron\":{\"expression\":\"* * * * *\",\"timezone\":\"PST8PDT\",\"schedule_delay\":1234}}";
+        Assert.assertEquals(expectedJsonStrDelay,
+                XContentHelper.toXContent(scheduleDelay, XContentType.JSON, false).utf8ToString());
     }
 
     public void testCronScheduleEqualsAndHashCode() {
         CronSchedule cronScheduleOne = new CronSchedule("* * * * *", ZoneId.of("PST8PDT"));
         CronSchedule cronScheduleTwo = new CronSchedule("* * * * *", ZoneId.of("PST8PDT"));
         CronSchedule cronScheduleThree = new CronSchedule("1 * * * *", ZoneId.of("PST8PDT"));
+        CronSchedule cronScheduleFour = new CronSchedule("1 * * * *", ZoneId.of("PST8PDT"), DELAY);
+        CronSchedule cronScheduleFive = new CronSchedule("1 * * * *", ZoneId.of("PST8PDT"), DELAY);
 
-        Assert.assertEquals(cronScheduleOne, cronScheduleTwo);
-        Assert.assertNotEquals(cronScheduleOne, cronScheduleThree);
-        Assert.assertEquals(cronScheduleOne.hashCode(), cronScheduleTwo.hashCode());
+        Assert.assertEquals("Identical cron schedules were not equal", cronScheduleOne, cronScheduleTwo);
+        Assert.assertNotEquals("Different cron schedules were called equal", cronScheduleOne, cronScheduleThree);
+        Assert.assertEquals("Identical cron schedules had different hash codes", cronScheduleOne.hashCode(), cronScheduleTwo.hashCode());
+        Assert.assertNotEquals("Different cron schedules were called equal", cronScheduleThree, cronScheduleFour);
+        Assert.assertNotEquals("Different cron schedules had the same hash code", cronScheduleThree.hashCode(), cronScheduleFour.hashCode());
+        Assert.assertEquals("Identical cron schedules were not equal", cronScheduleFour, cronScheduleFive);
+        Assert.assertEquals("Identical cron schedules had different hash codes", cronScheduleFour.hashCode(), cronScheduleFive.hashCode());
     }
 
     public void testCronScheduleAsStream() throws Exception {
@@ -171,5 +250,14 @@ public class CronScheduleTests extends OpenSearchTestCase {
         StreamInput input = out.bytes().streamInput();
         CronSchedule newCronSchedule = new CronSchedule(input);
         assertEquals(cronSchedule, newCronSchedule);
+    }
+
+    public void testCronScheduleAsStreamDelay() throws Exception {
+        BytesStreamOutput out = new BytesStreamOutput();
+        CronSchedule schedule = new CronSchedule("* * * * *", ZoneId.of("PST8PDT"), DELAY);
+        schedule.writeTo(out);
+        StreamInput input = out.bytes().streamInput();
+        CronSchedule newCronSchedule = new CronSchedule(input);
+        assertEquals(schedule, newCronSchedule);
     }
 }

--- a/spi/src/test/java/org/opensearch/jobscheduler/spi/schedule/IntervalScheduleTests.java
+++ b/spi/src/test/java/org/opensearch/jobscheduler/spi/schedule/IntervalScheduleTests.java
@@ -44,16 +44,20 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
+import java.util.Locale;
 
 public class IntervalScheduleTests extends OpenSearchTestCase {
 
     private IntervalSchedule intervalSchedule;
+    private IntervalSchedule intervalScheduleDelay;
     private Instant startTime;
+    private final long DELAY = 15000;
 
     @Before
     public void setup() throws ParseException {
-        startTime = new SimpleDateFormat("MM/dd/yyyy").parse("01/01/2019").toInstant();
+        startTime = new SimpleDateFormat("MM/dd/yyyy", Locale.ROOT).parse("01/01/2019").toInstant();
         this.intervalSchedule = new IntervalSchedule(startTime, 1, ChronoUnit.MINUTES);
+        this.intervalScheduleDelay = new IntervalSchedule(startTime, 3, ChronoUnit.MINUTES, DELAY);
     }
 
     @Test (expected =  IllegalArgumentException.class)
@@ -66,11 +70,21 @@ public class IntervalScheduleTests extends OpenSearchTestCase {
         Instant now = Instant.now();
         Clock testClock = Clock.fixed(now, ZoneId.systemDefault());
         this.intervalSchedule.setClock(testClock);
+        this.intervalScheduleDelay.setClock(testClock);
 
         Instant nextMinute = Instant.ofEpochSecond(now.getEpochSecond() / 60 * 60 + 60);
         Duration expected = Duration.of(nextMinute.toEpochMilli() - now.toEpochMilli(), ChronoUnit.MILLIS);
 
+        Instant nextIntervalPlusDelay = Instant.ofEpochSecond(((now.minusMillis(DELAY).getEpochSecond()) / 180 * 180) + 180).plusMillis(DELAY);
+        Duration expectedDelay = Duration.of(nextIntervalPlusDelay.toEpochMilli() - now.toEpochMilli(), ChronoUnit.MILLIS);
+
         Assert.assertEquals(expected, this.intervalSchedule.nextTimeToExecute());
+        Assert.assertEquals(expectedDelay, this.intervalScheduleDelay.nextTimeToExecute());
+
+        Assert.assertEquals(this.intervalSchedule.nextTimeToExecute(),
+                Duration.between(now, this.intervalSchedule.getNextExecutionTime(now)));
+        Assert.assertEquals(this.intervalScheduleDelay.nextTimeToExecute(),
+                Duration.between(now, this.intervalScheduleDelay.getNextExecutionTime(now)));
     }
 
     public void testGetPeriodStartingAt() {
@@ -135,8 +149,49 @@ public class IntervalScheduleTests extends OpenSearchTestCase {
         Assert.assertFalse(this.intervalSchedule.runningOnTime(lastExecutionTime));
     }
 
+    public void testRunningOnTimeWithDelay() {
+        Instant now = Instant.now();
+        if(now.minusMillis(DELAY).toEpochMilli() % (180 * 1000) == 0) {
+            // test "now" is not execution time case
+            now = now.plus(10, ChronoUnit.SECONDS);
+        }
+        Instant currentThreeMinutePlusDelay = Instant.ofEpochSecond(now.getEpochSecond() / 180 * 180).plusMillis(DELAY);
+
+        Clock testClock = Clock.fixed(now, ZoneId.systemDefault());
+        this.intervalScheduleDelay.setClock(testClock);
+
+        Instant lastExecutionTime = currentThreeMinutePlusDelay.plus(10, ChronoUnit.MILLIS);
+        Assert.assertTrue(this.intervalScheduleDelay.runningOnTime(lastExecutionTime));
+
+        lastExecutionTime = currentThreeMinutePlusDelay.minus(2, ChronoUnit.SECONDS);
+        Assert.assertFalse(this.intervalScheduleDelay.runningOnTime(lastExecutionTime));
+
+        // test "now" is execution time case
+        now = currentThreeMinutePlusDelay;
+        testClock = Clock.fixed(now, ZoneId.systemDefault());
+        this.intervalScheduleDelay.setClock(testClock);
+
+        lastExecutionTime = currentThreeMinutePlusDelay.minus(179500, ChronoUnit.MILLIS);
+        Assert.assertTrue(this.intervalScheduleDelay.runningOnTime(lastExecutionTime));
+
+        lastExecutionTime = currentThreeMinutePlusDelay.minus(178500, ChronoUnit.MILLIS);
+        Assert.assertFalse(this.intervalScheduleDelay.runningOnTime(lastExecutionTime));
+
+        // test "now" is in the first second, and last run in current second of current second
+        now = currentThreeMinutePlusDelay.plus(500, ChronoUnit.MILLIS);
+        testClock = Clock.fixed(now, ZoneId.systemDefault());
+        this.intervalScheduleDelay.setClock(testClock);
+
+        lastExecutionTime = currentThreeMinutePlusDelay;
+        Assert.assertTrue(this.intervalScheduleDelay.runningOnTime(lastExecutionTime));
+
+        lastExecutionTime = currentThreeMinutePlusDelay.minus(2, ChronoUnit.SECONDS);
+        Assert.assertFalse(this.intervalScheduleDelay.runningOnTime(lastExecutionTime));
+    }
+
     public void testRunningOnTime_nullLastExetime() {
         Assert.assertTrue(this.intervalSchedule.runningOnTime(null));
+        Assert.assertTrue(this.intervalScheduleDelay.runningOnTime(null));
     }
 
     public void testToXContent() throws IOException {
@@ -146,6 +201,12 @@ public class IntervalScheduleTests extends OpenSearchTestCase {
                 .utf8ToString();
         Assert.assertEquals(xContentJsonStr, XContentHelper.toXContent(this.intervalSchedule, XContentType.JSON, false)
                 .utf8ToString());
+
+        String xContentJsonStrDelay = "{\"interval\":{\"start_time\":" + epochMillis + ",\"period\":3,\"unit\":\"Minutes\",\"schedule_delay\":15000}}";
+        XContentHelper.toXContent(this.intervalScheduleDelay, XContentType.JSON, false)
+                .utf8ToString();
+        Assert.assertEquals(xContentJsonStrDelay, XContentHelper.toXContent(this.intervalScheduleDelay, XContentType.JSON, false)
+                .utf8ToString());
     }
 
     public void testIntervalScheduleEqualsAndHashCode() {
@@ -153,10 +214,15 @@ public class IntervalScheduleTests extends OpenSearchTestCase {
         IntervalSchedule intervalScheduleOne = new IntervalSchedule(Instant.ofEpochMilli(epochMilli), 5, ChronoUnit.MINUTES);
         IntervalSchedule intervalScheduleTwo = new IntervalSchedule(Instant.ofEpochMilli(epochMilli), 5, ChronoUnit.MINUTES);
         IntervalSchedule intervalScheduleThree = new IntervalSchedule(Instant.ofEpochMilli(epochMilli), 4, ChronoUnit.MINUTES);
+        IntervalSchedule intervalScheduleFour = new IntervalSchedule(Instant.ofEpochMilli(epochMilli), 4, ChronoUnit.MINUTES, 5000);
+        IntervalSchedule intervalScheduleFive = new IntervalSchedule(Instant.ofEpochMilli(epochMilli), 4, ChronoUnit.MINUTES, 5000);
 
-        Assert.assertEquals(intervalScheduleOne, intervalScheduleTwo);
-        Assert.assertNotEquals(intervalScheduleOne, intervalScheduleThree);
-        Assert.assertEquals(intervalScheduleOne.hashCode(), intervalScheduleTwo.hashCode());
+        Assert.assertEquals("Identical interval schedules were not equal", intervalScheduleOne, intervalScheduleTwo);
+        Assert.assertNotEquals("Different interval schedules were called equal", intervalScheduleOne, intervalScheduleThree);
+        Assert.assertEquals("Identical interval schedules had different hash codes", intervalScheduleOne.hashCode(), intervalScheduleTwo.hashCode());
+        Assert.assertNotEquals("Different interval schedules were called equal", intervalScheduleOne, intervalScheduleFour);
+        Assert.assertEquals("Identical interval schedules were not equal", intervalScheduleFour, intervalScheduleFive);
+        Assert.assertEquals("Identical interval schedules had different hash codes", intervalScheduleFour.hashCode(), intervalScheduleFive.hashCode());
     }
 
     public void testIntervalScheduleAsStream() throws Exception {
@@ -165,5 +231,12 @@ public class IntervalScheduleTests extends OpenSearchTestCase {
         StreamInput input = out.bytes().streamInput();
         IntervalSchedule newIntervalSchedule = new IntervalSchedule(input);
         assertEquals(intervalSchedule, newIntervalSchedule);
+
+        BytesStreamOutput outDelay = new BytesStreamOutput();
+        intervalScheduleDelay.writeTo(outDelay);
+        StreamInput inputDelay = outDelay.bytes().streamInput();
+        IntervalSchedule newIntervalScheduleDelay = new IntervalSchedule(inputDelay);
+        assertEquals(intervalScheduleDelay, newIntervalScheduleDelay);
     }
+
 }

--- a/spi/src/test/java/org/opensearch/jobscheduler/spi/schedule/ScheduleParserTests.java
+++ b/spi/src/test/java/org/opensearch/jobscheduler/spi/schedule/ScheduleParserTests.java
@@ -41,7 +41,7 @@ import java.time.temporal.ChronoUnit;
 public class ScheduleParserTests extends OpenSearchTestCase {
 
     public void testParseCronSchedule() throws IOException {
-        String cronScheduleJsonStr = "{\"cron\":{\"expression\":\"* * * * *\",\"timezone\":\"PST8PDT\"}}";
+        String cronScheduleJsonStr = "{\"cron\":{\"expression\":\"* * * * *\",\"timezone\":\"PST8PDT\", \"schedule_delay\":1234}}";
 
         XContentParser parser = this.createParser(XContentType.JSON.xContent(), new BytesArray(cronScheduleJsonStr));
         parser.nextToken();
@@ -53,20 +53,21 @@ public class ScheduleParserTests extends OpenSearchTestCase {
     }
 
     public void testParseIntervalSchedule() throws IOException {
-        String intervalScheduleJsonStr = "{\"interval\":{\"start_time\":1546329600000,\"period\":1,\"unit\":\"Minutes\"}}";
+        String intervalScheduleJsonStr = "{\"interval\":{\"start_time\":1546329600000,\"period\":1,\"unit\":\"Minutes\"" +
+                ", \"schedule_delay\":1234}}";
 
         XContentParser parser = this.createParser(XContentType.JSON.xContent(), new BytesArray(intervalScheduleJsonStr));
         parser.nextToken();
         Schedule schedule = ScheduleParser.parse(parser);
 
         Assert.assertTrue(schedule instanceof IntervalSchedule);
-        Assert.assertEquals(Instant.ofEpochMilli(1546329600000L), ((IntervalSchedule)schedule).getStartTime());
+        Assert.assertEquals(Instant.ofEpochMilli(1546329600000L).plusMillis(1234), ((IntervalSchedule)schedule).getStartTime());
         Assert.assertEquals(1, ((IntervalSchedule)schedule).getInterval());
         Assert.assertEquals(ChronoUnit.MINUTES, ((IntervalSchedule)schedule).getUnit());
     }
 
     @Test (expected = IllegalArgumentException.class)
-    public void testUnknownScheudleType() throws IOException {
+    public void testUnknownScheduleType() throws IOException {
         String scheduleJsonStr = "{\"unknown_type\":{\"field\":\"value\"}}";
 
         XContentParser parser = this.createParser(XContentType.JSON.xContent(), new BytesArray(scheduleJsonStr));


### PR DESCRIPTION
Signed-off-by: Clay Downs <downsrob@amazon.com>

### Description
Adds a delay parameter to the job scheduler which allows plugins to put off execution time by a fixed number of milliseconds. For example, an interval schedule which starts at 10 AM with a delay of 3 minutes and an interval of 7 minutes would run at 10:03 AM, then 10:10 AM, then 10:17 AM and so on. This parameter is being added to enable plugins to easily add a delay to job schedules without parsing and modifying the user defined interval or cron schedule. 

The ISM delay changes depend on this job scheduler change to add the delay feature to ISM rollup jobs.

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).