### PR TITLE
Adds 1.3.0.0 release notes

### DIFF
--- a/release-notes/opensearch.job-scheduler.release-notes-1.3.0.0.md
+++ b/release-notes/opensearch.job-scheduler.release-notes-1.3.0.0.md
@@ -1,0 +1,22 @@
+## Version 1.3.0.0 2022-03-11
+
+Compatible with OpenSearch 1.3.0
+
+### Infrastructure
+
+* Run CI on JDK 8, 11, and 14. ([130](https://github.com/opensearch-project/job-scheduler/pull/130))
+* Auto increment version after release. ([115](https://github.com/opensearch-project/job-scheduler/pull/115))
+* Update build.gradle to include job-scheduler jar in staging maven publications ([117](https://github.com/opensearch-project/job-scheduler/pull/117))
+* Using Github App token to trigger CI for version increment PRs ([126](https://github.com/opensearch-project/job-scheduler/pull/126))
+
+### Documentation
+
+* Add release notes for 1.3.0.0 ([#143](https://github.com/opensearch-project/job-scheduler/pull/143))
+
+### Maintenance
+
+* Bump version to 1.3 ([#106](https://github.com/opensearch-project/job-scheduler/pull/106))
+* Bumps cron-utils version ([111](https://github.com/opensearch-project/job-scheduler/pull/111))
+* Update copyright notices ([87](https://github.com/opensearch-project/job-scheduler/pull/87))
+* Add support for codeowners to repo ([100](https://github.com/opensearch-project/job-scheduler/pull/100))
+* Fixes copyright header ([127](https://github.com/opensearch-project/job-scheduler/pull/127))


### PR DESCRIPTION
Signed-off-by: Drew Baugher <46505179+dbbaughe@users.noreply.github.com>

### Description
Adds 1.3 release notes for job scheduler.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
