### PR TITLE
Removes rc1 version qualifier

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,9 +6,9 @@ import com.github.jengelman.gradle.plugins.shadow.ShadowPlugin
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "2.0.0-rc1-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "2.0.0-SNAPSHOT")
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
-        buildVersionQualifier = System.getProperty("build.version_qualifier", "rc1")
+        buildVersionQualifier = System.getProperty("build.version_qualifier", "")
     }
 
     repositories {


### PR DESCRIPTION
Signed-off-by: Clay Downs <downsrob@amazon.com>

### Description
Removes rc1 version qualifier
 
### Issues Resolved
https://github.com/opensearch-project/job-scheduler/issues/176
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
