### PR TITLE
Add slf4j which is the dep of cronutils

### DIFF
--- a/spi/build.gradle
+++ b/spi/build.gradle
@@ -43,12 +43,24 @@ jacocoTestReport {
 }
 check.dependsOn jacocoTestReport
 
+def slf4j_version_of_cronutils = "1.7.30"
 dependencies {
     compileOnly "org.opensearch:opensearch:${opensearch_version}"
+    // slf4j is the runtime dependency of cron-utils
+    // if cron-utils version gets bumped, pls check the slf4j version cron-utils depending on
+    //  and bump if needed
     implementation "com.cronutils:cron-utils:9.2.0"
+    runtimeOnly "org.slf4j:slf4j-api:${slf4j_version_of_cronutils}"
 
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
     testImplementation "org.apache.logging.log4j:log4j-core:${versions.log4j}"
+}
+
+configurations.all {
+    if (it.state != Configuration.State.UNRESOLVED) return
+    resolutionStrategy {
+        force "org.slf4j:slf4j-api:${slf4j_version_of_cronutils}"
+    }
 }
 
 shadowJar {


### PR DESCRIPTION
### Description

Job scheduler `- depend on -` cron-utils `- depend on -` slf4j

When we upgrade to OS 2.0, the dependency configuration `compile` is deprecated and `implementation` is used instead ([code change](https://github.com/opensearch-project/job-scheduler/pull/133/files#diff-ddfd6f002852c4395d6a0303ccf59041623cc8608a8a4acb4af5f2e8137ebc03R48)), after this, the transitive dependency slf4j is not on the compileClassPath anymore so the relocation of slf4j is not working silently. This PR adds back the slf4j dependency so it can be relocated correctly again.

To check whether the slf4j gets relocated:
1. build job scheduler jar
2. check if slf4j is relocated in the jar `jar tvf $file | grep -i "slf4j";`
 
### Issues Resolved
https://github.com/opensearch-project/index-management/issues/519
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
