### PR TITLE
Added groupId as org.opensearch.plugin in pluginZip publication

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -122,6 +122,7 @@ publishing {
             pom {
                 name = "opensearch-job-scheduler"
                 description = "OpenSearch Job Scheduler plugin"
+                groupId = "org.opensearch.plugin"
             }
         }
     }
@@ -312,4 +313,4 @@ task updateVersion {
         // Include the required files that needs to be updated with new Version
         ant.replaceregexp(file:'build.gradle', match: '"opensearch.version", "\\d.*"', replace: '"opensearch.version", "' + newVersion.tokenize('-')[0] + '-SNAPSHOT"', flags:'g', byline:true)
     }
-}  
+}


### PR DESCRIPTION
Signed-off-by: prudhvigodithi <pgodithi@amazon.com>

### Description
Added groupId as org.opensearch.plugin in pluginZip publication
 
### Issues Resolved
https://github.com/opensearch-project/job-scheduler/issues/225
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
