### PR TITLE
[Backport main] 2.3.0 Release notes

### DIFF
--- a/release-notes/opensearch.job-scheduler.release-notes-2.3.0.0.md
+++ b/release-notes/opensearch.job-scheduler.release-notes-2.3.0.0.md
@@ -1,0 +1,9 @@
+## Version 2.3.0.0 2022-09-08
+
+Compatible with OpenSearch 2.3.0
+
+### Maintenance
+* Removed version.yml ([#233](https://github.com/opensearch-project/job-scheduler/pull/233)) ([#235](https://github.com/opensearch-project/job-scheduler/pull/235))
+* Update to Gradle 7.5 ([#208](https://github.com/opensearch-project/job-scheduler/pull/208)) ([#228](https://github.com/opensearch-project/job-scheduler/pull/228))
+* Staging for version increment automation ([#204](https://github.com/opensearch-project/job-scheduler/pull/204)) ([#212](https://github.com/opensearch-project/job-scheduler/pull/212))
+


### PR DESCRIPTION
Manual backport of https://github.com/opensearch-project/job-scheduler/pull/237 to `main`