### PR TITLE
Update build.gradle to include job-scheduler jar when staging maven publications.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+import com.github.jengelman.gradle.plugins.shadow.ShadowPlugin
 
 buildscript {
     ext {
@@ -74,6 +75,39 @@ allprojects {
 
     plugins.withId('java') {
         sourceCompatibility = targetCompatibility = "1.8"
+    }
+
+}
+allprojects {
+    // Default to the apache license
+    project.ext.licenseName = 'The Apache Software License, Version 2.0'
+    project.ext.licenseUrl = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+    plugins.withType(ShadowPlugin).whenPluginAdded {
+        publishing {
+            repositories {
+                maven {
+                    name = 'staging'
+                    url = "${rootProject.buildDir}/local-staging-repo"
+                }
+            }
+            publications {
+                // add license information to generated poms
+                all {
+                    pom.withXml { XmlProvider xml ->
+                        Node node = xml.asNode()
+                        node.appendNode('inceptionYear', '2021')
+
+                        Node license = node.appendNode('licenses').appendNode('license')
+                        license.appendNode('name', project.licenseName)
+                        license.appendNode('url', project.licenseUrl)
+
+                        Node developer = node.appendNode('developers').appendNode('developer')
+                        developer.appendNode('name', 'OpenSearch')
+                        developer.appendNode('url', 'https://github.com/opensearch-project/job-scheduler')
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -62,10 +62,10 @@ fi
 [[ "$SNAPSHOT" == "true" ]] && VERSION=$VERSION-SNAPSHOT
 [ -z "$OUTPUT" ] && OUTPUT=artifacts
 
-./gradlew publishShadowPublicationToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
-./gradlew publishShadowPublicationToStagingRepository -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
-mkdir -p $OUTPUT/maven/org/opensearch/opensearch-job-scheduler-spi
-cp -r ./build/local-staging-repo/org/opensearch/opensearch-job-scheduler-spi $OUTPUT/maven/org/opensearch/opensearch-job-scheduler-spi
+./gradlew publishToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
+./gradlew publishAllPublicationsToStagingRepository -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
+mkdir -p $OUTPUT/maven/org/opensearch
+cp -r ./build/local-staging-repo/org/opensearch/. $OUTPUT/maven/org/opensearch
 
 ./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 [ -z "$OUTPUT" ] && OUTPUT=artifacts

--- a/spi/build.gradle
+++ b/spi/build.gradle
@@ -124,9 +124,8 @@ publishing {
               }
               developers {
                 developer {
-                  id = "amazonwebservices"
-                  organization = "Amazon Web Services"
-                  organizationUrl = "https://aws.amazon.com"
+                  name = "OpenSearch"
+                  url = "https://github.com/opensearch-project/job-scheduler"
                 }
               }
             }


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
- updates build.gradle to ensure the base jar has the required pom fields for publishing to maven central.
- updates to include this jar when publishing to the local staging repository currently used by CI to pick up artifacts for promotion.
- Updates developer on spi jar to be opensearch.
- Updates build.sh script to be in sync with the script in opensearch-build.  The version of this script in this repo is a backup, a separate PR will be made to opensearch-build.
 
### Issues Resolved
closes #114 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
