### PR TITLE
Updating BWC version to 2.6.0

### DIFF
--- a/sample-extension-plugin/build.gradle
+++ b/sample-extension-plugin/build.gradle
@@ -128,7 +128,7 @@ testClusters.integTest {
 }
 
 String baseName = "jobSchedulerBwcCluster"
-String bwcOpenSearchVersion = "2.5.0"
+String bwcOpenSearchVersion = "2.6.0"
 String bwcPluginVersion = bwcOpenSearchVersion + ".0"
 String bwcFilePath = "src/test/resources/bwc/job-scheduler/"
 String bwcFileName = "opensearch-job-scheduler-" + bwcPluginVersion + ".zip"


### PR DESCRIPTION
Signed-off-by: Joshua Palis <jpalis@amazon.com>

### Description
2.x has been bumped up to 2.6.0, updating 3.x BWC tests to use 2.6.0, now that 2.5.0 is not wire compatible
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
