### PR TITLE
Dropping support for jdk 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java:
-          - 11
-          - 14
-          - 17
+        java: [11, 17]
 
     name: Build and Test
     runs-on: ubuntu-latest

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [14]
+        java: [11]
     # Job name
     name: Build Job-scheduler with JDK ${{ matrix.java }}
     # This job runs on Linux


### PR DESCRIPTION
Signed-off-by: Ravi Thaluru <thalurur@users.noreply.github.com>

### Description
* Dropping support for JDK 14
 
### Issues Resolved
https://github.com/opensearch-project/job-scheduler/issues/158
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
