### PR TITLE
Adding Build and Test Workflow for Windows OS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,18 +8,21 @@ on:
       - "*"
 
 jobs:
-  build:
+  linux-build:
     strategy:
       matrix:
         java: [11, 17]
 
+    # Job name
     name: Build and Test
+    # This job runs on Linux
     runs-on: ubuntu-latest
 
     steps:
+      # This step uses the checkout Github action: https://github.com/actions/checkout
       - name: Checkout
         uses: actions/checkout@v2
-
+      # This step uses the setup-java Github action: https://github.com/actions/setup-java
       - name: Setup Java ${{ matrix.java }}
         uses: actions/setup-java@v1
         with:
@@ -37,4 +40,36 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+  windows-build:
+    strategy:
+      matrix:
+        java: [11, 17]
 
+    # Job name
+    name: Build and Test
+    # This job runs on Windows
+    runs-on: windows-latest
+
+    steps:
+      # This step uses the checkout Github action: https://github.com/actions/checkout
+      - name: Checkout
+        uses: actions/checkout@v2
+      # This step uses the setup-java Github action: https://github.com/actions/setup-java
+      - name: Setup Java ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+
+      - name: Build and Test
+        run: |
+          ./gradlew build -x integTest
+
+      - name: Publish to Maven Local
+        run: |
+          ./gradlew publishToMavenLocal
+          
+      - name: Upload Coverage Report
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          


### PR DESCRIPTION
Signed-off-by: Joshua Palis <jpalis@amazon.com>

### Description
Adds CI workflow for windows OS

### Issues Resolved
https://github.com/opensearch-project/job-scheduler/issues/75
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
