### PR TITLE
Update to 3.0.0, run backwards compatibility with OpenSearch 2.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ build
 bin/
 .classpath
 .vscode
+sample-extension-plugin/src/test/resources/

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ import org.opensearch.gradle.test.RestIntegTestTask
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "2.3.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "3.0.0-SNAPSHOT")
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
     }

--- a/sample-extension-plugin/build.gradle
+++ b/sample-extension-plugin/build.gradle
@@ -128,11 +128,11 @@ testClusters.integTest {
 }
 
 String baseName = "jobSchedulerBwcCluster"
-String bwcOpenSearchVersion = "2.1.0"
+String bwcOpenSearchVersion = "2.4.0"
 String bwcPluginVersion = bwcOpenSearchVersion + ".0"
 String bwcFilePath = "src/test/resources/bwc/job-scheduler/"
 String bwcFileName = "opensearch-job-scheduler-" + bwcPluginVersion + ".zip"
-String bwcDownloadUrl = "https://repo1.maven.org/maven2/org/opensearch/plugin/opensearch-job-scheduler/" + bwcPluginVersion + "/" + bwcFileName
+String bwcDownloadUrl = "https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/" + bwcOpenSearchVersion + "/latest/linux/x64/tar/builds/opensearch/plugins/" + bwcFileName
 
 2.times {i ->
     testClusters {

--- a/sample-extension-plugin/build.gradle
+++ b/sample-extension-plugin/build.gradle
@@ -127,19 +127,18 @@ testClusters.integTest {
     setting 'path.repo', repo.absolutePath
 }
 
-String bwcJobSchedulerVersion = "1.13.0.0"
 String baseName = "jobSchedulerBwcCluster"
+String bwcOpenSearchVersion = "2.1.0"
+String bwcPluginVersion = bwcOpenSearchVersion + ".0"
 String bwcFilePath = "src/test/resources/bwc/job-scheduler/"
-
-String bwc_js_download_url = "https://github.com/opendistro-for-elasticsearch/job-scheduler/releases/download/v" +
-        bwcJobSchedulerVersion + "/job-scheduler-artifacts.zip"
-String bwcJobSchedulerPlugin = "job-scheduler-artifacts.zip"
+String bwcFileName = "opensearch-job-scheduler-" + bwcPluginVersion + ".zip"
+String bwcDownloadUrl = "https://repo1.maven.org/maven2/org/opensearch/plugin/opensearch-job-scheduler/" + bwcPluginVersion + "/" + bwcFileName
 
 2.times {i ->
     testClusters {
         "${baseName}$i" {
             testDistribution = "ARCHIVE"
-            versions = ["7.10.2",opensearch_version]
+            versions = [bwcOpenSearchVersion, opensearch_version]
             numberOfNodes = 3
             plugin(provider(new Callable<RegularFile>(){
                 @Override
@@ -147,16 +146,15 @@ String bwcJobSchedulerPlugin = "job-scheduler-artifacts.zip"
                     return new RegularFile() {
                         @Override
                         File getAsFile() {
-                            File dir = new File(rootDir.path + "/sample-extension-plugin/" + bwcFilePath + bwcJobSchedulerVersion)
-
+                            File dir = new File(rootDir.path + "/sample-extension-plugin/" + bwcFilePath + bwcPluginVersion)
                             if (!dir.exists()) {
                                 dir.mkdirs()
                             }
-                            File f = new File(dir, bwcJobSchedulerPlugin)
+                            File f = new File(dir, bwcFileName)
                             if (!f.exists()) {
-                                new URL(bwc_js_download_url).withInputStream{ ins -> f.withOutputStream{ it << ins }}
+                                new URL(bwcDownloadUrl).withInputStream{ ins -> f.withOutputStream{ it << ins }}
                             }
-                            return fileTree(bwcFilePath + bwcJobSchedulerVersion).getSingleFile()
+                            return f 
                         }
                     }
                 }
@@ -191,7 +189,7 @@ task prepareBwcTests {
         }
         systemProperty 'tests.rest.bwcsuite', 'old_cluster'
         systemProperty 'tests.rest.bwcsuite_round', 'old'
-        systemProperty 'tests.plugin_bwc_version', bwcJobSchedulerVersion
+        systemProperty 'tests.plugin_bwc_version', bwcPluginVersion
         nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}$i".allHttpSocketURI.join(",")}")
         nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}$i".getName()}")
     }
@@ -211,7 +209,7 @@ task "${baseName}#mixedClusterTask"(type: StandaloneRestIntegTestTask) {
     }
     systemProperty 'tests.rest.bwcsuite', 'mixed_cluster'
     systemProperty 'tests.rest.bwcsuite_round', 'first'
-    systemProperty 'tests.plugin_bwc_version', bwcJobSchedulerVersion
+    systemProperty 'tests.plugin_bwc_version', bwcPluginVersion
     nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}0".allHttpSocketURI.join(",")}")
     nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}0".getName()}")
 }
@@ -230,7 +228,7 @@ task "${baseName}#twoThirdsUpgradedClusterTask"(type: StandaloneRestIntegTestTas
     }
     systemProperty 'tests.rest.bwcsuite', 'mixed_cluster'
     systemProperty 'tests.rest.bwcsuite_round', 'second'
-    systemProperty 'tests.plugin_bwc_version', bwcJobSchedulerVersion
+    systemProperty 'tests.plugin_bwc_version', bwcPluginVersion
     nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}0".allHttpSocketURI.join(",")}")
     nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}0".getName()}")
 }
@@ -250,7 +248,7 @@ task "${baseName}#rollingUpgradeClusterTask"(type: StandaloneRestIntegTestTask) 
     mustRunAfter "${baseName}#mixedClusterTask"
     systemProperty 'tests.rest.bwcsuite', 'mixed_cluster'
     systemProperty 'tests.rest.bwcsuite_round', 'third'
-    systemProperty 'tests.plugin_bwc_version', bwcJobSchedulerVersion
+    systemProperty 'tests.plugin_bwc_version', bwcPluginVersion
     nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}0".allHttpSocketURI.join(",")}")
     nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}0".getName()}")
 }
@@ -267,7 +265,7 @@ task "${baseName}#fullRestartClusterTask"(type: StandaloneRestIntegTestTask) {
         includeTestsMatching "org.opensearch.jobscheduler.sampleextension.bwc.*IT"
     }
     systemProperty 'tests.rest.bwcsuite', 'upgraded_cluster'
-    systemProperty 'tests.plugin_bwc_version', bwcJobSchedulerVersion
+    systemProperty 'tests.plugin_bwc_version', bwcPluginVersion
     nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}1".allHttpSocketURI.join(",")}")
     nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}1".getName()}")
 }

--- a/sample-extension-plugin/src/test/java/org/opensearch/jobscheduler/sampleextension/bwc/JobSchedulerBackwardsCompatibilityIT.java
+++ b/sample-extension-plugin/src/test/java/org/opensearch/jobscheduler/sampleextension/bwc/JobSchedulerBackwardsCompatibilityIT.java
@@ -36,28 +36,12 @@ public class JobSchedulerBackwardsCompatibilityIT extends SampleExtensionIntegTe
 
             switch (CLUSTER_TYPE) {
                 case OLD:
+                case MIXED:
                     /*
                     * as only the old version of job-scheduler plugin is loaded, we only assert that it is loaded.
                      */
-                    Assert.assertTrue(pluginNames.contains("opendistro-job-scheduler"));
+                    Assert.assertTrue(pluginNames.contains("opensearch-job-scheduler"));
                     break;
-                case MIXED:
-                    /*
-                    * for a 3-node mixedClusterTask, 1st node is upgraded, & 2 remaining nodes still have old versions.
-                    * for a 3-node twoThirdsUpgradedClusterTask, 2 nodes are upgraded, & 1 remaining node still have old versions.
-                    * for a 3-node rollingUpgradeClusterTask, all 3 nodes are upgraded.
-                    * so for first 2 scenarios, we assert, 3rd node still has older version of job-scheduler plugin & 1st/2nd node is upgraded to use latest plugins.
-                    * we cannot trigger a call for scheduling watcher job, as the older nodes do not have sample-extension plugin.
-                     */
-                    Map<String, Object> responseForOldNode = getAsMap(getPluginUriForMixedCluster("third"));
-                    Map<String, Map<String, Object>> responseMapForOldNode = (Map<String, Map<String, Object>>) responseForOldNode.get("nodes");
-
-                    for (Map<String, Object> respValuesForOldNode: responseMapForOldNode.values()) {
-                        List<Map<String, Object>> pluginsForOldNode = (List<Map<String, Object>>) respValuesForOldNode.get("plugins");
-                        List<String> pluginNamesForOldNode = pluginsForOldNode.stream().map(plugin -> plugin.get("name").toString()).collect(Collectors.toList());
-                        Assert.assertTrue("third".equals(System.getProperty("tests.rest.bwcsuite_round")) ||
-                                pluginNamesForOldNode.contains("opendistro-job-scheduler"));
-                    }
                 case UPGRADED:
                     /*
                     * As cluster is fully upgraded either by full restart or rolling upgrade, we assert, that all nodes are upgraded to use latest plugins.


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

OpenSearch 3.0 cannot be directly upgraded from OpenSearch 1.x.  This changes the BCW to use OpenSearch 2.4.0. The latest version of the job-scheduler plugin is also downloaded from CI.

We'll need to find a way to automate getting "the latest 2.x version" if we don't want to keep updating this number here every time a 2.x releases.
 
### Issues Resolved

https://github.com/opensearch-project/OpenSearch/issues/3615
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
