### PR TITLE
Increasing thread sleep to 100,000

### DIFF
--- a/sample-extension-plugin/src/test/java/org/opensearch/jobscheduler/sampleextension/bwc/JobSchedulerBackwardsCompatibilityIT.java
+++ b/sample-extension-plugin/src/test/java/org/opensearch/jobscheduler/sampleextension/bwc/JobSchedulerBackwardsCompatibilityIT.java
@@ -140,7 +140,7 @@ public class JobSchedulerBackwardsCompatibilityIT extends SampleExtensionIntegTe
         String jobId = OpenSearchRestTestCase.randomAlphaOfLength(10);
         createWatcherJobJson(jobId, jobParameter);
 
-        long actualCount = waitAndCountRecords(index, 80000);
+        long actualCount = waitAndCountRecords(index, 100000);
         Assert.assertEquals(1, actualCount);
     }
 }


### PR DESCRIPTION
Signed-off-by: Joshua Palis <jpalis@amazon.com>

### Description
There has been an increase of BWC test failures now that the windows CI workflow has been added. The source of the issue is the `createBasicWatcherJob()` method [here](https://github.com/opensearch-project/job-scheduler/blob/140ffd3d48f928db78fa9fb23242e8b50282f7aa/sample-extension-plugin/src/test/java/org/opensearch/jobscheduler/sampleextension/bwc/JobSchedulerBackwardsCompatibilityIT.java#L143) that counts the number of records within a job index after the job has been executed. The job is configured to execute every minute, and after waiting for 80,000 ms, the test attempts to confirm that there is only 1 record within the index. This error is not reproducible locally, and I suspect that this may be a transient fault. In order to mitigate this issue, increasing the thread sleep to 100,000


Example build failure : https://github.com/opensearch-project/job-scheduler/actions/runs/3803814253/jobs/6470491899#step:4:1189

 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
