### PR TITLE
increment to 1.2.5

### DIFF
--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -28,11 +28,11 @@ jobs:
       # job-scheduler
       - name: Build and Test
         run: |
-          ./gradlew build -Dopensearch.version=1.2.4-SNAPSHOT
+          ./gradlew build -Dopensearch.version=1.2.5-SNAPSHOT
 
       - name: Publish to Maven Local
         run: |
-          ./gradlew publishToMavenLocal -Dopensearch.version=1.2.4-SNAPSHOT
+          ./gradlew publishToMavenLocal -Dopensearch.version=1.2.5-SNAPSHOT
           
       - name: Upload Coverage Report
         uses: codecov/codecov-action@v1

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "1.2.4-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "1.2.5-SNAPSHOT")
     }
 
     repositories {


### PR DESCRIPTION
### Description
increment version to `1.2.5` following Release `1.2.5` issue
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
