### PR TITLE
[1.2] updating build.sh script to be the same as main

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -58,10 +58,10 @@ fi
 [[ "$SNAPSHOT" == "true" ]] && VERSION=$VERSION-SNAPSHOT
 [ -z "$OUTPUT" ] && OUTPUT=artifacts
 
-./gradlew publishShadowPublicationToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
-./gradlew publishShadowPublicationToStagingRepository -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
-mkdir -p $OUTPUT/maven/org/opensearch/opensearch-job-scheduler-spi
-cp -r ./build/local-staging-repo/org/opensearch/opensearch-job-scheduler-spi $OUTPUT/maven/org/opensearch/opensearch-job-scheduler-spi
+./gradlew publishToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
+./gradlew publishAllPublicationsToStagingRepository -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
+mkdir -p $OUTPUT/maven/org/opensearch
+cp -r ./build/local-staging-repo/org/opensearch/. $OUTPUT/maven/org/opensearch
 
 ./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 [ -z "$OUTPUT" ] && OUTPUT=artifacts


### PR DESCRIPTION
Signed-off-by: Amit Galitzky <amgalitz@amazon.com>

### Description
Updates build.sh script to be in sync with the script in the main branch. The build.sh was changed in this PR on main: #117. Only the build.sh change needed to be made in other branches. The version of this script in opensearch-build will be deleted once this change has been made to every supported branch. 
 
### Issues Resolved
#114 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
