### PR TITLE
Bumping up slf4j-api version to 1.7.36

### DIFF
--- a/spi/build.gradle
+++ b/spi/build.gradle
@@ -43,7 +43,7 @@ jacocoTestReport {
 }
 check.dependsOn jacocoTestReport
 
-def slf4j_version_of_cronutils = "1.7.30"
+def slf4j_version_of_cronutils = "1.7.36"
 dependencies {
     compileOnly "org.opensearch:opensearch:${opensearch_version}"
     // slf4j is the runtime dependency of cron-utils


### PR DESCRIPTION
Signed-off-by: Joshua Palis <jpalis@amazon.com>

### Description
OpenSearch 2.x currently has slf4j-api dependency version 1.7.36 [here](https://github.com/opensearch-project/OpenSearch/blob/fe8fd67884160e346def8c8503d09fb4b5eb5363/buildSrc/version.properties#L18). In preparation to [move JS to native plugins](https://github.com/opensearch-project/OpenSearch/issues/5310), we must also match this dependency version in order to avoid jarhell.
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
