### PR TITLE
Allow Job Scheduler Jobs to Lock Resources

### DIFF
--- a/spi/src/main/java/org/opensearch/jobscheduler/spi/LockModel.java
+++ b/spi/src/main/java/org/opensearch/jobscheduler/spi/LockModel.java
@@ -277,7 +277,7 @@ public final class LockModel implements ToXContentObject {
             .field(RELEASED, this.released);
         if (resource != null) {
             builder.field(RESOURCE, this.resource)
-                .field(RESOURCE_TYPE, this.resourceType);
+                    .field(RESOURCE_TYPE, this.resourceType);
         }
         return builder.endObject();
     }

--- a/spi/src/main/java/org/opensearch/jobscheduler/spi/LockModel.java
+++ b/spi/src/main/java/org/opensearch/jobscheduler/spi/LockModel.java
@@ -6,25 +6,33 @@
 package org.opensearch.jobscheduler.spi;
 
 import org.opensearch.common.Strings;
+import org.opensearch.common.hash.MurmurHash3;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.common.xcontent.XContentParserUtils;
 import org.opensearch.index.seqno.SequenceNumbers;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.nio.ByteBuffer;
 import java.time.Instant;
+import java.util.Base64;
+import java.util.Map;
 import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
 
 public final class LockModel implements ToXContentObject {
-    private static final String LOCK_ID_DELIMITR = "-";
+    private static final String LOCK_ID_DELIMITER = "-";
     public static final String JOB_INDEX_NAME = "job_index_name";
     public static final String JOB_ID = "job_id";
     public static final String LOCK_TIME = "lock_time";
     public static final String LOCK_DURATION = "lock_duration_seconds";
     public static final String RELEASED = "released";
+    public static final String RESOURCE = "resource";
+    public static final String RESOURCE_TYPE = "resource_type";
 
     private final String lockId;
     private final String jobIndexName;
@@ -34,6 +42,8 @@ public final class LockModel implements ToXContentObject {
     private final boolean released;
     private final long seqNo;
     private final long primaryTerm;
+    private final Map<String, Object> resource;
+    private final String resourceType;
 
     /**
      * Use this constructor to copy existing lock and update the seqNo and primaryTerm.
@@ -42,9 +52,18 @@ public final class LockModel implements ToXContentObject {
      * @param seqNo       sequence number from OpenSearch document.
      * @param primaryTerm primary term from OpenSearch document.
      */
-    public LockModel(final LockModel copyLock, long seqNo, long primaryTerm) {
-        this(copyLock.jobIndexName, copyLock.jobId, copyLock.lockTime, copyLock.lockDurationSeconds,
-            copyLock.released, seqNo, primaryTerm);
+    public LockModel(final LockModel copyLock, long seqNo, long primaryTerm) throws IOException {
+        this (
+            copyLock.jobIndexName,
+            copyLock.jobId,
+            copyLock.resourceType,
+            copyLock.resource,
+            copyLock.lockTime,
+            copyLock.lockDurationSeconds,
+            copyLock.released,
+            seqNo,
+            primaryTerm
+        );
     }
 
     /**
@@ -53,9 +72,19 @@ public final class LockModel implements ToXContentObject {
      * @param copyLock JobSchedulerLockModel to copy from.
      * @param released boolean flag to indicate if the lock is released
      */
-    public LockModel(final LockModel copyLock, final boolean released) {
-        this(copyLock.jobIndexName, copyLock.jobId, copyLock.lockTime, copyLock.lockDurationSeconds,
-            released, copyLock.seqNo, copyLock.primaryTerm);
+    public LockModel(final LockModel copyLock, final boolean released) throws IOException {
+        this (
+            copyLock.jobIndexName,
+            copyLock.jobId,
+            copyLock.resourceType,
+            copyLock.resource,
+            copyLock.lockTime,
+            copyLock.lockDurationSeconds,
+            released,
+            copyLock.seqNo,
+            copyLock.primaryTerm
+        );
+
     }
 
     /**
@@ -67,37 +96,129 @@ public final class LockModel implements ToXContentObject {
      * @param released            boolean flag to indicate if the lock is released
      */
     public LockModel(final LockModel copyLock,
-                     final Instant updateLockTime, final long lockDurationSeconds, final boolean released) {
-        this(copyLock.jobIndexName, copyLock.jobId, updateLockTime, lockDurationSeconds, released, copyLock.seqNo, copyLock.primaryTerm);
+                     final Instant updateLockTime, final long lockDurationSeconds, final boolean released) throws IOException {
+        this (
+            copyLock.jobIndexName,
+            copyLock.jobId,
+            copyLock.resourceType,
+            copyLock.resource,
+            updateLockTime,
+            lockDurationSeconds,
+            released,
+            copyLock.seqNo,
+            copyLock.primaryTerm
+        );
     }
 
-    public LockModel(String jobIndexName, String jobId, Instant lockTime, long lockDurationSeconds, boolean released) {
+    /**
+     * Use this constructor to build a job-scheduler lock.
+     * @param jobIndexName          index of job acquiring the lock.
+     * @param jobId                 id of job acquiring the lock.
+     * @param lockTime              time at which the lock is acquired.
+     * @param lockDurationSeconds   duration for which the lock is valid.
+     * @param released              boolean flag to indicate if the lock is released.
+     */
+    public LockModel(String jobIndexName, String jobId, Instant lockTime, long lockDurationSeconds, boolean released) throws IOException {
         this(jobIndexName, jobId, lockTime, lockDurationSeconds, released,
-            SequenceNumbers.UNASSIGNED_SEQ_NO, SequenceNumbers.UNASSIGNED_PRIMARY_TERM);
+                SequenceNumbers.UNASSIGNED_SEQ_NO, SequenceNumbers.UNASSIGNED_PRIMARY_TERM);
     }
 
+    /**
+     * Fully parametrized constructor for building a job-scheduler lock
+     * @param jobIndexName          index of job acquiring the lock.
+     * @param jobId                 id of job acquiring the lock.
+     * @param lockTime              time at which the lock is acquired.
+     * @param lockDurationSeconds   duration for which the lock is valid.
+     * @param released              boolean flag to indicate if the lock is released.
+     * @param seqNo                 sequence number from OpenSearch document.
+     * @param primaryTerm           primary term from OpenSearch document.
+     */
     public LockModel(String jobIndexName, String jobId, Instant lockTime,
-                     long lockDurationSeconds, boolean released, long seqNo, long primaryTerm) {
-        this.lockId = jobIndexName + LOCK_ID_DELIMITR + jobId;
-        this.jobIndexName = jobIndexName;
-        this.jobId = jobId;
-        this.lockTime = lockTime;
-        this.lockDurationSeconds = lockDurationSeconds;
-        this.released = released;
-        this.seqNo = seqNo;
-        this.primaryTerm = primaryTerm;
+                     long lockDurationSeconds, boolean released, long seqNo, long primaryTerm) throws IOException {
+        this(jobIndexName, jobId, null, null, lockTime, lockDurationSeconds, released, seqNo, primaryTerm);
+    }
+
+    public LockModel(String jobIndexName, String jobId, String resourceType, Map<String, Object> resource, Instant lockTime,
+                     long lockDurationSeconds, boolean released) throws IOException {
+        this(jobIndexName, jobId, resourceType, resource, lockTime, lockDurationSeconds, released,
+                SequenceNumbers.UNASSIGNED_SEQ_NO, SequenceNumbers.UNASSIGNED_PRIMARY_TERM);
+    }
+
+    /***
+     *
+     * @param jobIndexName          index of job acquiring the lock
+     * @param jobId                 id of the job acquiring the lock
+     * @param resourceType          type of job acquiring the lock
+     * @param resource              resource to acquire
+     * @param lockTime              time at which lock is acquired
+     * @param lockDurationSeconds   duration for which lock is valid
+     * @param released              boolean flag for whether lock is released
+     * @param seqNo                 sequence number from Opensearch document
+     * @param primaryTerm           primary term from Opensearch document
+     * @throws IOException          throws IOException if resource fails to serialize
+     */
+    public LockModel(String jobIndexName, String jobId, String resourceType, Map<String, Object> resource, Instant lockTime,
+                     long lockDurationSeconds, boolean released, long seqNo, long primaryTerm) throws IOException {
+        if (resourceType != null) {
+            this.lockId = LockModel.generateResourceLockId(jobIndexName, resourceType, resource);
+            this.jobIndexName = jobIndexName;
+            this.jobId = jobId;
+            this.resourceType = resourceType;
+            this.resource = resource;
+            this.lockTime = lockTime;
+            this.lockDurationSeconds = lockDurationSeconds;
+            this.released = released;
+            this.seqNo = seqNo;
+            this.primaryTerm = primaryTerm;
+        }
+        else {
+            this.lockId = jobIndexName + LOCK_ID_DELIMITER + jobId;
+            this.jobIndexName = jobIndexName;
+            this.jobId = jobId;
+            this.lockTime = lockTime;
+            this.lockDurationSeconds = lockDurationSeconds;
+            this.released = released;
+            this.seqNo = seqNo;
+            this.primaryTerm = primaryTerm;
+            this.resource = null;
+            this.resourceType = null;
+        }
+
     }
 
     public static String generateLockId(String jobIndexName, String jobId) {
-        return jobIndexName + LOCK_ID_DELIMITR + jobId;
+        return jobIndexName + LOCK_ID_DELIMITER + jobId;
+    }
+
+    public static String generateResourceLockId(String jobIndexName, String resourceType, Map<String, Object> resource) throws IOException {
+        try {
+            byte[] resourceAsBytes = serialize(resource);
+            MurmurHash3.Hash128 hash = MurmurHash3.hash128(resourceAsBytes, 0, resourceAsBytes.length, 0,
+                    new MurmurHash3.Hash128());
+            byte[] resourceHashBytes = ByteBuffer.allocate(16).putLong(hash.h1).putLong(hash.h2).array();
+            String resourceAsHashString = Base64.getUrlEncoder().withoutPadding().encodeToString(resourceHashBytes);
+            return jobIndexName + LOCK_ID_DELIMITER + resourceType + LOCK_ID_DELIMITER + resourceAsHashString;
+        } catch (IOException ioException) {
+            ioException.printStackTrace();
+            throw ioException;
+        }
+    }
+
+    private static byte[] serialize(Object obj) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ObjectOutputStream os = new ObjectOutputStream(out);
+        os.writeObject(obj);
+        return out.toByteArray();
     }
 
     public static LockModel parse(final XContentParser parser, long seqNo, long primaryTerm) throws IOException {
         String jobIndexName = null;
         String jobId = null;
+        String resourceType = null;
         Instant lockTime = null;
         Long lockDurationSecond = null;
         Boolean released = null;
+        Map<String, Object> resource = null;
 
         XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (!XContentParser.Token.END_OBJECT.equals(parser.nextToken())) {
@@ -119,31 +240,42 @@ public final class LockModel implements ToXContentObject {
                 case RELEASED:
                     released = parser.booleanValue();
                     break;
+                case RESOURCE:
+                    resource = parser.map();
+                    break;
+                case RESOURCE_TYPE:
+                    resourceType = parser.text();
+                    break;
                 default:
                     throw new IllegalArgumentException("Unknown field " + fieldName);
             }
         }
 
         return new LockModel(
-            requireNonNull(jobIndexName, "JobIndexName cannot be null"),
-            requireNonNull(jobId, "JobId cannot be null"),
-            requireNonNull(lockTime, "lockTime cannot be null"),
-            requireNonNull(lockDurationSecond, "lockDurationSeconds cannot be null"),
-            requireNonNull(released, "released cannot be null"),
-            seqNo,
-            primaryTerm
+                requireNonNull(jobIndexName, "JobIndexName cannot be null"),
+                requireNonNull(jobId, "JobId cannot be null"),
+                resourceType,
+                resource,
+                requireNonNull(lockTime, "lockTime cannot be null"),
+                requireNonNull(lockDurationSecond, "lockDurationSeconds cannot be null"),
+                requireNonNull(released, "released cannot be null"),
+                seqNo,
+                primaryTerm
         );
     }
 
     @Override public XContentBuilder toXContent(final XContentBuilder builder, final Params params) throws IOException {
         builder.startObject()
-            .field(JOB_INDEX_NAME, this.jobIndexName)
-            .field(JOB_ID, this.jobId)
-            .field(LOCK_TIME, this.lockTime.getEpochSecond())
-            .field(LOCK_DURATION, this.lockDurationSeconds)
-            .field(RELEASED, this.released)
-            .endObject();
-        return builder;
+                .field(JOB_INDEX_NAME, this.jobIndexName)
+                .field(JOB_ID, this.jobId)
+                .field(LOCK_TIME, this.lockTime.getEpochSecond())
+                .field(LOCK_DURATION, this.lockDurationSeconds)
+                .field(RELEASED, this.released);
+        if (resource != null) {
+            builder.field(RESOURCE, this.resource)
+                    .field(RESOURCE_TYPE, this.resourceType);
+        }
+        return builder.endObject();
     }
 
     @Override public String toString() {
@@ -186,11 +318,17 @@ public final class LockModel implements ToXContentObject {
         return lockTime.getEpochSecond() + lockDurationSeconds < Instant.now().getEpochSecond();
     }
 
+    public Map<String, Object> getResource() {
+        return resource;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         LockModel lockModel = (LockModel) o;
+        boolean resourceCheck = Objects.equals(resource, lockModel.resource);
+        boolean resourceTypeCheck = Objects.equals(resourceType, lockModel.resourceType);
         return lockDurationSeconds == lockModel.lockDurationSeconds &&
                 released == lockModel.released &&
                 seqNo == lockModel.seqNo &&
@@ -198,7 +336,9 @@ public final class LockModel implements ToXContentObject {
                 lockId.equals(lockModel.lockId) &&
                 jobIndexName.equals(lockModel.jobIndexName) &&
                 jobId.equals(lockModel.jobId) &&
-                lockTime.equals(lockModel.lockTime);
+                lockTime.equals(lockModel.lockTime) &&
+                resourceCheck &&
+                resourceTypeCheck;
     }
 
     @Override

--- a/spi/src/main/java/org/opensearch/jobscheduler/spi/utils/LockService.java
+++ b/spi/src/main/java/org/opensearch/jobscheduler/spi/utils/LockService.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.jobscheduler.spi.utils;
 
+import org.opensearch.action.support.master.AcknowledgedResponse;
 import org.opensearch.jobscheduler.spi.JobExecutionContext;
 import org.opensearch.jobscheduler.spi.LockModel;
 import org.opensearch.jobscheduler.spi.ScheduledJobParameter;
@@ -38,14 +39,14 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.Map;
 
 public final class LockService {
     private static final Logger logger = LogManager.getLogger(LockService.class);
-    private static final String LOCK_INDEX_NAME = ".opendistro-job-scheduler-lock";
+    public static final String LOCK_INDEX_NAME = ".opendistro-job-scheduler-lock";
 
     private final Client client;
     private final ClusterService clusterService;
-
     // This is used in tests to control time.
     private Instant testInstant = null;
 
@@ -54,7 +55,8 @@ public final class LockService {
         this.clusterService = clusterService;
     }
 
-    private String lockMapping() {
+    @VisibleForTesting
+    String lockMapping() {
         try {
             InputStream in = LockService.class.getResourceAsStream("opensearch_job_scheduler_lock.json");
             StringBuilder stringBuilder = new StringBuilder();
@@ -68,6 +70,25 @@ public final class LockService {
         }
     }
 
+    private void checkAndUpdateLockMapping(ActionListener<Boolean> listener) {
+        SchemaUtils.checkAndUpdateLockIndexMapping(lockMapping(), clusterService,
+                client.admin().indices(), new ActionListener<AcknowledgedResponse>() {
+                    @Override
+                    public void onResponse(AcknowledgedResponse acknowledgedResponse) {
+                        if (!acknowledgedResponse.isAcknowledged()) {
+                            logger.error("Error updating lock index mapping.");
+                        }
+                        listener.onResponse(acknowledgedResponse.isAcknowledged());
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        listener.onFailure(e);
+                    }
+                }
+        );
+    }
+
     public boolean lockIndexExist() {
         return clusterService.state().routingTable().hasIndex(LOCK_INDEX_NAME);
     }
@@ -79,15 +100,15 @@ public final class LockService {
         } else {
             final CreateIndexRequest request = new CreateIndexRequest(LOCK_INDEX_NAME).mapping(lockMapping());
             client.admin().indices().create(request, ActionListener.wrap(
-               response -> listener.onResponse(response.isAcknowledged()),
-               exception -> {
-                   if (exception instanceof ResourceAlreadyExistsException
-                           || exception.getCause() instanceof ResourceAlreadyExistsException) {
-                       listener.onResponse(true);
-                   } else {
-                       listener.onFailure(exception);
-                   }
-               }
+                    response -> listener.onResponse(response.isAcknowledged()),
+                    exception -> {
+                        if (exception instanceof ResourceAlreadyExistsException
+                                || exception.getCause() instanceof ResourceAlreadyExistsException) {
+                            checkAndUpdateLockMapping(listener);
+                        } else {
+                            listener.onFailure(exception);
+                        }
+                    }
             ));
         }
     }
@@ -103,7 +124,7 @@ public final class LockService {
      *                 have {@code LockDurationSeconds}.
      */
     public void acquireLock(final ScheduledJobParameter jobParameter,
-                                 final JobExecutionContext context, ActionListener<LockModel> listener) {
+                            final JobExecutionContext context, ActionListener<LockModel> listener) {
         final String jobIndexName = context.getJobIndexName();
         final String jobId = context.getJobId();
         if (jobParameter.getLockDurationSeconds() == null) {
@@ -151,6 +172,69 @@ public final class LockService {
         }
     }
 
+    /**
+     * Attempts to acquire lock the job. If the lock does not exists it attempts to create the lock document.
+     * If the Lock document exists, it will try to update and acquire lock.
+     *
+     * @param context a {@code JobExecutionContext} containing job index name and job id.
+     * @param lockDurationSeconds the amount of time in seconds that the lock should exist
+     * @param resourceType the type of process that is acquiring the lock. Used decrease the scope of the lock.
+     * @param resource the resource that is being locked.
+     * @param listener an {@code ActionListener} that has onResponse and onFailure that is used to return the lock if it was acquired
+     *                 or else null. Passes {@code IllegalArgumentException} to onFailure if the {@code ScheduledJobParameter} does not
+     *                 have {@code LockDurationSeconds}.
+     */
+    public void acquireLockOnResource(final JobExecutionContext context,
+                                      final Long lockDurationSeconds,
+                                      final String resourceType,
+                                      final Map<String, Object> resource,
+                                      ActionListener<LockModel> listener) {
+        final String jobIndexName = context.getJobIndexName();
+        final String jobId = context.getJobId();
+        if (lockDurationSeconds == null) {
+            listener.onFailure(new IllegalArgumentException("Job LockDuration should not be null"));
+        } else {
+            createLockIndex(ActionListener.wrap(
+                    created -> {
+                        if (created) {
+                            try {
+                                findLock(LockModel.generateResourceLockId(jobIndexName, resourceType, resource), ActionListener.wrap(
+                                        existingLock -> {
+                                            if (existingLock != null) {
+                                                if (isLockReleasedOrExpired(existingLock)) {
+                                                    // Lock is expired. Attempt to acquire lock.
+                                                    logger.debug("lock is released or expired: " + existingLock);
+                                                    LockModel updateLock = new LockModel(existingLock, getNow(),
+                                                            lockDurationSeconds, false);
+                                                    updateLock(updateLock, listener);
+                                                } else {
+                                                    logger.debug("Lock is NOT released or expired. " + existingLock);
+                                                    // Lock is still not expired. Return null as we cannot acquire lock.
+                                                    listener.onResponse(null);
+                                                }
+                                            } else {
+                                                // There is no lock object and it is first time. Create new lock.
+                                                LockModel tempLock = new LockModel(jobIndexName, jobId, resourceType, resource, getNow(),
+                                                        lockDurationSeconds, false);
+                                                logger.debug("Lock does not exist. Creating new lock" + tempLock);
+                                                createLock(tempLock, listener);
+                                            }
+                                        },
+                                        listener::onFailure
+                                ));
+                            } catch (VersionConflictEngineException e) {
+                                logger.debug("could not acquire lock {}", e.getMessage());
+                                listener.onResponse(null);
+                            }
+                        } else {
+                            listener.onResponse(null);
+                        }
+                    },
+                    listener::onFailure
+            ));
+        }
+    }
+
     private boolean isLockReleasedOrExpired(final LockModel lock) {
         return lock.isReleased() || lock.isExpired();
     }
@@ -158,30 +242,32 @@ public final class LockService {
     private void updateLock(final LockModel updateLock, ActionListener<LockModel> listener) {
         try {
             UpdateRequest updateRequest = new UpdateRequest()
-                .index(LOCK_INDEX_NAME)
-                .id(updateLock.getLockId())
-                .setIfSeqNo(updateLock.getSeqNo())
-                .setIfPrimaryTerm(updateLock.getPrimaryTerm())
-                .doc(updateLock.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS))
-                .fetchSource(true);
-
-            client.update(updateRequest, ActionListener.wrap(
-                    response -> listener.onResponse(new LockModel(updateLock, response.getSeqNo(),
-                            response.getPrimaryTerm())),
-                    exception -> {
-                        if (exception instanceof VersionConflictEngineException) {
-                            logger.debug("could not acquire lock {}", exception.getMessage());
-                        }
-                        if (exception instanceof DocumentMissingException) {
-                            logger.debug("Document is deleted. This happens if the job is already removed and" +
-                                    " this is the last run." +
-                                    "{}", exception.getMessage());
-                        }
-                        if (exception instanceof IOException) {
-                            logger.error("IOException occurred updating lock.", exception);
-                        }
-                        listener.onResponse(null);
-                    }));
+                    .index(LOCK_INDEX_NAME)
+                    .id(updateLock.getLockId())
+                    .setIfSeqNo(updateLock.getSeqNo())
+                    .setIfPrimaryTerm(updateLock.getPrimaryTerm())
+                    .doc(updateLock.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS))
+                    .fetchSource(true);
+            checkAndUpdateLockMapping(ActionListener.wrap(
+                    updated -> client.update(updateRequest, ActionListener.wrap(
+                            response -> listener.onResponse(new LockModel(updateLock, response.getSeqNo(),
+                                    response.getPrimaryTerm())),
+                            exception -> {
+                                if (exception instanceof VersionConflictEngineException) {
+                                    logger.debug("could not acquire lock {}", exception.getMessage());
+                                }
+                                if (exception instanceof DocumentMissingException) {
+                                    logger.debug("Document is deleted. This happens if the job is already removed and" +
+                                            " this is the last run." +
+                                            "{}", exception.getMessage());
+                                }
+                                if (exception instanceof IOException) {
+                                    logger.error("IOException occurred updating lock.", exception);
+                                }
+                                listener.onResponse(null);
+                            })),
+                    listener::onFailure
+            ));
         } catch (IOException e) {
             logger.error("IOException occurred updating lock.", e);
             listener.onResponse(null);
@@ -191,23 +277,29 @@ public final class LockService {
     private void createLock(final LockModel tempLock, ActionListener<LockModel> listener) {
         try {
             final IndexRequest request = new IndexRequest(LOCK_INDEX_NAME)
-                .id(tempLock.getLockId())
-                .source(tempLock.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS))
-                .setIfSeqNo(SequenceNumbers.UNASSIGNED_SEQ_NO)
-                .setIfPrimaryTerm(SequenceNumbers.UNASSIGNED_PRIMARY_TERM)
-                .create(true);
-            client.index(request, ActionListener.wrap(
-                    response -> listener.onResponse(new LockModel(tempLock, response.getSeqNo(),
-                            response.getPrimaryTerm())),
-                    exception -> {
-                       if (exception instanceof VersionConflictEngineException) {
-                           logger.debug("Lock is already created. {}", exception.getMessage());
-                       }
-                       if (exception instanceof IOException) {
-                           logger.error("IOException occurred creating lock", exception);
-                       }
-                       listener.onResponse(null);
-                    }
+                    .id(tempLock.getLockId())
+                    .source(tempLock.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS))
+                    .setIfSeqNo(SequenceNumbers.UNASSIGNED_SEQ_NO)
+                    .setIfPrimaryTerm(SequenceNumbers.UNASSIGNED_PRIMARY_TERM)
+                    .create(true);
+            checkAndUpdateLockMapping(ActionListener.wrap(
+                    updated -> client.index(request, ActionListener.wrap(
+                            response -> {
+                                LockModel newLock = new LockModel(tempLock, response.getSeqNo(),
+                                        response.getPrimaryTerm());
+                                listener.onResponse(newLock);
+                            },
+                            exception -> {
+                                if (exception instanceof VersionConflictEngineException) {
+                                    logger.debug("Lock is already created. {}", exception.getMessage());
+                                }
+                                if (exception instanceof IOException) {
+                                    logger.error("IOException occurred creating lock", exception);
+                                }
+                                listener.onResponse(null);
+                            }
+                    )),
+                    listener::onFailure
             ));
         } catch (IOException e) {
             logger.error("IOException occurred creating lock", e);
@@ -218,27 +310,28 @@ public final class LockService {
     private void findLock(final String lockId, ActionListener<LockModel> listener) {
         GetRequest getRequest = new GetRequest(LOCK_INDEX_NAME).id(lockId);
         client.get(getRequest, ActionListener.wrap(
-                response -> {
-                    if (!response.isExists()) {
-                        listener.onResponse(null);
-                    } else {
-                        try {
-                            XContentParser parser = XContentType.JSON.xContent()
-                                    .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE,
-                                            response.getSourceAsString());
-                            parser.nextToken();
-                            listener.onResponse(LockModel.parse(parser, response.getSeqNo(), response.getPrimaryTerm()));
-                        } catch (IOException e) {
-                            logger.error("IOException occurred finding lock", e);
-                            listener.onResponse(null);
+                        response -> {
+                            if (!response.isExists()) {
+                                listener.onResponse(null);
+                            } else {
+                                try {
+                                    XContentParser parser = XContentType.JSON.xContent()
+                                            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE,
+                                                    response.getSourceAsString());
+                                    parser.nextToken();
+                                    listener.onResponse(LockModel.parse(parser, response.getSeqNo(), response.getPrimaryTerm()));
+                                } catch (IOException e) {
+                                    logger.error("IOException occurred finding lock", e);
+                                    listener.onResponse(null);
+                                }
+                            }
+                        },
+                        exception -> {
+                            logger.error("Exception occurred finding lock", exception);
+                            listener.onFailure(exception);
                         }
-                    }
-                },
-                exception -> {
-                    logger.error("Exception occurred finding lock", exception);
-                    listener.onFailure(exception);
-                }
         ));
+
     }
 
     /**
@@ -256,12 +349,19 @@ public final class LockService {
             listener.onResponse(false);
         } else {
             logger.debug("Releasing lock: " + lock);
-            final LockModel lockToRelease = new LockModel(lock, true);
-            updateLock(lockToRelease, ActionListener.wrap(
-                    releasedLock -> listener.onResponse(releasedLock != null),
-                    listener::onFailure
-            ));
+            try {
+                final LockModel lockToRelease = new LockModel(lock, true);
+                updateLock(lockToRelease, ActionListener.wrap(
+                        releasedLock -> listener.onResponse(releasedLock != null),
+                        listener::onFailure
+                ));
+            } catch (IOException e) {
+                logger.debug("Failed to serialize resource in lock.");
+                listener.onFailure(e);
+            }
+
         }
+
     }
 
     /**
@@ -274,20 +374,19 @@ public final class LockService {
      */
     public void deleteLock(final String lockId, ActionListener<Boolean> listener) {
         DeleteRequest deleteRequest = new DeleteRequest(LOCK_INDEX_NAME).id(lockId);
-        client.delete(deleteRequest, ActionListener.wrap(
-                response -> {
-                    listener.onResponse(response.getResult() == DocWriteResponse.Result.DELETED ||
-                            response.getResult() == DocWriteResponse.Result.NOT_FOUND);
-                },
-                exception -> {
-                    if (exception instanceof IndexNotFoundException
-                            || exception.getCause() instanceof IndexNotFoundException) {
-                        logger.debug("Index is not found to delete lock. {}", exception.getMessage());
-                        listener.onResponse(true);
-                    } else {
-                        listener.onFailure(exception);
-                    }
-                }));
+        checkAndUpdateLockMapping(ActionListener.wrap(
+                updated -> client.delete(deleteRequest, ActionListener.wrap(
+                        response -> listener.onResponse(response.getResult() == DocWriteResponse.Result.DELETED ||
+                                response.getResult() == DocWriteResponse.Result.NOT_FOUND),
+                        exception -> {
+                            if (exception instanceof IndexNotFoundException
+                                    || exception.getCause() instanceof IndexNotFoundException) {
+                                listener.onResponse(true);
+                            } else {
+                                listener.onFailure(exception);
+                            }
+                        })),
+                listener::onFailure));
     }
 
     /**
@@ -307,18 +406,23 @@ public final class LockService {
         } else {
             logger.debug("Renewing lock: {}. The lock was acquired or renewed on: {}, and the duration was {} sec.",
                     lock, lock.getLockTime(), lock.getLockDurationSeconds());
-            final LockModel lockToRenew = new LockModel(lock, getNow(), lock.getLockDurationSeconds(), false);
-            updateLock(lockToRenew, ActionListener.wrap(
-                    renewedLock -> {
-                        logger.debug("Renewed lock: {}. It is supposed to be valid for another {} sec from {}.",
-                                renewedLock, renewedLock.getLockDurationSeconds(), renewedLock.getLockTime());
-                        listener.onResponse(renewedLock);
-                    },
-                    exception -> {
-                        logger.debug("Failed to renew lock: {}.", lock);
-                        listener.onFailure(exception);
-                    }
-            ));
+            try {
+                final LockModel lockToRenew = new LockModel(lock, getNow(), lock.getLockDurationSeconds(), false);
+                updateLock(lockToRenew, ActionListener.wrap(
+                        renewedLock -> {
+                            logger.debug("Renewed lock: {}. It is supposed to be valid for another {} sec from {}.",
+                                    renewedLock, renewedLock.getLockDurationSeconds(), renewedLock.getLockTime());
+                            listener.onResponse(renewedLock);
+                        },
+                        exception -> {
+                            logger.debug("Failed to renew lock: {}.", lock);
+                            listener.onFailure(exception);
+                        }
+                ));
+            } catch (IOException e) {
+                logger.debug("Failed to serialize resource in lock.");
+                listener.onFailure(e);
+            }
         }
     }
 

--- a/spi/src/main/java/org/opensearch/jobscheduler/spi/utils/LockService.java
+++ b/spi/src/main/java/org/opensearch/jobscheduler/spi/utils/LockService.java
@@ -71,8 +71,11 @@ public final class LockService {
     }
 
     private void checkAndUpdateLockMapping(ActionListener<Boolean> listener) {
-        SchemaUtils.checkAndUpdateLockIndexMapping(lockMapping(), clusterService,
-                client.admin().indices(), new ActionListener<AcknowledgedResponse>() {
+        SchemaUtils.checkAndUpdateLockIndexMapping(
+                lockMapping(),
+                clusterService,
+                client.admin().indices(),
+                new ActionListener<AcknowledgedResponse>() {
                     @Override
                     public void onResponse(AcknowledgedResponse acknowledgedResponse) {
                         if (!acknowledgedResponse.isAcknowledged()) {
@@ -99,17 +102,20 @@ public final class LockService {
             listener.onResponse(true);
         } else {
             final CreateIndexRequest request = new CreateIndexRequest(LOCK_INDEX_NAME).mapping(lockMapping());
-            client.admin().indices().create(request, ActionListener.wrap(
-                response -> listener.onResponse(response.isAcknowledged()),
-                exception -> {
-                    if (exception instanceof ResourceAlreadyExistsException
-                            || exception.getCause() instanceof ResourceAlreadyExistsException) {
-                        checkAndUpdateLockMapping(listener);
-                    } else {
-                        listener.onFailure(exception);
-                    }
-                }
-            ));
+            client.admin().indices().create(
+                    request,
+                    ActionListener.wrap(
+                            response -> listener.onResponse(response.isAcknowledged()),
+                            exception -> {
+                                if (exception instanceof ResourceAlreadyExistsException
+                                        || exception.getCause() instanceof ResourceAlreadyExistsException) {
+                                    checkAndUpdateLockMapping(listener);
+                                } else {
+                                    listener.onFailure(exception);
+                                }
+                            }
+                    )
+            );
         }
     }
 
@@ -362,19 +368,22 @@ public final class LockService {
      */
     public void deleteLock(final String lockId, ActionListener<Boolean> listener) {
         DeleteRequest deleteRequest = new DeleteRequest(LOCK_INDEX_NAME).id(lockId);
-        checkAndUpdateLockMapping(ActionListener.wrap(
-                updated -> client.delete(deleteRequest, ActionListener.wrap(
-                        response -> listener.onResponse(response.getResult() == DocWriteResponse.Result.DELETED ||
-                                response.getResult() == DocWriteResponse.Result.NOT_FOUND),
-                        exception -> {
-                            if (exception instanceof IndexNotFoundException
-                                    || exception.getCause() instanceof IndexNotFoundException) {
-                                listener.onResponse(true);
-                            } else {
-                                listener.onFailure(exception);
-                            }
-                        })),
-                listener::onFailure));
+        checkAndUpdateLockMapping(
+                ActionListener.wrap(
+                        updated -> client.delete(deleteRequest, ActionListener.wrap(
+                                response -> listener.onResponse(response.getResult() == DocWriteResponse.Result.DELETED ||
+                                        response.getResult() == DocWriteResponse.Result.NOT_FOUND),
+                                exception -> {
+                                    if (exception instanceof IndexNotFoundException
+                                            || exception.getCause() instanceof IndexNotFoundException) {
+                                        listener.onResponse(true);
+                                    } else {
+                                        listener.onFailure(exception);
+                                    }
+                                })),
+                        listener::onFailure
+                )
+        );
     }
 
     /**

--- a/spi/src/main/java/org/opensearch/jobscheduler/spi/utils/SchemaUtils.java
+++ b/spi/src/main/java/org/opensearch/jobscheduler/spi/utils/SchemaUtils.java
@@ -43,8 +43,7 @@ public class SchemaUtils {
                     while (xcp.nextToken() != Token.END_OBJECT) {
                         if (xcp.currentName().equals(SCHEMA_VERSION)) {
                             return xcp.longValue();
-                        }
-                        else {
+                        } else {
                             xcp.nextToken();
                         }
                     }

--- a/spi/src/main/java/org/opensearch/jobscheduler/spi/utils/SchemaUtils.java
+++ b/spi/src/main/java/org/opensearch/jobscheduler/spi/utils/SchemaUtils.java
@@ -27,7 +27,6 @@ import java.util.Map;
 public class SchemaUtils {
     private static final String _META = "_meta";
     private static final String SCHEMA_VERSION = "schema_version";
-    private static final String _DOC = "_doc";
     private static final long DEFAULT_SCHEMA_VERSION = 1L;
     private static final Logger logger = LogManager.getLogger(SchemaUtils.class);
 

--- a/spi/src/main/java/org/opensearch/jobscheduler/spi/utils/SchemaUtils.java
+++ b/spi/src/main/java/org/opensearch/jobscheduler/spi/utils/SchemaUtils.java
@@ -86,7 +86,7 @@ public class SchemaUtils {
                 long newSchemaVersion = getSchemaVersion(mapping);
                 IndexMetadata indexMetadata = clusterState.metadata().indices().get(LockService.LOCK_INDEX_NAME);
                 if (shouldUpdateIndex(indexMetadata, newSchemaVersion)) {
-                    PutMappingRequest putMappingRequest = new PutMappingRequest(LockService.LOCK_INDEX_NAME).type(_DOC).source(mapping, XContentType.JSON);
+                    PutMappingRequest putMappingRequest = new PutMappingRequest(LockService.LOCK_INDEX_NAME).source(mapping, XContentType.JSON);
                     client.putMapping(putMappingRequest, listener);
                 } else {
                     listener.onResponse(new AcknowledgedResponse(true));

--- a/spi/src/main/java/org/opensearch/jobscheduler/spi/utils/SchemaUtils.java
+++ b/spi/src/main/java/org/opensearch/jobscheduler/spi/utils/SchemaUtils.java
@@ -1,0 +1,110 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.jobscheduler.spi.utils;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.admin.indices.mapping.put.PutMappingRequest;
+import org.opensearch.action.support.master.AcknowledgedResponse;
+import org.opensearch.client.IndicesAdminClient;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.xcontent.LoggingDeprecationHandler;
+import org.opensearch.common.xcontent.NamedXContentRegistry;
+import org.opensearch.common.xcontent.XContentParser;
+import org.opensearch.common.xcontent.XContentParser.Token;
+import org.opensearch.common.xcontent.XContentType;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class SchemaUtils {
+    private static final String _META = "_meta";
+    private static final String SCHEMA_VERSION = "schema_version";
+    private static final String _DOC = "_doc";
+    private static final long DEFAULT_SCHEMA_VERSION = 1L;
+    private static final Logger logger = LogManager.getLogger(SchemaUtils.class);
+
+    public static long schemaVersion(String mapping) throws IOException {
+        XContentParser xcp = XContentType.JSON.xContent().createParser(NamedXContentRegistry.EMPTY,
+                LoggingDeprecationHandler.INSTANCE, mapping);
+        while (!xcp.isClosed()) {
+            Token token = xcp.currentToken();
+            if (token != null && token != Token.END_OBJECT && token != Token.START_OBJECT) {
+                if (!xcp.currentName().equals(_META)) {
+                    xcp.nextToken();
+                    xcp.skipChildren();
+                } else {
+                    while (xcp.nextToken() != Token.END_OBJECT) {
+                        if (xcp.currentName().equals(SCHEMA_VERSION)) {
+                            // throw new IOException(xcp.currentName() + xcp.currentToken());
+                            return xcp.longValue();
+                        }
+                        else {
+                            xcp.nextToken();
+                        }
+                    }
+                }
+            }
+            xcp.nextToken();
+        }
+        return DEFAULT_SCHEMA_VERSION;
+    }
+
+    public static boolean shouldUpdateIndex(IndexMetadata index, long newVersion) {
+        long oldVersion = DEFAULT_SCHEMA_VERSION;
+        Map<String, Object> indexMapping = index.mapping().sourceAsMap();
+        if (indexMapping != null && indexMapping.containsKey(_META)) {
+            Object meta = indexMapping.get(_META);
+            if (meta instanceof HashMap) {
+                HashMap<?, ?> metaData = (HashMap<?, ?>) meta;
+                if (metaData.containsKey(SCHEMA_VERSION)) {
+                    Object oldVersionObject = metaData.get(SCHEMA_VERSION);
+                    if (oldVersionObject instanceof Long) {
+                        oldVersion = (Long) oldVersionObject;
+                    }
+                    if (oldVersionObject instanceof Integer) {
+                        Integer version = (Integer) oldVersionObject;
+                        oldVersion = version.longValue();
+                    }
+                }
+            }
+        }
+        return newVersion > oldVersion;
+    }
+
+
+    public static void checkAndUpdateLockIndexMapping(String mapping, ClusterService clusterService,
+                                                      IndicesAdminClient client, ActionListener<AcknowledgedResponse> listener) {
+        ClusterState clusterState = clusterService.state();
+        if (clusterState.metadata().indices().containsKey(LockService.LOCK_INDEX_NAME)) {
+            try {
+                long newSchemaVersion = schemaVersion(mapping);
+                IndexMetadata indexMetadata = clusterState.metadata().indices().get(LockService.LOCK_INDEX_NAME);
+                if (shouldUpdateIndex(indexMetadata, newSchemaVersion)) {
+                    PutMappingRequest putMappingRequest = new PutMappingRequest(LockService.LOCK_INDEX_NAME).type(_DOC).source(mapping, XContentType.JSON);
+                    client.putMapping(putMappingRequest, listener);
+                } else {
+                    listener.onResponse(new AcknowledgedResponse(true));
+                }
+            } catch (Exception e) {
+                listener.onResponse(new AcknowledgedResponse(false));
+            }
+        } else {
+            listener.onResponse(new AcknowledgedResponse(false));
+        }
+    }
+
+}

--- a/spi/src/main/resources/org/opensearch/jobscheduler/spi/utils/opensearch_job_scheduler_lock.json
+++ b/spi/src/main/resources/org/opensearch/jobscheduler/spi/utils/opensearch_job_scheduler_lock.json
@@ -1,5 +1,8 @@
 {
   "dynamic": "strict",
+  "_meta": {
+    "schema_version": 2
+  },
   "properties": {
     "job_index_name": {
       "type": "keyword"
@@ -16,6 +19,13 @@
     },
     "released": {
       "type": "boolean"
+    },
+    "resource_type": {
+      "type": "text"
+    },
+    "resource": {
+      "type": "object",
+      "enabled": "false"
     }
   }
 }

--- a/spi/src/test/java/org/opensearch/jobscheduler/spi/utils/LockServiceIT.java
+++ b/spi/src/test/java/org/opensearch/jobscheduler/spi/utils/LockServiceIT.java
@@ -5,6 +5,10 @@
 
 package org.opensearch.jobscheduler.spi.utils;
 
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.collect.ImmutableOpenMap;
+import org.opensearch.common.xcontent.XContentParser;
+import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.jobscheduler.spi.JobDocVersion;
 import org.opensearch.jobscheduler.spi.JobExecutionContext;
 import org.opensearch.jobscheduler.spi.LockModel;
@@ -22,7 +26,9 @@ import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -36,9 +42,9 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
     static final String JOB_ID = "test_job_id";
     static final String JOB_INDEX_NAME = "test_job_index_name";
     static final long LOCK_DURATION_SECONDS = 60;
-    static final ScheduledJobParameter  TEST_SCHEDULED_JOB_PARAM = new ScheduledJobParameter() {
+    static final ScheduledJobParameter TEST_SCHEDULED_JOB_PARAM = new ScheduledJobParameter() {
 
-        @Override public XContentBuilder toXContent(final XContentBuilder builder, final Params params) throws IOException {
+        @Override public XContentBuilder toXContent(final XContentBuilder builder, final Params params) {
             return builder;
         }
 
@@ -77,6 +83,40 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
         Mockito.when(this.clusterService.state().routingTable().hasIndex(".opendistro-job-scheduler-lock"))
                 .thenReturn(false)
                 .thenReturn(true);
+        try {
+            /*
+                This sample index will be what is read in by the indexMetadata.mapping().sourceAsMap() call in
+                SchemaUtils.shouldUpdateIndex. Once this is read -- the shouldUpdate ought to return true.
+                This will cause the check and update to create a put request to update the mapping to the new mapping.
+                If the put request fails, then there is a problem with the way checkAndUpdate is working and that should
+                be investigated.
+
+                All this will run when any of the tests that acquire a lock run because the acquisition of the lock
+                triggers the call the LockService.checkAndUpdateMappings.
+
+             */
+            String indexContent = "{\"testIndex\":{\"settings\":{\"index\":{\"creation_date\":\"1558407515699\"," +
+                    "\"number_of_shards\":\"1\",\"number_of_replicas\":\"1\",\"uuid\":\"t-VBBW6aR6KpJ3XP5iISOA\"," +
+                    "\"version\":{\"created\":\"6040399\"},\"provided_name\":\"data_test\"}},\"mapping_version\":123," +
+                    "\"settings_version\":123,\"mappings\":{\"_doc\":{\"_meta\":{\"schema_version\":1},\"properties\":" +
+                    "{\"name\":{\"type\":\"keyword\"}}}}}}";
+            XContentParser parser = createParser(XContentType.JSON.xContent(), indexContent);
+            IndexMetadata index = IndexMetadata.fromXContent(parser);
+            IndexMetadata indexMetadata = Mockito.mock(IndexMetadata.class, Mockito.RETURNS_DEEP_STUBS);
+            Mockito.when(indexMetadata.mapping().sourceAsMap()).thenReturn(index.mapping().sourceAsMap());
+
+            // create an indexMetdata map with the index Content
+            Map<String, IndexMetadata> indexMetadataHashMap = new HashMap<>();
+            indexMetadataHashMap.put(".opendistro-job-scheduler-lock", indexMetadata);
+            ImmutableOpenMap.Builder<String, IndexMetadata> mapBuilder = new ImmutableOpenMap.Builder<>();
+            mapBuilder.putAll(indexMetadataHashMap);
+            ImmutableOpenMap<String, IndexMetadata> indexMetadataMap = mapBuilder.build();
+            Mockito.when(this.clusterService.state().metadata().indices())
+                    .thenReturn(indexMetadataMap);
+        }
+        catch (IOException e) {
+            fail(e.getMessage());
+        }
     }
 
     public void testSanity() throws Exception {
@@ -84,11 +124,12 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LockService lockService = new LockService(client(), this.clusterService);
         final JobExecutionContext context = new JobExecutionContext(Instant.now(), new JobDocVersion(0, 0, 0),
-            lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
+                lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
         Instant testTime = Instant.now();
         lockService.setTime(testTime);
         lockService.acquireLock(TEST_SCHEDULED_JOB_PARAM, context, ActionListener.wrap(
                 lock -> {
+                    // assertEquals("", lock.toString());
                     assertNotNull("Expected to successfully grab lock.", lock);
                     assertEquals("job_id does not match.", JOB_ID + uniqSuffix, lock.getJobId());
                     assertEquals("job_index_name does not match.", JOB_INDEX_NAME + uniqSuffix, lock.getJobIndexName());
@@ -117,12 +158,92 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
         latch.await(5L, TimeUnit.SECONDS);
     }
 
+    public void testSanityResourceLock() throws Exception {
+        String uniqSuffix = "_sanity";
+        CountDownLatch latch = new CountDownLatch(1);
+        LockService lockService = new LockService(client(), this.clusterService);
+        String jobIndexName = JOB_INDEX_NAME + uniqSuffix;
+        final JobExecutionContext context = new JobExecutionContext(Instant.now(), new JobDocVersion(0, 0, 0),
+                lockService, jobIndexName, JOB_ID + uniqSuffix);
+        Instant testTime = Instant.now();
+        lockService.setTime(testTime);
+        Map<String, Object> resource = new HashMap<>();
+        resource.put("node_name", "node");
+        String expectedLockName = LockModel.generateResourceLockId(jobIndexName, "shrink", resource);
+        lockService.acquireLockOnResource(context, (long) 1000, "shrink", resource, ActionListener.wrap(
+                lock -> {
+                    assertNotNull("Expected to successfully grab lock.", lock);
+                    assertEquals("lock name does not match", expectedLockName, lock.getLockId());
+                    assertEquals("lock_time does not match.", testTime.getEpochSecond(), lock.getLockTime().getEpochSecond());
+                    assertFalse("Lock should not be released.", lock.isReleased());
+                    assertFalse("Lock should not expire.", lock.isExpired());
+                    lockService.release(lock, ActionListener.wrap(
+                            released -> {
+                                assertTrue("Failed to release lock.", released);
+                                lockService.deleteLock(lock.getLockId(), ActionListener.wrap(
+                                        deleted -> {
+                                            assertTrue("Failed to delete lock.", deleted);
+                                            latch.countDown();
+                                        },
+                                        exception -> {
+                                            fail(exception.getMessage());
+                                        }
+                                ));
+                            },
+                            exception -> {
+                                fail(exception.getMessage());
+                            }
+                    ));
+                },
+                exception -> {
+                    fail(exception.getMessage());
+                }
+        ));
+        latch.await(5L, TimeUnit.SECONDS);
+    }
+
+    public void testSecondAcquireResourceLockFail() throws Exception {
+        String uniqSuffix = "_second_acquire";
+        CountDownLatch latch = new CountDownLatch(1);
+        LockService lockService = new LockService(client(), this.clusterService);
+        final JobExecutionContext context = new JobExecutionContext(Instant.now(), new JobDocVersion(0, 0, 0),
+                lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
+        Map<String, Object> resource = new HashMap<>();
+        resource.put("node_name", "node");
+        lockService.acquireLockOnResource(context, (long) 1000, "shrink", resource, ActionListener.wrap(
+                lock -> {
+                    assertNotNull("Expected to successfully grab lock", lock);
+                    lockService.acquireLockOnResource(context, (long) 1000, "shrink", resource, ActionListener.wrap(
+                            lock2 -> {
+                                assertNull("Expected to failed to get lock.", lock2);
+                                lockService.release(lock, ActionListener.wrap(
+                                        released -> {
+                                            assertTrue("Failed to release lock.", released);
+                                            lockService.deleteLock(lock.getLockId(), ActionListener.wrap(
+                                                    deleted -> {
+                                                        assertTrue("Failed to delete lock.", deleted);
+                                                        latch.countDown();
+                                                    },
+                                                    exception -> fail(exception.getMessage())
+                                            ));
+                                        },
+                                        exception -> fail(exception.getMessage())
+                                ));
+                            },
+                            exception -> fail(exception.getMessage())
+                    ));
+                },
+                exception -> fail(exception.getMessage())
+        ));
+        latch.await(10L, TimeUnit.SECONDS);
+    }
+
     public void testSecondAcquireLockFail() throws Exception {
         String uniqSuffix = "_second_acquire";
         CountDownLatch latch = new CountDownLatch(1);
         LockService lockService = new LockService(client(), this.clusterService);
         final JobExecutionContext context = new JobExecutionContext(Instant.now(), new JobDocVersion(0, 0, 0),
-            lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
+                lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
 
         lockService.acquireLock(TEST_SCHEDULED_JOB_PARAM, context, ActionListener.wrap(
                 lock -> {
@@ -157,7 +278,7 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LockService lockService = new LockService(client(), this.clusterService);
         final JobExecutionContext context = new JobExecutionContext(Instant.now(), new JobDocVersion(0, 0, 0),
-            lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
+                lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
 
         lockService.acquireLock(TEST_SCHEDULED_JOB_PARAM, context, ActionListener.wrap(
                 lock -> {
@@ -193,6 +314,48 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
         latch.await(5L, TimeUnit.SECONDS);
     }
 
+    public void testResourceLockReleasedAndAcquired() throws Exception {
+        String uniqSuffix = "_resource_lock_release+acquire";
+        CountDownLatch latch = new CountDownLatch(1);
+        LockService lockService = new LockService(client(), this.clusterService);
+        final JobExecutionContext context = new JobExecutionContext(Instant.now(), new JobDocVersion(0, 0, 0),
+                lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
+        Map<String, Object> resource = new HashMap<>();
+        resource.put("node_name", "node");
+        lockService.acquireLockOnResource(context, (long) 1000, "shrink", resource, ActionListener.wrap(
+                lock -> {
+                    assertNotNull("Expected to successfully grab lock", lock);
+                    lockService.release(lock, ActionListener.wrap(
+                            released -> {
+                                assertTrue("Failed to release lock.", released);
+                                lockService.acquireLockOnResource(context, (long) 1000, "shrink", resource, ActionListener.wrap(
+                                        lock2 -> {
+                                            assertNotNull("Expected to successfully grab lock2", lock2);
+                                            lockService.release(lock2, ActionListener.wrap(
+                                                    released2 -> {
+                                                        assertTrue("Failed to release lock2.", released2);
+                                                        lockService.deleteLock(lock2.getLockId(), ActionListener.wrap(
+                                                                deleted -> {
+                                                                    assertTrue("Failed to delete lock2.", deleted);
+                                                                    latch.countDown();
+                                                                },
+                                                                exception -> fail(exception.getMessage())
+                                                        ));
+                                                    },
+                                                    exception -> fail(exception.getMessage())
+                                            ));
+                                        },
+                                        exception -> fail(exception.getMessage())
+                                ));
+                            },
+                            exception -> fail(exception.getMessage())
+                    ));
+                },
+                exception -> fail(exception.getMessage())
+        ));
+        latch.await(5L, TimeUnit.SECONDS);
+    }
+
     public void testLockExpired() throws Exception {
         String uniqSuffix = "_lock_expire";
         CountDownLatch latch = new CountDownLatch(1);
@@ -200,7 +363,7 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
         // Set lock time in the past.
         lockService.setTime(Instant.now().minus(Duration.ofSeconds(LOCK_DURATION_SECONDS + LOCK_DURATION_SECONDS)));
         final JobExecutionContext context = new JobExecutionContext(Instant.now(), new JobDocVersion(0, 0, 0),
-            lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
+                lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
 
 
         lockService.acquireLock(TEST_SCHEDULED_JOB_PARAM, context, ActionListener.wrap(
@@ -239,7 +402,57 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
         latch.await(5L, TimeUnit.SECONDS);
     }
 
+    public void testResourceLockExpired() throws Exception {
+        String uniqSuffix = "_lock_expire";
+        CountDownLatch latch = new CountDownLatch(1);
+        LockService lockService = new LockService(client(), this.clusterService);
+        // Set lock time in the past.
+        lockService.setTime(Instant.now().minus(Duration.ofSeconds(LOCK_DURATION_SECONDS + LOCK_DURATION_SECONDS)));
+        final JobExecutionContext context = new JobExecutionContext(Instant.now(), new JobDocVersion(0, 0, 0),
+                lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
+
+        Map<String, Object> resource = new HashMap<>();
+        resource.put("node_name", "node");
+
+        lockService.acquireLockOnResource(context, LOCK_DURATION_SECONDS, "shrink", resource, ActionListener.wrap(
+                lock -> {
+                    assertNotNull("Expected to successfully grab lock", lock);
+                    // Set lock back to current time to make the lock expire.
+                    lockService.setTime(null);
+                    lockService.acquireLockOnResource(context, LOCK_DURATION_SECONDS, "shrink", resource, ActionListener.wrap(
+                            lock2 -> {
+                                assertNotNull("Expected to successfully grab lock", lock2);
+                                lockService.release(lock, ActionListener.wrap(
+                                        released -> {
+                                            assertFalse("Expected to fail releasing lock.", released);
+                                            lockService.release(lock2, ActionListener.wrap(
+                                                    released2 -> {
+                                                        assertTrue("Expecting to successfully release lock.", released2);
+                                                        lockService.deleteLock(lock.getLockId(), ActionListener.wrap(
+                                                                deleted -> {
+                                                                    assertTrue("Failed to delete lock.", deleted);
+                                                                    latch.countDown();
+                                                                },
+                                                                exception -> fail(exception.getMessage())
+                                                        ));
+                                                    },
+                                                    exception -> fail(exception.getMessage())
+                                            ));
+                                        },
+                                        exception -> fail(exception.getMessage())
+                                ));
+                            },
+                            exception -> fail(exception.getMessage())
+                    ));
+                },
+                exception -> fail(exception.getMessage())
+        ));
+        latch.await(5L, TimeUnit.SECONDS);
+    }
+
     public void testDeleteLockWithOutIndexCreation() throws Exception {
+        ImmutableOpenMap<String, IndexMetadata> emptyMap = new ImmutableOpenMap.Builder<String, IndexMetadata>().build();
+        Mockito.when(this.clusterService.state().metadata().indices()).thenReturn(emptyMap);
         CountDownLatch latch = new CountDownLatch(1);
         LockService lockService = new LockService(client(), this.clusterService);
         lockService.deleteLock("NonExistingLockId", ActionListener.wrap(
@@ -283,7 +496,7 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         final LockService lockService = new LockService(client(), this.clusterService);
         final JobExecutionContext context = new JobExecutionContext(Instant.now(), new JobDocVersion(0, 0, 0),
-            lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
+                lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
 
 
         lockService.createLockIndex(ActionListener.wrap(
@@ -358,7 +571,7 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         final LockService lockService = new LockService(client(), this.clusterService);
         final JobExecutionContext context = new JobExecutionContext(Instant.now(), new JobDocVersion(0, 0, 0),
-            lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
+                lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
 
         lockService.createLockIndex(ActionListener.wrap(
                 created -> {

--- a/spi/src/test/java/org/opensearch/jobscheduler/spi/utils/LockServiceIT.java
+++ b/spi/src/test/java/org/opensearch/jobscheduler/spi/utils/LockServiceIT.java
@@ -84,17 +84,8 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
                 .thenReturn(false)
                 .thenReturn(true);
         try {
-            /*
-                This sample index will be what is read in by the indexMetadata.mapping().sourceAsMap() call in
-                SchemaUtils.shouldUpdateIndex. Once this is read -- the shouldUpdate ought to return true.
-                This will cause the check and update to create a put request to update the mapping to the new mapping.
-                If the put request fails, then there is a problem with the way checkAndUpdate is working and that should
-                be investigated.
-
-                All this will run when any of the tests that acquire a lock run because the acquisition of the lock
-                triggers the call the LockService.checkAndUpdateMappings.
-
-             */
+            // This sample index will read in by the indexMetadata.mapping().sourceAsMap(), and cause SchemaUtils.shouldUpdateIndex
+            // to be true, leading to a put request to update the mapping to the new lock mapping as a part of every test.
             String indexContent = "{\"testIndex\":{\"settings\":{\"index\":{\"creation_date\":\"1558407515699\"," +
                     "\"number_of_shards\":\"1\",\"number_of_replicas\":\"1\",\"uuid\":\"t-VBBW6aR6KpJ3XP5iISOA\"," +
                     "\"version\":{\"created\":\"6040399\"},\"provided_name\":\"data_test\"}},\"mapping_version\":123," +
@@ -107,7 +98,7 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
 
             // create an indexMetdata map with the index Content
             Map<String, IndexMetadata> indexMetadataHashMap = new HashMap<>();
-            indexMetadataHashMap.put(".opendistro-job-scheduler-lock", indexMetadata);
+            indexMetadataHashMap.put(LockService.LOCK_INDEX_NAME, indexMetadata);
             ImmutableOpenMap.Builder<String, IndexMetadata> mapBuilder = new ImmutableOpenMap.Builder<>();
             mapBuilder.putAll(indexMetadataHashMap);
             ImmutableOpenMap<String, IndexMetadata> indexMetadataMap = mapBuilder.build();
@@ -124,12 +115,11 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LockService lockService = new LockService(client(), this.clusterService);
         final JobExecutionContext context = new JobExecutionContext(Instant.now(), new JobDocVersion(0, 0, 0),
-                lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
+            lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
         Instant testTime = Instant.now();
         lockService.setTime(testTime);
         lockService.acquireLock(TEST_SCHEDULED_JOB_PARAM, context, ActionListener.wrap(
                 lock -> {
-                    // assertEquals("", lock.toString());
                     assertNotNull("Expected to successfully grab lock.", lock);
                     assertEquals("job_id does not match.", JOB_ID + uniqSuffix, lock.getJobId());
                     assertEquals("job_index_name does not match.", JOB_INDEX_NAME + uniqSuffix, lock.getJobIndexName());
@@ -185,19 +175,13 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
                                             assertTrue("Failed to delete lock.", deleted);
                                             latch.countDown();
                                         },
-                                        exception -> {
-                                            fail(exception.getMessage());
-                                        }
+                                        exception -> fail(exception.getMessage())
                                 ));
                             },
-                            exception -> {
-                                fail(exception.getMessage());
-                            }
+                            exception -> fail(exception.getMessage())
                     ));
                 },
-                exception -> {
-                    fail(exception.getMessage());
-                }
+                exception -> fail(exception.getMessage())
         ));
         latch.await(5L, TimeUnit.SECONDS);
     }
@@ -243,7 +227,7 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LockService lockService = new LockService(client(), this.clusterService);
         final JobExecutionContext context = new JobExecutionContext(Instant.now(), new JobDocVersion(0, 0, 0),
-                lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
+            lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
 
         lockService.acquireLock(TEST_SCHEDULED_JOB_PARAM, context, ActionListener.wrap(
                 lock -> {
@@ -278,7 +262,7 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LockService lockService = new LockService(client(), this.clusterService);
         final JobExecutionContext context = new JobExecutionContext(Instant.now(), new JobDocVersion(0, 0, 0),
-                lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
+            lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
 
         lockService.acquireLock(TEST_SCHEDULED_JOB_PARAM, context, ActionListener.wrap(
                 lock -> {
@@ -363,7 +347,7 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
         // Set lock time in the past.
         lockService.setTime(Instant.now().minus(Duration.ofSeconds(LOCK_DURATION_SECONDS + LOCK_DURATION_SECONDS)));
         final JobExecutionContext context = new JobExecutionContext(Instant.now(), new JobDocVersion(0, 0, 0),
-                lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
+            lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
 
 
         lockService.acquireLock(TEST_SCHEDULED_JOB_PARAM, context, ActionListener.wrap(
@@ -496,7 +480,7 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         final LockService lockService = new LockService(client(), this.clusterService);
         final JobExecutionContext context = new JobExecutionContext(Instant.now(), new JobDocVersion(0, 0, 0),
-                lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
+            lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
 
 
         lockService.createLockIndex(ActionListener.wrap(
@@ -571,7 +555,7 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         final LockService lockService = new LockService(client(), this.clusterService);
         final JobExecutionContext context = new JobExecutionContext(Instant.now(), new JobDocVersion(0, 0, 0),
-                lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
+            lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
 
         lockService.createLockIndex(ActionListener.wrap(
                 created -> {

--- a/spi/src/test/java/org/opensearch/jobscheduler/spi/utils/SchemaUtilsTests.java
+++ b/spi/src/test/java/org/opensearch/jobscheduler/spi/utils/SchemaUtilsTests.java
@@ -9,6 +9,7 @@ import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.test.OpenSearchTestCase;
+
 import java.io.IOException;
 
 public class SchemaUtilsTests extends OpenSearchTestCase {

--- a/spi/src/test/java/org/opensearch/jobscheduler/spi/utils/SchemaUtilsTests.java
+++ b/spi/src/test/java/org/opensearch/jobscheduler/spi/utils/SchemaUtilsTests.java
@@ -1,0 +1,107 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.jobscheduler.spi.utils;
+
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.xcontent.XContentParser;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.test.OpenSearchTestCase;
+import java.io.IOException;
+
+
+public class SchemaUtilsTests extends OpenSearchTestCase {
+
+    public void testGetSchemaVersion() {
+        String message = "{\"user\":{ \"name\":\"test\"},\"_meta\":{\"schema_version\": 2}}";
+        try {
+            long schemaVersion = SchemaUtils.schemaVersion(message);
+            // This must be updated every time the opensearch_job_scheduler_lock.json is changed.
+            long currentSchemaVersion = 2L;
+            assertEquals(currentSchemaVersion, schemaVersion);
+        }
+        catch (IOException exception) {
+            fail(exception.getMessage());
+        }
+    }
+
+    public void testGetSchemaWithoutSchemaVersion() {
+        String message = "{\"user\":{ \"name\":\"test\"},\"_meta\":{\"test\": 1}}";
+        try {
+            long schemaVersion = SchemaUtils.schemaVersion(message);
+            assertEquals(1L, schemaVersion);
+        }
+        catch (IOException exception) {
+            fail(exception.getMessage());
+        }
+    }
+
+    public void testGetSchemaWithWrongSchemaVersion() {
+        String message = "{\"user\":{ \"name\":\"test\"},\"_meta\":{\"schema_version\": \"wrong\"}}";
+        try {
+            // just attempt getting the schema version
+            SchemaUtils.schemaVersion(message);
+        }
+        catch (Exception exception) {
+            assertTrue(exception instanceof IllegalArgumentException);
+        }
+    }
+
+    public void testShouldUpdateIndexWithoutOriginalVersion() {
+        String indexContent = "{\"testIndex\":{\"settings\":{\"index\":{\"creation_date\":\"1558407515699\"," +
+                "\"number_of_shards\":\"1\",\"number_of_replicas\":\"1\",\"uuid\":\"t-VBBW6aR6KpJ3XP5iISOA\"," +
+                "\"version\":{\"created\":\"6040399\"},\"provided_name\":\"data_test\"}},\"mapping_version\":123," +
+                "\"settings_version\":123,\"mappings\":{\"_doc\":{\"properties\":{\"name\":{\"type\":\"keyword\"}}}}}}";
+        try {
+            // just attempt getting the schema version
+            XContentParser parser = createParser(XContentType.JSON.xContent(), indexContent);
+            IndexMetadata index = IndexMetadata.fromXContent(parser);
+            assertTrue(SchemaUtils.shouldUpdateIndex(index, 10));
+        }
+        catch (Exception exception) {
+            fail(exception.getMessage());
+        }
+    }
+
+    public void testShouldUpdateIndexWithLaggedVersion() {
+        String indexContent = "{\"testIndex\":{\"settings\":{\"index\":{\"creation_date\":\"1558407515699\"," +
+                "\"number_of_shards\":\"1\",\"number_of_replicas\":\"1\",\"uuid\":\"t-VBBW6aR6KpJ3XP5iISOA\"," +
+                "\"version\":{\"created\":\"6040399\"},\"provided_name\":\"data_test\"}},\"mapping_version\":123," +
+                "\"settings_version\":123,\"mappings\":{\"_doc\":{\"_meta\":{\"schema_version\":1},\"properties\":" +
+                "{\"name\":{\"type\":\"keyword\"}}}}}}";
+        try {
+            // just attempt getting the schema version
+            XContentParser parser = createParser(XContentType.JSON.xContent(), indexContent);
+            IndexMetadata index = IndexMetadata.fromXContent(parser);
+            assertTrue(SchemaUtils.shouldUpdateIndex(index, 10));
+        }
+        catch (Exception exception) {
+            fail(exception.getMessage());
+        }
+    }
+
+    public void testShouldUpdateIndexWithSameVersion() {
+        String indexContent = "{\"testIndex\":{\"settings\":{\"index\":{\"creation_date\":\"1558407515699\"," +
+                "\"number_of_shards\":\"1\",\"number_of_replicas\":\"1\",\"uuid\":\"t-VBBW6aR6KpJ3XP5iISOA\"," +
+                "\"version\":{\"created\":\"6040399\"},\"provided_name\":\"data_test\"}},\"mapping_version\":123," +
+                "\"settings_version\":123,\"mappings\":{\"_doc\":{\"_meta\":{\"schema_version\":10},\"properties\":" +
+                "{\"name\":{\"type\":\"keyword\"}}}}}}";
+        try {
+            // just attempt getting the schema version
+            XContentParser parser = createParser(XContentType.JSON.xContent(), indexContent);
+            IndexMetadata index = IndexMetadata.fromXContent(parser);
+            assertFalse(SchemaUtils.shouldUpdateIndex(index, 10));
+        }
+        catch (Exception exception) {
+            fail(exception.getMessage());
+        }
+    }
+}

--- a/spi/src/test/java/org/opensearch/jobscheduler/spi/utils/SchemaUtilsTests.java
+++ b/spi/src/test/java/org/opensearch/jobscheduler/spi/utils/SchemaUtilsTests.java
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 package org.opensearch.jobscheduler.spi.utils;
@@ -17,18 +11,17 @@ import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.test.OpenSearchTestCase;
 import java.io.IOException;
 
-
 public class SchemaUtilsTests extends OpenSearchTestCase {
+
+    // This must be updated every time the opensearch_job_scheduler_lock.json is changed.
+    private static final long currentSchemaVersion = 2L;
 
     public void testGetSchemaVersion() {
         String message = "{\"user\":{ \"name\":\"test\"},\"_meta\":{\"schema_version\": 2}}";
         try {
-            long schemaVersion = SchemaUtils.schemaVersion(message);
-            // This must be updated every time the opensearch_job_scheduler_lock.json is changed.
-            long currentSchemaVersion = 2L;
+            long schemaVersion = SchemaUtils.getSchemaVersion(message);
             assertEquals(currentSchemaVersion, schemaVersion);
-        }
-        catch (IOException exception) {
+        } catch (IOException exception) {
             fail(exception.getMessage());
         }
     }
@@ -36,10 +29,9 @@ public class SchemaUtilsTests extends OpenSearchTestCase {
     public void testGetSchemaWithoutSchemaVersion() {
         String message = "{\"user\":{ \"name\":\"test\"},\"_meta\":{\"test\": 1}}";
         try {
-            long schemaVersion = SchemaUtils.schemaVersion(message);
+            long schemaVersion = SchemaUtils.getSchemaVersion(message);
             assertEquals(1L, schemaVersion);
-        }
-        catch (IOException exception) {
+        } catch (IOException exception) {
             fail(exception.getMessage());
         }
     }
@@ -47,10 +39,8 @@ public class SchemaUtilsTests extends OpenSearchTestCase {
     public void testGetSchemaWithWrongSchemaVersion() {
         String message = "{\"user\":{ \"name\":\"test\"},\"_meta\":{\"schema_version\": \"wrong\"}}";
         try {
-            // just attempt getting the schema version
-            SchemaUtils.schemaVersion(message);
-        }
-        catch (Exception exception) {
+            SchemaUtils.getSchemaVersion(message);
+        } catch (Exception exception) {
             assertTrue(exception instanceof IllegalArgumentException);
         }
     }
@@ -61,12 +51,10 @@ public class SchemaUtilsTests extends OpenSearchTestCase {
                 "\"version\":{\"created\":\"6040399\"},\"provided_name\":\"data_test\"}},\"mapping_version\":123," +
                 "\"settings_version\":123,\"mappings\":{\"_doc\":{\"properties\":{\"name\":{\"type\":\"keyword\"}}}}}}";
         try {
-            // just attempt getting the schema version
             XContentParser parser = createParser(XContentType.JSON.xContent(), indexContent);
             IndexMetadata index = IndexMetadata.fromXContent(parser);
             assertTrue(SchemaUtils.shouldUpdateIndex(index, 10));
-        }
-        catch (Exception exception) {
+        } catch (Exception exception) {
             fail(exception.getMessage());
         }
     }
@@ -78,29 +66,25 @@ public class SchemaUtilsTests extends OpenSearchTestCase {
                 "\"settings_version\":123,\"mappings\":{\"_doc\":{\"_meta\":{\"schema_version\":1},\"properties\":" +
                 "{\"name\":{\"type\":\"keyword\"}}}}}}";
         try {
-            // just attempt getting the schema version
             XContentParser parser = createParser(XContentType.JSON.xContent(), indexContent);
             IndexMetadata index = IndexMetadata.fromXContent(parser);
             assertTrue(SchemaUtils.shouldUpdateIndex(index, 10));
-        }
-        catch (Exception exception) {
+        } catch (Exception exception) {
             fail(exception.getMessage());
         }
     }
 
-    public void testShouldUpdateIndexWithSameVersion() {
+    public void testShouldNotUpdateIndexWithSameVersion() {
         String indexContent = "{\"testIndex\":{\"settings\":{\"index\":{\"creation_date\":\"1558407515699\"," +
                 "\"number_of_shards\":\"1\",\"number_of_replicas\":\"1\",\"uuid\":\"t-VBBW6aR6KpJ3XP5iISOA\"," +
                 "\"version\":{\"created\":\"6040399\"},\"provided_name\":\"data_test\"}},\"mapping_version\":123," +
                 "\"settings_version\":123,\"mappings\":{\"_doc\":{\"_meta\":{\"schema_version\":10},\"properties\":" +
                 "{\"name\":{\"type\":\"keyword\"}}}}}}";
         try {
-            // just attempt getting the schema version
             XContentParser parser = createParser(XContentType.JSON.xContent(), indexContent);
             IndexMetadata index = IndexMetadata.fromXContent(parser);
             assertFalse(SchemaUtils.shouldUpdateIndex(index, 10));
-        }
-        catch (Exception exception) {
+        } catch (Exception exception) {
             fail(exception.getMessage());
         }
     }

--- a/src/test/java/org/opensearch/jobscheduler/sweeper/JobSweeperTests.java
+++ b/src/test/java/org/opensearch/jobscheduler/sweeper/JobSweeperTests.java
@@ -5,6 +5,12 @@
 
 package org.opensearch.jobscheduler.sweeper;
 
+import org.opensearch.client.AdminClient;
+import org.opensearch.client.IndicesAdminClient;
+import org.opensearch.cluster.metadata.MappingMetadata;
+import org.opensearch.common.collect.ImmutableOpenMap;
+import org.opensearch.common.xcontent.XContentParser;
+import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.jobscheduler.JobSchedulerSettings;
 import org.opensearch.jobscheduler.ScheduledJobProvider;
 import org.opensearch.jobscheduler.scheduler.JobScheduler;
@@ -79,7 +85,7 @@ public class JobSweeperTests extends OpenSearchAllocationTestCase {
     private Double jitterLimit = 0.95;
 
     @Before
-    public void setup() throws IOException {
+    public void setup() {
         this.client = Mockito.mock(Client.class);
         this.threadPool = Mockito.mock(ThreadPool.class);
         this.scheduler = Mockito.mock(JobScheduler.class);
@@ -210,7 +216,45 @@ public class JobSweeperTests extends OpenSearchAllocationTestCase {
         Engine.DeleteResult deleteResult = new Engine.DeleteResult(1L, 1L, 1L, true);
 
         Set<String> jobIdSet = new HashSet<>();
+        String indexContent;
         jobIdSet.add("doc-id");
+        AdminClient mockAdminClient = Mockito.mock(AdminClient.class);
+        Mockito.when(this.client.admin()).thenReturn(mockAdminClient);
+        IndicesAdminClient indicesAdminClient = Mockito.mock(IndicesAdminClient.class);
+        Mockito.when(mockAdminClient.indices()).thenReturn(indicesAdminClient);
+        try {
+            indexContent = "{\"testIndex\":{\"settings\":{\"index\":{\"creation_date\":\"1558407515699\"," +
+                    "\"number_of_shards\":\"1\",\"number_of_replicas\":\"1\",\"uuid\":\"t-VBBW6aR6KpJ3XP5iISOA\"," +
+                    "\"version\":{\"created\":\"6040399\"},\"provided_name\":\"data_test\"}},\"mapping_version\":123," +
+                    "\"settings_version\":123,\"mappings\":{\"_doc\":{\"_meta\":{\"schema_version\":1},\"properties\":" +
+                    "{\"name\":{\"type\":\"keyword\"}}}}}}";
+            XContentParser parser = createParser(XContentType.JSON.xContent(), indexContent);
+            IndexMetadata realIndex = IndexMetadata.fromXContent(parser);
+            IndexMetadata indexMetadata = Mockito.mock(IndexMetadata.class);
+
+            MappingMetadata mappingMetadata = Mockito.mock(MappingMetadata.class);
+            Mockito.when(indexMetadata.mapping()).thenReturn(mappingMetadata);
+
+            Mockito.when(mappingMetadata.sourceAsMap()).thenReturn(realIndex.mapping().sourceAsMap());
+
+            Map<String, IndexMetadata> indexMetadataHashMap = new HashMap<>();
+            indexMetadataHashMap.put(".opendistro-job-scheduler-lock", indexMetadata);
+
+            ImmutableOpenMap.Builder<String, IndexMetadata> mapBuilder = new ImmutableOpenMap.Builder<>();
+            mapBuilder.putAll(indexMetadataHashMap);
+
+            ImmutableOpenMap<String, IndexMetadata> indexMetadataMap = mapBuilder.build();
+            ClusterState state = Mockito.mock(ClusterState.class);
+            Metadata metadata = Mockito.mock(Metadata.class);
+            Mockito.when(clusterService.state()).thenReturn(state);
+            Mockito.when(state.metadata()).thenReturn(metadata);
+            Mockito.when(metadata.indices())
+                    .thenReturn(indexMetadataMap);
+        }
+        catch (IOException e) {
+            fail(e.getMessage());
+        }
+
         Mockito.when(this.scheduler.getScheduledJobIds("index-name")).thenReturn(jobIdSet);
 
         ActionFuture<DeleteResponse> actionFuture = Mockito.mock(ActionFuture.class);
@@ -280,8 +324,8 @@ public class JobSweeperTests extends OpenSearchAllocationTestCase {
         BytesReference source = this.getTestJsonSource();
 
         Term uid = new Term(
-            "id_field",
-            new BytesRef(docId.getBytes(Charset.defaultCharset()), 0, docId.getBytes(Charset.defaultCharset()).length)
+                "id_field",
+                new BytesRef(docId.getBytes(Charset.defaultCharset()), 0, docId.getBytes(Charset.defaultCharset()).length)
         );
         ParsedDocument parsedDocument = new ParsedDocument(null, null, docId, null, docs, source, null, null);
 


### PR DESCRIPTION
### Current Locking system

The current locking system in the job-scheduler only allows for locking based on job_index_name and job_id. This extends the existing job scheduler LockService and LockModel to to be able to acquire locks on any arbitrary resource.

### Why extend the current locking service?

The motivation for the extension of the LockingService is for the [Index State Management Shrink Action.](https://github.com/opensearch-project/index-management/issues/40) The shrink action needs to place a lock on a specific node with enough space for the shrinking index so that no other Shrink job can simultaneously allocate shards to the same node. The previous job locking service is insufficient for this use case because it solely locks based on job_index_name and job_id, with the purpose of enabling users to keep separate scheduled runs of the same job from overlapping on a resource. This extension would allow for locking of specific resources across jobs per jobIndexName. 

For the Index Management use case, this locking system could be implemented in other ways, for example using the Cluster State. However, using the job scheduler lock index scales much better, and allows more services to use the index for more generic locks.

### Changes to LockModel

To allow for locking of arbitrary resources that extend across job_ids, this change adds an additional type of LockModel. This new lock type may be used through the resourceType and resource parameters added to the LockModel constructor. Using these parameters, the lock will be identified through a combination of the jobIndexName, the resourceType, and a hash of a map which should represent the resource.

### Issues Resolved
NA
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
