### PR TITLE
Removes usage of mapping types

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ import com.github.jengelman.gradle.plugins.shadow.ShadowPlugin
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "2.0.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "2.0.0-alpha1-SNAPSHOT")
     }
 
     repositories {

--- a/spi/src/main/java/org/opensearch/jobscheduler/spi/utils/LockService.java
+++ b/spi/src/main/java/org/opensearch/jobscheduler/spi/utils/LockService.java
@@ -41,11 +41,6 @@ import java.time.Instant;
 
 public final class LockService {
     private static final Logger logger = LogManager.getLogger(LockService.class);
-    /**
-     * This should go away starting ES 7. We use "_doc" for future compatibility as described here:
-     * https://www.elastic.co/guide/en/elasticsearch/reference/6.x/removal-of-types.html#_schedule_for_removal_of_mapping_types
-     */
-    private static final String MAPPING_TYPE = "_doc";
     private static final String LOCK_INDEX_NAME = ".opendistro-job-scheduler-lock";
 
     private final Client client;
@@ -82,8 +77,7 @@ public final class LockService {
         if (lockIndexExist()) {
             listener.onResponse(true);
         } else {
-            final CreateIndexRequest request = new CreateIndexRequest(LOCK_INDEX_NAME)
-                    .mapping(MAPPING_TYPE, lockMapping(), XContentType.JSON);
+            final CreateIndexRequest request = new CreateIndexRequest(LOCK_INDEX_NAME).mapping(lockMapping());
             client.admin().indices().create(request, ActionListener.wrap(
                response -> listener.onResponse(response.isAcknowledged()),
                exception -> {

--- a/src/test/java/org/opensearch/jobscheduler/sweeper/JobSweeperTests.java
+++ b/src/test/java/org/opensearch/jobscheduler/sweeper/JobSweeperTests.java
@@ -283,7 +283,7 @@ public class JobSweeperTests extends OpenSearchAllocationTestCase {
             "id_field",
             new BytesRef(docId.getBytes(Charset.defaultCharset()), 0, docId.getBytes(Charset.defaultCharset()).length)
         );
-        ParsedDocument parsedDocument = new ParsedDocument(null, null, docId, "_doc", null, docs, source, null, null);
+        ParsedDocument parsedDocument = new ParsedDocument(null, null, docId, null, docs, source, null, null);
 
         return new Engine.Index(uid, primaryTerm, parsedDocument);
     }
@@ -293,7 +293,7 @@ public class JobSweeperTests extends OpenSearchAllocationTestCase {
             "id_field",
             new BytesRef(docId.getBytes(Charset.defaultCharset()), 0, docId.getBytes(Charset.defaultCharset()).length)
         );
-        return new Engine.Delete("_doc", docId, uid, 1L);
+        return new Engine.Delete(docId, uid, 1L);
     }
 
     private BytesReference getTestJsonSource() {


### PR DESCRIPTION
Signed-off-by: Drew Baugher <dbbaughe@amazon.com>

### Description
Points to 2.0.0 alpha1 snapshot.
Removes usages of mapping types in job scheduler.
Running into build failure with reaper class though, tried building with both JDK 11 and 14.
 

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
