### PR TITLE
[Backport 1.x] - Update maven publication to include cksums. 

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -59,8 +59,9 @@ fi
 [ -z "$OUTPUT" ] && OUTPUT=artifacts
 
 ./gradlew publishShadowPublicationToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
-mkdir -p $OUTPUT/maven/org/opensearch
-cp -r ./spi/build/distributions/* $OUTPUT/maven/org/opensearch
+./gradlew publishShadowPublicationToStagingRepository -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
+mkdir -p $OUTPUT/maven/org/opensearch/opensearch-job-scheduler-spi
+cp -r ./build/local-staging-repo/org/opensearch/opensearch-job-scheduler-spi $OUTPUT/maven/org/opensearch/opensearch-job-scheduler-spi
 
 ./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 [ -z "$OUTPUT" ] && OUTPUT=artifacts

--- a/spi/build.gradle
+++ b/spi/build.gradle
@@ -113,16 +113,13 @@ task javadocJar(type: Jar) {
     dependsOn javadoc
 }
 
-tasks.withType(Jar) { task ->
-    task.doLast {
-        ant.checksum algorithm: 'md5', file: it.archivePath
-        ant.checksum algorithm: 'sha1', file: it.archivePath
-        ant.checksum algorithm: 'sha-256', file: it.archivePath, fileext: '.sha256'
-        ant.checksum algorithm: 'sha-512', file: it.archivePath, fileext: '.sha512'
-    }
-}
-
 publishing {
+    repositories {
+        maven {
+            name = 'staging'
+            url = "${rootProject.buildDir}/local-staging-repo"
+        }
+    }
     publications {
         shadow(MavenPublication) { publication ->
             project.shadow.component(publication)


### PR DESCRIPTION
### Description
This is a backport of #82 to 1.x branch.
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
