### PR TITLE
Update maven publication to include cksums.

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -59,8 +59,9 @@ fi
 [ -z "$OUTPUT" ] && OUTPUT=artifacts
 
 ./gradlew publishShadowPublicationToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
-mkdir -p $OUTPUT/maven/org/opensearch
-cp -r ./spi/build/distributions/* $OUTPUT/maven/org/opensearch
+./gradlew publishShadowPublicationToStagingRepository -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
+mkdir -p $OUTPUT/maven/org/opensearch/opensearch-job-scheduler-spi
+cp -r ./build/local-staging-repo/org/opensearch/opensearch-job-scheduler-spi $OUTPUT/maven/org/opensearch/opensearch-job-scheduler-spi
 
 ./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 [ -z "$OUTPUT" ] && OUTPUT=artifacts

--- a/spi/build.gradle
+++ b/spi/build.gradle
@@ -113,16 +113,13 @@ task javadocJar(type: Jar) {
     dependsOn javadoc
 }
 
-tasks.withType(Jar) { task ->
-    task.doLast {
-        ant.checksum algorithm: 'md5', file: it.archivePath
-        ant.checksum algorithm: 'sha1', file: it.archivePath
-        ant.checksum algorithm: 'sha-256', file: it.archivePath, fileext: '.sha256'
-        ant.checksum algorithm: 'sha-512', file: it.archivePath, fileext: '.sha512'
-    }
-}
-
 publishing {
+    repositories {
+        maven {
+            name = 'staging'
+            url = "${rootProject.buildDir}/local-staging-repo"
+        }
+    }
     publications {
         shadow(MavenPublication) { publication ->
             project.shadow.component(publication)


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
This change adds a task to publish to a local staging repo under build/ that includes cksums.  It also updates build.sh to use this new task and copy the contents of the staging repo to the output directory.
The maven publish plugin will not include these cksums when publishing to maven local but will when published to a separate folder.

```
/scripts/build.sh -v 1.2.0 -s true
```

```
~/workspace/job-scheduler (maven)$ find artifacts/maven/org/opensearch/opensearch-job-scheduler-spi
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/maven-metadata.xml.sha256
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/maven-metadata.xml
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/1.2.0.0-SNAPSHOT
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/1.2.0.0-SNAPSHOT/opensearch-job-scheduler-spi-1.2.0.0-20211103.210801-2-javadoc.jar.sha512
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/1.2.0.0-SNAPSHOT/opensearch-job-scheduler-spi-1.2.0.0-20211103.210801-2-javadoc.jar.md5
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/1.2.0.0-SNAPSHOT/opensearch-job-scheduler-spi-1.2.0.0-20211103.210801-2.pom.md5
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/1.2.0.0-SNAPSHOT/opensearch-job-scheduler-spi-1.2.0.0-20211103.210704-1-sources.jar.sha256
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/1.2.0.0-SNAPSHOT/opensearch-job-scheduler-spi-1.2.0.0-20211103.210704-1.pom.sha512
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/1.2.0.0-SNAPSHOT/opensearch-job-scheduler-spi-1.2.0.0-20211103.210801-2.pom.sha1
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/1.2.0.0-SNAPSHOT/opensearch-job-scheduler-spi-1.2.0.0-20211103.210704-1.jar.sha256
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/1.2.0.0-SNAPSHOT/opensearch-job-scheduler-spi-1.2.0.0-20211103.210801-2-sources.jar.sha1
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/1.2.0.0-SNAPSHOT/opensearch-job-scheduler-spi-1.2.0.0-20211103.210704-1.jar
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/1.2.0.0-SNAPSHOT/maven-metadata.xml.sha256
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/1.2.0.0-SNAPSHOT/opensearch-job-scheduler-spi-1.2.0.0-20211103.210704-1.pom.sha1
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/1.2.0.0-SNAPSHOT/opensearch-job-scheduler-spi-1.2.0.0-20211103.210801-2.jar.sha256
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/1.2.0.0-SNAPSHOT/opensearch-job-scheduler-spi-1.2.0.0-20211103.210801-2.pom.sha512
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/1.2.0.0-SNAPSHOT/opensearch-job-scheduler-spi-1.2.0.0-20211103.210704-1-sources.jar.md5
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/1.2.0.0-SNAPSHOT/opensearch-job-scheduler-spi-1.2.0.0-20211103.210704-1-javadoc.jar.sha1
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/1.2.0.0-SNAPSHOT/opensearch-job-scheduler-spi-1.2.0.0-20211103.210801-2.jar.md5
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/1.2.0.0-SNAPSHOT/opensearch-job-scheduler-spi-1.2.0.0-20211103.210704-1-sources.jar
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/1.2.0.0-SNAPSHOT/opensearch-job-scheduler-spi-1.2.0.0-20211103.210704-1.pom
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/1.2.0.0-SNAPSHOT/opensearch-job-scheduler-spi-1.2.0.0-20211103.210704-1-javadoc.jar.sha512
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/1.2.0.0-SNAPSHOT/opensearch-job-scheduler-spi-1.2.0.0-20211103.210704-1-javadoc.jar
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/1.2.0.0-SNAPSHOT/opensearch-job-scheduler-spi-1.2.0.0-20211103.210801-2-sources.jar.sha256
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/1.2.0.0-SNAPSHOT/maven-metadata.xml
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/1.2.0.0-SNAPSHOT/opensearch-job-scheduler-spi-1.2.0.0-20211103.210704-1.pom.sha256
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/1.2.0.0-SNAPSHOT/opensearch-job-scheduler-spi-1.2.0.0-20211103.210704-1.jar.sha512
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/1.2.0.0-SNAPSHOT/opensearch-job-scheduler-spi-1.2.0.0-20211103.210801-2.jar.sha512
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/1.2.0.0-SNAPSHOT/opensearch-job-scheduler-spi-1.2.0.0-20211103.210801-2.pom.sha256
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/1.2.0.0-SNAPSHOT/maven-metadata.xml.sha512
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/1.2.0.0-SNAPSHOT/opensearch-job-scheduler-spi-1.2.0.0-20211103.210704-1.jar.sha1
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/1.2.0.0-SNAPSHOT/opensearch-job-scheduler-spi-1.2.0.0-20211103.210704-1.jar.md5
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/1.2.0.0-SNAPSHOT/opensearch-job-scheduler-spi-1.2.0.0-20211103.210801-2-javadoc.jar.sha256
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/1.2.0.0-SNAPSHOT/opensearch-job-scheduler-spi-1.2.0.0-20211103.210801-2.pom
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/1.2.0.0-SNAPSHOT/opensearch-job-scheduler-spi-1.2.0.0-20211103.210704-1-sources.jar.sha1
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/1.2.0.0-SNAPSHOT/opensearch-job-scheduler-spi-1.2.0.0-20211103.210704-1-sources.jar.sha512
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/1.2.0.0-SNAPSHOT/opensearch-job-scheduler-spi-1.2.0.0-20211103.210801-2.jar.sha1
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/1.2.0.0-SNAPSHOT/opensearch-job-scheduler-spi-1.2.0.0-20211103.210704-1-javadoc.jar.sha256
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/1.2.0.0-SNAPSHOT/opensearch-job-scheduler-spi-1.2.0.0-20211103.210801-2-javadoc.jar.sha1
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/1.2.0.0-SNAPSHOT/maven-metadata.xml.md5
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/1.2.0.0-SNAPSHOT/opensearch-job-scheduler-spi-1.2.0.0-20211103.210801-2-sources.jar.sha512
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/1.2.0.0-SNAPSHOT/maven-metadata.xml.sha1
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/1.2.0.0-SNAPSHOT/opensearch-job-scheduler-spi-1.2.0.0-20211103.210704-1-javadoc.jar.md5
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/1.2.0.0-SNAPSHOT/opensearch-job-scheduler-spi-1.2.0.0-20211103.210801-2-sources.jar
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/1.2.0.0-SNAPSHOT/opensearch-job-scheduler-spi-1.2.0.0-20211103.210704-1.pom.md5
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/1.2.0.0-SNAPSHOT/opensearch-job-scheduler-spi-1.2.0.0-20211103.210801-2-sources.jar.md5
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/1.2.0.0-SNAPSHOT/opensearch-job-scheduler-spi-1.2.0.0-20211103.210801-2.jar
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/1.2.0.0-SNAPSHOT/opensearch-job-scheduler-spi-1.2.0.0-20211103.210801-2-javadoc.jar
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/maven-metadata.xml.sha512
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/maven-metadata.xml.md5
artifacts/maven/org/opensearch/opensearch-job-scheduler-spi/maven-metadata.xml.sha1
```
 
### Issues Resolved
closes #79 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
