### PR TITLE
Build on JDK 17.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
         java:
           - 11
           - 14
+          - 17
 
     name: Build and Test
     runs-on: ubuntu-latest

--- a/build.gradle
+++ b/build.gradle
@@ -74,10 +74,11 @@ allprojects {
     apply from: "$rootDir/build-tools/repositories.gradle"
 
     plugins.withId('java') {
-        sourceCompatibility = targetCompatibility = "1.8"
+        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_11
     }
-
 }
+
 allprojects {
     // Default to the apache license
     project.ext.licenseName = 'The Apache Software License, Version 2.0'

--- a/spi/build.gradle
+++ b/spi/build.gradle
@@ -30,7 +30,7 @@ ext {
 }
 
 jacoco {
-    toolVersion = '0.8.5'
+    toolVersion = '0.8.7'
     reportsDir = file("$buildDir/JacocoReport")
 }
 


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

Removing JDK 8 and building on JDK 17.
 
### Issues Resolved

Closes https://github.com/opensearch-project/job-scheduler/issues/136.
Closes https://github.com/opensearch-project/job-scheduler/issues/137.
Closes https://github.com/opensearch-project/OpenSearch/issues/2299.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
