### PR TITLE
Fixes possible negative jitter

### DIFF
--- a/src/main/java/org/opensearch/jobscheduler/scheduler/JobScheduler.java
+++ b/src/main/java/org/opensearch/jobscheduler/scheduler/JobScheduler.java
@@ -167,7 +167,10 @@ public class JobScheduler {
                 double jitter = jobParameter.getJitter() == null ? 0d : jobParameter.getJitter();
                 jitter = jitter > jitterLimit ? jitterLimit : jitter;
                 jitter = jitter < 0 ? 0 : jitter;
-                long jitterMillis = Math.round(Randomness.get().nextLong() % interval.toMillis() * jitter);
+                long randomLong = Randomness.get().nextLong();
+                if (randomLong == Long.MIN_VALUE) randomLong += 17; // to ensure the * -1 below doesn't fail to change to positive
+                long randomPositiveLong = randomLong < 0 ? randomLong * -1 : randomLong;
+                long jitterMillis = Math.round(randomPositiveLong % interval.toMillis() * jitter);
                 if (jitter > 0) {
                     log.info("Will delay {} miliseconds for next execution of job {}", jitterMillis, jobParameter.getName());
                 }


### PR DESCRIPTION
Signed-off-by: Drew Baugher <46505179+dbbaughe@users.noreply.github.com>

### Description
Current logic of jitter allows a negative value to be set and throw an exception

```
2021-11-01T14:46:11,738][INFO ][o.o.j.s.JobScheduler     ] [integTest-0] Will delay -34267 miliseconds for next execution of job testing-01
...
[2021-11-01T14:46:20,547][INFO ][o.o.j.s.JobScheduler     ] [integTest-0] Will delay 32889 miliseconds for next execution of job testing-01
...
[2021-11-01T14:48:27,705][INFO ][o.o.j.s.JobScheduler     ] [integTest-0] Will delay -29262 miliseconds for next execution of job testing-01
[2021-11-01T14:48:27,707][ERROR][o.o.b.OpenSearchUncaughtExceptionHandler] [integTest-0] uncaught exception in thread [opensearch[integTest-0][open_distro_job_scheduler][T#3]]
java.lang.IllegalArgumentException: duration cannot be negative, was given [-2158096000]
        at org.opensearch.common.unit.TimeValue.<init>(TimeValue.java:65) ~[opensearch-core-1.2.0-SNAPSHOT.jar:1.2.0-SNAPSHOT]
        at org.opensearch.jobscheduler.scheduler.JobScheduler.reschedule(JobScheduler.java:201) ~[?:?]
        at org.opensearch.jobscheduler.scheduler.JobScheduler.lambda$reschedule$0(JobScheduler.java:188) ~[?:?]
        at org.opensearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:733) ~[opensearch-1.2.0-SNAPSHOT.jar:1.2.0-SNAPSHOT]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630) ~[?:?]
        at java.lang.Thread.run(Thread.java:832) [?:?]
...
```

ISM job fails to run after that, this appears to have be introduced with the recent change of adding support for using jitter in ISM (https://github.com/opensearch-project/index-management/commit/ab122799283a58bb3f5c6f6d8576c7ba5875f13b), as previously ISM was not using it in OpenSearch and would not have hit this issue.

 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
