### PR TITLE
Bumps cron-utils version to 9.1.6

### DIFF
--- a/spi/build.gradle
+++ b/spi/build.gradle
@@ -66,7 +66,7 @@ check.dependsOn jacocoTestReport
 
 dependencies {
     compileOnly "org.opensearch:opensearch:${opensearch_version}"
-    compile "com.cronutils:cron-utils:9.1.3"
+    compile "com.cronutils:cron-utils:9.1.6"
 
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
     testImplementation "org.apache.logging.log4j:log4j-core:${versions.log4j}"


### PR DESCRIPTION
### Description
Bumps cron-utils version to 9.1.6 due to CVE.
 
### Issues Resolved
NA
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
