### PR TITLE
Bumps cron-utils version

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -14,7 +14,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@master
         with:
-          args: --accept=200,403,429  "**/*.html" "**/*.md" "**/*.txt" "**/*.json" --exclude-file .lychee.excludes
+          args: --accept=200,403,429  **/*.html **/*.md **/*.txt **/*.json --exclude-file .lychee.excludes
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Fail if there were link errors

--- a/spi/build.gradle
+++ b/spi/build.gradle
@@ -66,7 +66,7 @@ check.dependsOn jacocoTestReport
 
 dependencies {
     compileOnly "org.opensearch:opensearch:${opensearch_version}"
-    compile "com.cronutils:cron-utils:9.1.3"
+    compile "com.cronutils:cron-utils:9.1.6"
 
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
     testImplementation "org.apache.logging.log4j:log4j-core:${versions.log4j}"


### PR DESCRIPTION
Signed-off-by: Clay Downs <downsrob@amazon.com>

### Description
Bumps the cron-utils version from 9.1.3 to 9.1.6
 
### Issues Resolved

 
### Check List
- [ ] New functionality includes testing.
  - [X] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
