### PR TITLE
Enables locking on an arbitrary lockID

### DIFF
--- a/spi/src/main/java/org/opensearch/jobscheduler/spi/LockModel.java
+++ b/spi/src/main/java/org/opensearch/jobscheduler/spi/LockModel.java
@@ -153,6 +153,23 @@ public final class LockModel implements ToXContentObject {
         );
     }
 
+    /*
+     * Parses the LockModel while also taking in the lockID, which will be the document ID of the lock being parsed.
+     */
+    public static LockModel parseWithID(final XContentParser parser, long seqNo, long primaryTerm, String lockId) throws IOException {
+        LockModel lockNoID = parse(parser, seqNo, primaryTerm);
+        return new LockModel(
+                lockNoID.jobIndexName,
+                lockNoID.jobId,
+                requireNonNull(lockId, "LockId cannot be when explicitly provided in the parser"),
+                lockNoID.lockTime,
+                lockNoID.lockDurationSeconds,
+                lockNoID.released,
+                seqNo,
+                primaryTerm
+        );
+    }
+
     @Override public XContentBuilder toXContent(final XContentBuilder builder, final Params params) throws IOException {
         builder.startObject()
             .field(JOB_INDEX_NAME, this.jobIndexName)

--- a/spi/src/main/java/org/opensearch/jobscheduler/spi/LockModel.java
+++ b/spi/src/main/java/org/opensearch/jobscheduler/spi/LockModel.java
@@ -43,7 +43,7 @@ public final class LockModel implements ToXContentObject {
      * @param primaryTerm primary term from OpenSearch document.
      */
     public LockModel(final LockModel copyLock, long seqNo, long primaryTerm) {
-        this(copyLock.jobIndexName, copyLock.jobId, copyLock.lockId, copyLock.lockTime, copyLock.lockDurationSeconds,
+        this(copyLock.jobIndexName, copyLock.jobId, copyLock.lockTime, copyLock.lockDurationSeconds,
             copyLock.released, seqNo, primaryTerm);
     }
 
@@ -54,7 +54,7 @@ public final class LockModel implements ToXContentObject {
      * @param released boolean flag to indicate if the lock is released
      */
     public LockModel(final LockModel copyLock, final boolean released) {
-        this(copyLock.jobIndexName, copyLock.jobId, copyLock.lockId, copyLock.lockTime, copyLock.lockDurationSeconds,
+        this(copyLock.jobIndexName, copyLock.jobId, copyLock.lockTime, copyLock.lockDurationSeconds,
             released, copyLock.seqNo, copyLock.primaryTerm);
     }
 
@@ -68,8 +68,7 @@ public final class LockModel implements ToXContentObject {
      */
     public LockModel(final LockModel copyLock,
                      final Instant updateLockTime, final long lockDurationSeconds, final boolean released) {
-        this(copyLock.jobIndexName, copyLock.jobId, copyLock.lockId, updateLockTime, lockDurationSeconds, released,
-                copyLock.seqNo, copyLock.primaryTerm);
+        this(copyLock.jobIndexName, copyLock.jobId, updateLockTime, lockDurationSeconds, released, copyLock.seqNo, copyLock.primaryTerm);
     }
 
     public LockModel(String jobIndexName, String jobId, Instant lockTime, long lockDurationSeconds, boolean released) {
@@ -77,26 +76,9 @@ public final class LockModel implements ToXContentObject {
             SequenceNumbers.UNASSIGNED_SEQ_NO, SequenceNumbers.UNASSIGNED_PRIMARY_TERM);
     }
 
-    public LockModel(String jobIndexName, String jobId, String lockId, Instant lockTime, long lockDurationSeconds, boolean released) {
-        this(jobIndexName, jobId, lockId, lockTime, lockDurationSeconds, released,
-                SequenceNumbers.UNASSIGNED_SEQ_NO, SequenceNumbers.UNASSIGNED_PRIMARY_TERM);
-    }
-
     public LockModel(String jobIndexName, String jobId, Instant lockTime,
                      long lockDurationSeconds, boolean released, long seqNo, long primaryTerm) {
         this.lockId = jobIndexName + LOCK_ID_DELIMITR + jobId;
-        this.jobIndexName = jobIndexName;
-        this.jobId = jobId;
-        this.lockTime = lockTime;
-        this.lockDurationSeconds = lockDurationSeconds;
-        this.released = released;
-        this.seqNo = seqNo;
-        this.primaryTerm = primaryTerm;
-    }
-
-    public LockModel(String jobIndexName, String jobId, String lockId, Instant lockTime,
-                     long lockDurationSeconds, boolean released, long seqNo, long primaryTerm) {
-        this.lockId = lockId;
         this.jobIndexName = jobIndexName;
         this.jobId = jobId;
         this.lockTime = lockTime;
@@ -150,23 +132,6 @@ public final class LockModel implements ToXContentObject {
             requireNonNull(released, "released cannot be null"),
             seqNo,
             primaryTerm
-        );
-    }
-
-    /*
-     * Parses the LockModel while also taking in the lockID, which will be the document ID of the lock being parsed.
-     */
-    public static LockModel parseWithID(final XContentParser parser, long seqNo, long primaryTerm, String lockId) throws IOException {
-        LockModel lockNoID = parse(parser, seqNo, primaryTerm);
-        return new LockModel(
-                lockNoID.jobIndexName,
-                lockNoID.jobId,
-                requireNonNull(lockId, "LockId cannot be when explicitly provided in the parser"),
-                lockNoID.lockTime,
-                lockNoID.lockDurationSeconds,
-                lockNoID.released,
-                seqNo,
-                primaryTerm
         );
     }
 

--- a/spi/src/main/java/org/opensearch/jobscheduler/spi/LockModel.java
+++ b/spi/src/main/java/org/opensearch/jobscheduler/spi/LockModel.java
@@ -43,7 +43,7 @@ public final class LockModel implements ToXContentObject {
      * @param primaryTerm primary term from OpenSearch document.
      */
     public LockModel(final LockModel copyLock, long seqNo, long primaryTerm) {
-        this(copyLock.jobIndexName, copyLock.jobId, copyLock.lockTime, copyLock.lockDurationSeconds,
+        this(copyLock.jobIndexName, copyLock.jobId, copyLock.lockId, copyLock.lockTime, copyLock.lockDurationSeconds,
             copyLock.released, seqNo, primaryTerm);
     }
 
@@ -54,7 +54,7 @@ public final class LockModel implements ToXContentObject {
      * @param released boolean flag to indicate if the lock is released
      */
     public LockModel(final LockModel copyLock, final boolean released) {
-        this(copyLock.jobIndexName, copyLock.jobId, copyLock.lockTime, copyLock.lockDurationSeconds,
+        this(copyLock.jobIndexName, copyLock.jobId, copyLock.lockId, copyLock.lockTime, copyLock.lockDurationSeconds,
             released, copyLock.seqNo, copyLock.primaryTerm);
     }
 
@@ -68,7 +68,8 @@ public final class LockModel implements ToXContentObject {
      */
     public LockModel(final LockModel copyLock,
                      final Instant updateLockTime, final long lockDurationSeconds, final boolean released) {
-        this(copyLock.jobIndexName, copyLock.jobId, updateLockTime, lockDurationSeconds, released, copyLock.seqNo, copyLock.primaryTerm);
+        this(copyLock.jobIndexName, copyLock.jobId, copyLock.lockId, updateLockTime, lockDurationSeconds, released,
+                copyLock.seqNo, copyLock.primaryTerm);
     }
 
     public LockModel(String jobIndexName, String jobId, Instant lockTime, long lockDurationSeconds, boolean released) {
@@ -76,9 +77,26 @@ public final class LockModel implements ToXContentObject {
             SequenceNumbers.UNASSIGNED_SEQ_NO, SequenceNumbers.UNASSIGNED_PRIMARY_TERM);
     }
 
+    public LockModel(String jobIndexName, String jobId, String lockId, Instant lockTime, long lockDurationSeconds, boolean released) {
+        this(jobIndexName, jobId, lockId, lockTime, lockDurationSeconds, released,
+                SequenceNumbers.UNASSIGNED_SEQ_NO, SequenceNumbers.UNASSIGNED_PRIMARY_TERM);
+    }
+
     public LockModel(String jobIndexName, String jobId, Instant lockTime,
                      long lockDurationSeconds, boolean released, long seqNo, long primaryTerm) {
         this.lockId = jobIndexName + LOCK_ID_DELIMITR + jobId;
+        this.jobIndexName = jobIndexName;
+        this.jobId = jobId;
+        this.lockTime = lockTime;
+        this.lockDurationSeconds = lockDurationSeconds;
+        this.released = released;
+        this.seqNo = seqNo;
+        this.primaryTerm = primaryTerm;
+    }
+
+    public LockModel(String jobIndexName, String jobId, String lockId, Instant lockTime,
+                     long lockDurationSeconds, boolean released, long seqNo, long primaryTerm) {
+        this.lockId = lockId;
         this.jobIndexName = jobIndexName;
         this.jobId = jobId;
         this.lockTime = lockTime;

--- a/spi/src/main/java/org/opensearch/jobscheduler/spi/LockModel.java
+++ b/spi/src/main/java/org/opensearch/jobscheduler/spi/LockModel.java
@@ -80,6 +80,8 @@ public final class LockModel implements ToXContentObject {
                      long lockDurationSeconds, boolean released, long seqNo, long primaryTerm) {
         this.lockId = jobIndexName + LOCK_ID_DELIMITR + jobId;
         this.jobIndexName = jobIndexName;
+        // The jobId parameter does not necessarily need to represent the id of a job scheduler job, as it is being used
+        // to scope the lock, and could represent any resource.
         this.jobId = jobId;
         this.lockTime = lockTime;
         this.lockDurationSeconds = lockDurationSeconds;

--- a/spi/src/main/java/org/opensearch/jobscheduler/spi/utils/LockService.java
+++ b/spi/src/main/java/org/opensearch/jobscheduler/spi/utils/LockService.java
@@ -114,8 +114,8 @@ public final class LockService {
      * Attempts to acquire a lock with a specific lock Id. If the lock does not exist it attempts to create the lock document.
      * If the Lock document exists, it will try to update and acquire the lock.
      *
+     * @param jobParameter a {@code ScheduledJobParameter} containing the lock duration.
      * @param context a {@code JobExecutionContext} containing job index name and job id.
-     * @param lockDurationSeconds the amount of time in seconds that the lock should exist
      * @param lockId the unique Id for the lock. This should represent the resource that the lock is on, whether it be
      *               a job, or some other arbitrary resource.
      * @param listener an {@code ActionListener} that has onResponse and onFailure that is used to return the lock if it was acquired

--- a/spi/src/main/java/org/opensearch/jobscheduler/spi/utils/LockService.java
+++ b/spi/src/main/java/org/opensearch/jobscheduler/spi/utils/LockService.java
@@ -38,7 +38,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
-import java.util.Map;
 
 public final class LockService {
     private static final Logger logger = LogManager.getLogger(LockService.class);
@@ -250,7 +249,7 @@ public final class LockService {
                                     .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE,
                                             response.getSourceAsString());
                             parser.nextToken();
-                            listener.onResponse(LockModel.parse(parser, response.getSeqNo(), response.getPrimaryTerm()));
+                            listener.onResponse(LockModel.parseWithID(parser, response.getSeqNo(), response.getPrimaryTerm(), response.getId()));
                         } catch (IOException e) {
                             logger.error("IOException occurred finding lock", e);
                             listener.onResponse(null);

--- a/spi/src/test/java/org/opensearch/jobscheduler/spi/utils/LockServiceIT.java
+++ b/spi/src/test/java/org/opensearch/jobscheduler/spi/utils/LockServiceIT.java
@@ -117,17 +117,56 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
         latch.await(5L, TimeUnit.SECONDS);
     }
 
+    public void testSanityWithCustomLockID() throws Exception {
+        String lockID = "sanity_test_lock";
+        String uniqSuffix = "_sanity";
+        CountDownLatch latch = new CountDownLatch(1);
+        LockService lockService = new LockService(client(), this.clusterService);
+        final JobExecutionContext context = new JobExecutionContext(Instant.now(), new JobDocVersion(0, 0, 0),
+                lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
+        Instant testTime = Instant.now();
+        lockService.setTime(testTime);
+        lockService.acquireLockWithId(TEST_SCHEDULED_JOB_PARAM, context, lockID, ActionListener.wrap(
+                lock -> {
+                    assertNotNull("Expected to successfully grab lock.", lock);
+                    assertEquals("job_id does not match.", JOB_ID + uniqSuffix, lock.getJobId());
+                    assertEquals("job_index_name does not match.", JOB_INDEX_NAME + uniqSuffix, lock.getJobIndexName());
+                    assertEquals("lock_id does not match.", lockID, lock.getLockId());
+                    assertEquals("lock_duration_seconds does not match.", LOCK_DURATION_SECONDS, lock.getLockDurationSeconds());
+                    assertEquals("lock_time does not match.", testTime.getEpochSecond(), lock.getLockTime().getEpochSecond());
+                    assertFalse("Lock should not be released.", lock.isReleased());
+                    assertFalse("Lock should not expire.", lock.isExpired());
+                    lockService.release(lock, ActionListener.wrap(
+                            released -> {
+                                assertTrue("Failed to release lock.", released);
+                                lockService.deleteLock(lock.getLockId(), ActionListener.wrap(
+                                        deleted -> {
+                                            assertTrue("Failed to delete lock.", deleted);
+                                            latch.countDown();
+                                        },
+                                        exception -> fail(exception.getMessage())
+                                ));
+                            },
+                            exception -> fail(exception.getMessage())
+                    ));
+                },
+                exception -> fail(exception.getMessage())
+        ));
+        latch.await(5L, TimeUnit.SECONDS);
+    }
+
     public void testSecondAcquireLockFail() throws Exception {
         String uniqSuffix = "_second_acquire";
+        String lockID = randomAlphaOfLengthBetween(6, 15);
         CountDownLatch latch = new CountDownLatch(1);
         LockService lockService = new LockService(client(), this.clusterService);
         final JobExecutionContext context = new JobExecutionContext(Instant.now(), new JobDocVersion(0, 0, 0),
             lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
 
-        lockService.acquireLock(TEST_SCHEDULED_JOB_PARAM, context, ActionListener.wrap(
+        lockService.acquireLockWithId(TEST_SCHEDULED_JOB_PARAM, context, lockID, ActionListener.wrap(
                 lock -> {
                     assertNotNull("Expected to successfully grab lock", lock);
-                    lockService.acquireLock(TEST_SCHEDULED_JOB_PARAM, context, ActionListener.wrap(
+                    lockService.acquireLockWithId(TEST_SCHEDULED_JOB_PARAM, context, lockID, ActionListener.wrap(
                             lock2 -> {
                                 assertNull("Expected to failed to get lock.", lock2);
                                 lockService.release(lock, ActionListener.wrap(
@@ -154,18 +193,19 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
 
     public void testLockReleasedAndAcquired() throws Exception {
         String uniqSuffix = "_lock_release+acquire";
+        String lockID = randomAlphaOfLengthBetween(6, 15);
         CountDownLatch latch = new CountDownLatch(1);
         LockService lockService = new LockService(client(), this.clusterService);
         final JobExecutionContext context = new JobExecutionContext(Instant.now(), new JobDocVersion(0, 0, 0),
             lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
 
-        lockService.acquireLock(TEST_SCHEDULED_JOB_PARAM, context, ActionListener.wrap(
+        lockService.acquireLockWithId(TEST_SCHEDULED_JOB_PARAM, context, lockID, ActionListener.wrap(
                 lock -> {
                     assertNotNull("Expected to successfully grab lock", lock);
                     lockService.release(lock, ActionListener.wrap(
                             released -> {
                                 assertTrue("Failed to release lock.", released);
-                                lockService.acquireLock(TEST_SCHEDULED_JOB_PARAM, context, ActionListener.wrap(
+                                lockService.acquireLockWithId(TEST_SCHEDULED_JOB_PARAM, context, lockID, ActionListener.wrap(
                                         lock2 -> {
                                             assertNotNull("Expected to successfully grab lock2", lock2);
                                             lockService.release(lock2, ActionListener.wrap(
@@ -195,6 +235,7 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
 
     public void testLockExpired() throws Exception {
         String uniqSuffix = "_lock_expire";
+        String lockID = randomAlphaOfLengthBetween(6, 15);
         CountDownLatch latch = new CountDownLatch(1);
         LockService lockService = new LockService(client(), this.clusterService);
         // Set lock time in the past.
@@ -203,12 +244,12 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
             lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
 
 
-        lockService.acquireLock(TEST_SCHEDULED_JOB_PARAM, context, ActionListener.wrap(
+        lockService.acquireLockWithId(TEST_SCHEDULED_JOB_PARAM, context, lockID, ActionListener.wrap(
                 lock -> {
                     assertNotNull("Expected to successfully grab lock", lock);
                     // Set lock back to current time to make the lock expire.
                     lockService.setTime(null);
-                    lockService.acquireLock(TEST_SCHEDULED_JOB_PARAM, context, ActionListener.wrap(
+                    lockService.acquireLockWithId(TEST_SCHEDULED_JOB_PARAM, context, lockID, ActionListener.wrap(
                             lock2 -> {
                                 assertNotNull("Expected to successfully grab lock", lock2);
                                 lockService.release(lock, ActionListener.wrap(
@@ -280,11 +321,11 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
     @Ignore
     public void testMultiThreadCreateLock() throws Exception {
         String uniqSuffix = "_multi_thread_create";
+        String lockID = randomAlphaOfLengthBetween(6, 15);
         CountDownLatch latch = new CountDownLatch(1);
         final LockService lockService = new LockService(client(), this.clusterService);
         final JobExecutionContext context = new JobExecutionContext(Instant.now(), new JobDocVersion(0, 0, 0),
             lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
-
 
         lockService.createLockIndex(ActionListener.wrap(
                 created -> {
@@ -293,7 +334,7 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
                         final AtomicReference<LockModel> lockModelAtomicReference = new AtomicReference<>(null);
                         Callable<Boolean> callable = () -> {
                             CountDownLatch callableLatch = new CountDownLatch(1);
-                            lockService.acquireLock(TEST_SCHEDULED_JOB_PARAM, context, ActionListener.wrap(
+                            lockService.acquireLockWithId(TEST_SCHEDULED_JOB_PARAM, context, lockID, ActionListener.wrap(
                                     lock -> {
                                         if (lock != null) {
                                             lockModelAtomicReference.set(lock);
@@ -355,6 +396,7 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
     @Ignore
     public void testMultiThreadAcquireLock() throws Exception {
         String uniqSuffix = "_multi_thread_acquire";
+        String lockID = randomAlphaOfLengthBetween(6, 15);
         CountDownLatch latch = new CountDownLatch(1);
         final LockService lockService = new LockService(client(), this.clusterService);
         final JobExecutionContext context = new JobExecutionContext(Instant.now(), new JobDocVersion(0, 0, 0),
@@ -365,7 +407,7 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
                     if (created) {
                         // Set lock time in the past.
                         lockService.setTime(Instant.now().minus(Duration.ofSeconds(LOCK_DURATION_SECONDS + LOCK_DURATION_SECONDS)));
-                        lockService.acquireLock(TEST_SCHEDULED_JOB_PARAM, context, ActionListener.wrap(
+                        lockService.acquireLockWithId(TEST_SCHEDULED_JOB_PARAM, context, lockID, ActionListener.wrap(
                                 createdLock -> {
                                     assertNotNull(createdLock);
                                     // Set lock back to current time to make the lock expire.
@@ -375,7 +417,7 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
                                     final AtomicReference<LockModel> lockModelAtomicReference = new AtomicReference<>(null);
                                     Callable<Boolean> callable = () -> {
                                         CountDownLatch callableLatch = new CountDownLatch(1);
-                                        lockService.acquireLock(TEST_SCHEDULED_JOB_PARAM, context, ActionListener.wrap(
+                                        lockService.acquireLockWithId(TEST_SCHEDULED_JOB_PARAM, context, lockID, ActionListener.wrap(
                                                 lock -> {
                                                     if (lock != null) {
                                                         lockModelAtomicReference.set(lock);
@@ -430,12 +472,13 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
 
     public void testRenewLock() throws Exception {
         String uniqSuffix = "_lock_renew";
+        String lockID = randomAlphaOfLengthBetween(6, 15);
         CountDownLatch latch = new CountDownLatch(1);
         LockService lockService = new LockService(client(), this.clusterService);
         final JobExecutionContext context = new JobExecutionContext(Instant.now(), new JobDocVersion(0, 0, 0),
                 lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
 
-        lockService.acquireLock(TEST_SCHEDULED_JOB_PARAM, context, ActionListener.wrap(
+        lockService.acquireLockWithId(TEST_SCHEDULED_JOB_PARAM, context, lockID, ActionListener.wrap(
                 lock -> {
                     assertNotNull("Expected to successfully grab lock", lock);
                     // Set the time of LockService (the 'lockTime' of acquired locks) to a fixed time.

--- a/spi/src/test/java/org/opensearch/jobscheduler/spi/utils/LockServiceIT.java
+++ b/spi/src/test/java/org/opensearch/jobscheduler/spi/utils/LockServiceIT.java
@@ -80,7 +80,7 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LockService lockService = new LockService(client(), this.clusterService);
         final JobExecutionContext context = new JobExecutionContext(Instant.now(), new JobDocVersion(0, 0, 0),
-                lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
+            lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
         Instant testTime = Instant.now();
         lockService.setTime(testTime);
         lockService.acquireLock(TEST_SCHEDULED_JOB_PARAM, context, ActionListener.wrap(
@@ -119,7 +119,7 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LockService lockService = new LockService(client(), this.clusterService);
         final JobExecutionContext context = new JobExecutionContext(Instant.now(), new JobDocVersion(0, 0, 0),
-                lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
+            lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
         Instant testTime = Instant.now();
         lockService.setTime(testTime);
         lockService.acquireLockWithId(TEST_SCHEDULED_JOB_PARAM, context, lockID, ActionListener.wrap(
@@ -157,7 +157,7 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LockService lockService = new LockService(client(), this.clusterService);
         final JobExecutionContext context = new JobExecutionContext(Instant.now(), new JobDocVersion(0, 0, 0),
-                lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
+            lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
 
         lockService.acquireLockWithId(TEST_SCHEDULED_JOB_PARAM, context, lockID, ActionListener.wrap(
                 lock -> {
@@ -193,7 +193,7 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LockService lockService = new LockService(client(), this.clusterService);
         final JobExecutionContext context = new JobExecutionContext(Instant.now(), new JobDocVersion(0, 0, 0),
-                lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
+            lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
 
         lockService.acquireLockWithId(TEST_SCHEDULED_JOB_PARAM, context, lockID, ActionListener.wrap(
                 lock -> {
@@ -237,7 +237,7 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
         // Set lock time in the past.
         lockService.setTime(Instant.now().minus(Duration.ofSeconds(LOCK_DURATION_SECONDS + LOCK_DURATION_SECONDS)));
         final JobExecutionContext context = new JobExecutionContext(Instant.now(), new JobDocVersion(0, 0, 0),
-                lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
+            lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
 
         lockService.acquireLockWithId(TEST_SCHEDULED_JOB_PARAM, context, lockID, ActionListener.wrap(
                 lock -> {
@@ -320,7 +320,7 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         final LockService lockService = new LockService(client(), this.clusterService);
         final JobExecutionContext context = new JobExecutionContext(Instant.now(), new JobDocVersion(0, 0, 0),
-                lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
+            lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
 
         lockService.createLockIndex(ActionListener.wrap(
                 created -> {
@@ -395,7 +395,7 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         final LockService lockService = new LockService(client(), this.clusterService);
         final JobExecutionContext context = new JobExecutionContext(Instant.now(), new JobDocVersion(0, 0, 0),
-                lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
+            lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
 
         lockService.createLockIndex(ActionListener.wrap(
                 created -> {

--- a/spi/src/test/java/org/opensearch/jobscheduler/spi/utils/LockServiceIT.java
+++ b/spi/src/test/java/org/opensearch/jobscheduler/spi/utils/LockServiceIT.java
@@ -23,7 +23,11 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 

--- a/spi/src/test/java/org/opensearch/jobscheduler/spi/utils/LockServiceIT.java
+++ b/spi/src/test/java/org/opensearch/jobscheduler/spi/utils/LockServiceIT.java
@@ -5,29 +5,25 @@
 
 package org.opensearch.jobscheduler.spi.utils;
 
+import org.junit.Before;
+import org.junit.Ignore;
+import org.mockito.Mockito;
+import org.opensearch.action.ActionListener;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.jobscheduler.spi.JobDocVersion;
 import org.opensearch.jobscheduler.spi.JobExecutionContext;
 import org.opensearch.jobscheduler.spi.LockModel;
 import org.opensearch.jobscheduler.spi.ScheduledJobParameter;
 import org.opensearch.jobscheduler.spi.schedule.Schedule;
-import org.opensearch.action.ActionListener;
-import org.opensearch.cluster.service.ClusterService;
-import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -84,7 +80,7 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LockService lockService = new LockService(client(), this.clusterService);
         final JobExecutionContext context = new JobExecutionContext(Instant.now(), new JobDocVersion(0, 0, 0),
-            lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
+                lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
         Instant testTime = Instant.now();
         lockService.setTime(testTime);
         lockService.acquireLock(TEST_SCHEDULED_JOB_PARAM, context, ActionListener.wrap(
@@ -161,7 +157,7 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LockService lockService = new LockService(client(), this.clusterService);
         final JobExecutionContext context = new JobExecutionContext(Instant.now(), new JobDocVersion(0, 0, 0),
-            lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
+                lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
 
         lockService.acquireLockWithId(TEST_SCHEDULED_JOB_PARAM, context, lockID, ActionListener.wrap(
                 lock -> {
@@ -197,7 +193,7 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LockService lockService = new LockService(client(), this.clusterService);
         final JobExecutionContext context = new JobExecutionContext(Instant.now(), new JobDocVersion(0, 0, 0),
-            lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
+                lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
 
         lockService.acquireLockWithId(TEST_SCHEDULED_JOB_PARAM, context, lockID, ActionListener.wrap(
                 lock -> {
@@ -241,8 +237,7 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
         // Set lock time in the past.
         lockService.setTime(Instant.now().minus(Duration.ofSeconds(LOCK_DURATION_SECONDS + LOCK_DURATION_SECONDS)));
         final JobExecutionContext context = new JobExecutionContext(Instant.now(), new JobDocVersion(0, 0, 0),
-            lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
-
+                lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
 
         lockService.acquireLockWithId(TEST_SCHEDULED_JOB_PARAM, context, lockID, ActionListener.wrap(
                 lock -> {
@@ -325,7 +320,7 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         final LockService lockService = new LockService(client(), this.clusterService);
         final JobExecutionContext context = new JobExecutionContext(Instant.now(), new JobDocVersion(0, 0, 0),
-            lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
+                lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
 
         lockService.createLockIndex(ActionListener.wrap(
                 created -> {
@@ -400,7 +395,7 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         final LockService lockService = new LockService(client(), this.clusterService);
         final JobExecutionContext context = new JobExecutionContext(Instant.now(), new JobDocVersion(0, 0, 0),
-            lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
+                lockService, JOB_INDEX_NAME + uniqSuffix, JOB_ID + uniqSuffix);
 
         lockService.createLockIndex(ActionListener.wrap(
                 created -> {


### PR DESCRIPTION
Signed-off-by: Clay Downs <downsrob@amazon.com>

### Description
This change allows for locking an arbitrary resource across jobs by repurposing the LockModel job_id to be any user provided lock ID String. The locks are still scoped to the specific job index provided.

Previously, locks could only be acquired by supplying the ScheduledJobParameter and JobExecutionContext. The job index name, job ID, and lock duration would then be extracted from those objects. This change adds a method to acquire a lock with any provided lock ID, and allows for explicitly providing the job index name and lock duration, so the ScheduledJobParameter and JobExecutionContext are no longer required.

### Issues Resolved
https://github.com/opensearch-project/job-scheduler/issues/166
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
