### PR TITLE
[Extensions] Create a proxy ScheduledJobRunner, ScheduledJobParser to invoke corresponding registered Job Detail actions

### DIFF
--- a/spi/src/main/java/org/opensearch/jobscheduler/spi/JobDocVersion.java
+++ b/spi/src/main/java/org/opensearch/jobscheduler/spi/JobDocVersion.java
@@ -8,12 +8,17 @@
  */
 package org.opensearch.jobscheduler.spi;
 
+import java.io.IOException;
 import java.util.Locale;
+
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.io.stream.Writeable;
 
 /**
  * Structure to represent scheduled job document version. JobScheduler use this to determine this job
  */
-public class JobDocVersion implements Comparable<JobDocVersion> {
+public class JobDocVersion implements Comparable<JobDocVersion>, Writeable {
     private final long primaryTerm;
     private final long seqNo;
     private final long version;
@@ -22,6 +27,19 @@ public class JobDocVersion implements Comparable<JobDocVersion> {
         this.primaryTerm = primaryTerm;
         this.seqNo = seqNo;
         this.version = version;
+    }
+
+    public JobDocVersion(StreamInput in) throws IOException {
+        this.primaryTerm = in.readLong();
+        this.seqNo = in.readLong();
+        this.version = in.readLong();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeLong(this.primaryTerm);
+        out.writeLong(this.seqNo);
+        out.writeLong(this.version);
     }
 
     public long getPrimaryTerm() {

--- a/spi/src/main/java/org/opensearch/jobscheduler/spi/JobExecutionContext.java
+++ b/spi/src/main/java/org/opensearch/jobscheduler/spi/JobExecutionContext.java
@@ -8,11 +8,15 @@
  */
 package org.opensearch.jobscheduler.spi;
 
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.io.stream.Writeable;
 import org.opensearch.jobscheduler.spi.utils.LockService;
 
+import java.io.IOException;
 import java.time.Instant;
 
-public class JobExecutionContext {
+public class JobExecutionContext implements Writeable {
     private final Instant expectedExecutionTime;
     private final JobDocVersion jobVersion;
     private final LockService lockService;
@@ -31,6 +35,22 @@ public class JobExecutionContext {
         this.lockService = lockService;
         this.jobIndexName = jobIndexName;
         this.jobId = jobId;
+    }
+
+    public JobExecutionContext(StreamInput in) throws IOException {
+        this.expectedExecutionTime = in.readInstant();
+        this.jobVersion = new JobDocVersion(in);
+        this.lockService = null;
+        this.jobIndexName = in.readString();
+        this.jobId = in.readString();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeInstant(this.expectedExecutionTime);
+        this.jobVersion.writeTo(out);
+        out.writeString(this.jobIndexName);
+        out.writeString(this.jobId);
     }
 
     public Instant getExpectedExecutionTime() {
@@ -52,4 +72,5 @@ public class JobExecutionContext {
     public String getJobId() {
         return this.jobId;
     }
+
 }

--- a/spi/src/main/java/org/opensearch/jobscheduler/spi/LockModel.java
+++ b/spi/src/main/java/org/opensearch/jobscheduler/spi/LockModel.java
@@ -13,9 +13,9 @@ import org.opensearch.OpenSearchException;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
-import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.common.xcontent.XContentParserUtils;
+import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.index.seqno.SequenceNumbers;
 
 import java.io.IOException;
@@ -177,13 +177,13 @@ public final class LockModel implements ToXContentObject {
     @Override
     public String toString() {
         try {
-            XContentBuilder builder = XContentFactory.jsonBuilder();
+            XContentBuilder builder = JsonXContent.contentBuilder();
             builder.humanReadable(true);
             this.toXContent(builder, EMPTY_PARAMS);
             return BytesReference.bytes(builder).utf8ToString();
         } catch (IOException e) {
             try {
-                XContentBuilder builder = XContentFactory.jsonBuilder();
+                XContentBuilder builder = JsonXContent.contentBuilder();
                 builder.startObject();
                 builder.field("error", "error building toString out of XContent: " + e.getMessage());
                 builder.field("stack_trace", ExceptionsHelper.stackTrace(e));

--- a/spi/src/main/java/org/opensearch/jobscheduler/spi/LockModel.java
+++ b/spi/src/main/java/org/opensearch/jobscheduler/spi/LockModel.java
@@ -8,12 +8,14 @@
  */
 package org.opensearch.jobscheduler.spi;
 
-import org.opensearch.common.Strings;
+import org.opensearch.ExceptionsHelper;
+import org.opensearch.OpenSearchException;
+import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.common.xcontent.XContentParserUtils;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.seqno.SequenceNumbers;
 
 import java.io.IOException;
@@ -174,7 +176,23 @@ public final class LockModel implements ToXContentObject {
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this, false, true);
+        try {
+            XContentBuilder builder = XContentFactory.jsonBuilder();
+            builder.humanReadable(true);
+            this.toXContent(builder, EMPTY_PARAMS);
+            return BytesReference.bytes(builder).utf8ToString();
+        } catch (IOException e) {
+            try {
+                XContentBuilder builder = XContentFactory.jsonBuilder();
+                builder.startObject();
+                builder.field("error", "error building toString out of XContent: " + e.getMessage());
+                builder.field("stack_trace", ExceptionsHelper.stackTrace(e));
+                builder.endObject();
+                return BytesReference.bytes(builder).utf8ToString();
+            } catch (IOException e2) {
+                throw new OpenSearchException("cannot generate error message for deserialization", e);
+            }
+        }
     }
 
     public String getLockId() {

--- a/src/main/java/org/opensearch/jobscheduler/JobSchedulerPlugin.java
+++ b/src/main/java/org/opensearch/jobscheduler/JobSchedulerPlugin.java
@@ -95,7 +95,7 @@ public class JobSchedulerPlugin extends Plugin implements ActionPlugin, Extensib
         Supplier<RepositoriesService> repositoriesServiceSupplier
     ) {
         this.lockService = new LockService(client, clusterService);
-        this.jobDetailsService = new JobDetailsService(client, clusterService, this.indicesToListen);
+        this.jobDetailsService = new JobDetailsService(client, clusterService, this.indicesToListen, this.indexToJobProviders);
         this.scheduler = new JobScheduler(threadPool, this.lockService);
         this.sweeper = initSweeper(
             environment.settings(),

--- a/src/main/java/org/opensearch/jobscheduler/model/ExtensionJobParameter.java
+++ b/src/main/java/org/opensearch/jobscheduler/model/ExtensionJobParameter.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.jobscheduler.model;
+
+import java.io.IOException;
+import java.time.Instant;
+
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.io.stream.Writeable;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.jobscheduler.spi.ScheduledJobParameter;
+import org.opensearch.jobscheduler.spi.schedule.CronSchedule;
+import org.opensearch.jobscheduler.spi.schedule.IntervalSchedule;
+import org.opensearch.jobscheduler.spi.schedule.Schedule;
+import org.opensearch.jobscheduler.spi.ScheduledJobParameter;
+
+public class ExtensionJobParameter implements ScheduledJobParameter, Writeable {
+
+    enum ScheduleType {
+        CRON,
+        INTERVAL
+    }
+
+    private String extensionJobName;
+
+    private Schedule extensionJobSchedule;
+
+    private Instant lastUpdateTime;
+
+    private Instant enabledTime;
+
+    private boolean isEnabled;
+
+    private Long lockDurationSeconds;
+
+    private Double jitter;
+
+    public ExtensionJobParameter(
+        String extensionJobName,
+        Schedule extensionJobSchedule,
+        Instant lastUpdateTime,
+        Instant enabledTime,
+        boolean isEnabled,
+        Long lockDurationSeconds,
+        Double jitter
+    ) {
+        this.extensionJobName = extensionJobName;
+        this.extensionJobSchedule = extensionJobSchedule;
+        this.lastUpdateTime = lastUpdateTime;
+        this.enabledTime = enabledTime;
+        this.isEnabled = isEnabled;
+        this.lockDurationSeconds = lockDurationSeconds;
+        this.jitter = jitter;
+    }
+
+    public ExtensionJobParameter(StreamInput in) throws IOException {
+        this.extensionJobName = in.readString();
+        if (in.readEnum(ExtensionJobParameter.ScheduleType.class) == ScheduleType.CRON) {
+            this.extensionJobSchedule = new CronSchedule(in);
+        } else {
+            this.extensionJobSchedule = new IntervalSchedule(in);
+        }
+        this.lastUpdateTime = in.readInstant();
+        this.enabledTime = in.readInstant();
+        this.isEnabled = in.readBoolean();
+        this.lockDurationSeconds = in.readLong();
+        this.jitter = in.readDouble();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(this.extensionJobName);
+        if (this.extensionJobSchedule instanceof CronSchedule) {
+            out.writeEnum(ScheduleType.CRON);
+        } else {
+            out.writeEnum(ScheduleType.INTERVAL);
+        }
+        this.extensionJobSchedule.writeTo(out);
+        out.writeInstant(this.lastUpdateTime);
+        out.writeInstant(this.enabledTime);
+        out.writeBoolean(this.isEnabled);
+        out.writeLong(this.lockDurationSeconds);
+        out.writeDouble(this.jitter);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        // no op
+        return null;
+    }
+
+    @Override
+    public String getName() {
+        return this.extensionJobName;
+    }
+
+    @Override
+    public Instant getLastUpdateTime() {
+        return this.lastUpdateTime;
+    }
+
+    @Override
+    public Instant getEnabledTime() {
+        return this.enabledTime;
+    }
+
+    @Override
+    public Schedule getSchedule() {
+        return this.extensionJobSchedule;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return this.isEnabled;
+    }
+
+}

--- a/src/main/java/org/opensearch/jobscheduler/model/ExtensionJobParameter.java
+++ b/src/main/java/org/opensearch/jobscheduler/model/ExtensionJobParameter.java
@@ -75,16 +75,19 @@ public class ExtensionJobParameter implements ScheduledJobParameter, Writeable {
     }
 
     public ExtensionJobParameter(ScheduledJobParameter jobParameter) {
+
         // Convert job Parameter into writeable ExtensionJobParameter
-        this(
-            jobParameter.getName(),
-            jobParameter.getSchedule(),
-            jobParameter.getLastUpdateTime(),
-            jobParameter.getEnabledTime(),
-            jobParameter.isEnabled(),
-            jobParameter.getLockDurationSeconds(),
-            jobParameter.getJitter()
-        );
+        this.jobName = jobParameter.getName();
+        this.schedule = jobParameter.getSchedule();
+        this.lastUpdateTime = jobParameter.getLastUpdateTime();
+        this.enabledTime = jobParameter.getEnabledTime();
+        this.isEnabled = jobParameter.isEnabled();
+        this.lockDurationSeconds = jobParameter.getLockDurationSeconds();
+        if (jobParameter.getJitter() != null) {
+            this.jitter = jobParameter.getJitter();
+        } else {
+            this.jitter = 0.0;
+        }
     }
 
     public ExtensionJobParameter(StreamInput in) throws IOException {

--- a/src/main/java/org/opensearch/jobscheduler/model/ExtensionJobParameter.java
+++ b/src/main/java/org/opensearch/jobscheduler/model/ExtensionJobParameter.java
@@ -21,6 +21,11 @@ import org.opensearch.jobscheduler.spi.schedule.IntervalSchedule;
 import org.opensearch.jobscheduler.spi.schedule.Schedule;
 import org.opensearch.jobscheduler.spi.ScheduledJobParameter;
 
+/**
+ * A {@link Writeable} {@link ScheduledJobParameter} used to transport job parameters between OpenSearch and Extensions
+ *
+ * @opensearch.internal
+ */
 public class ExtensionJobParameter implements ScheduledJobParameter, Writeable {
 
     enum ScheduleType {

--- a/src/main/java/org/opensearch/jobscheduler/model/ExtensionJobParameter.java
+++ b/src/main/java/org/opensearch/jobscheduler/model/ExtensionJobParameter.java
@@ -28,7 +28,10 @@ import org.opensearch.jobscheduler.spi.ScheduledJobParameter;
  */
 public class ExtensionJobParameter implements ScheduledJobParameter, Writeable {
 
-    enum ScheduleType {
+    /**
+    * Enum for Schedule types used to indicate which Schedule constructor to use to read from/write to the stream. Job schedules can be set via cron expression or interval.
+    */
+    public enum ScheduleType {
         CRON,
         INTERVAL
     }
@@ -155,6 +158,16 @@ public class ExtensionJobParameter implements ScheduledJobParameter, Writeable {
     @Override
     public boolean isEnabled() {
         return this.isEnabled;
+    }
+
+    @Override
+    public Long getLockDurationSeconds() {
+        return this.lockDurationSeconds;
+    }
+
+    @Override
+    public Double getJitter() {
+        return this.jitter;
     }
 
 }

--- a/src/main/java/org/opensearch/jobscheduler/model/ExtensionJobParameter.java
+++ b/src/main/java/org/opensearch/jobscheduler/model/ExtensionJobParameter.java
@@ -60,6 +60,19 @@ public class ExtensionJobParameter implements ScheduledJobParameter, Writeable {
         this.jitter = jitter;
     }
 
+    public ExtensionJobParameter(ScheduledJobParameter jobParameter) {
+        // Convert job Parameter into writeable ExtensionJobParameter
+        this(
+            jobParameter.getName(),
+            jobParameter.getSchedule(),
+            jobParameter.getLastUpdateTime(),
+            jobParameter.getEnabledTime(),
+            jobParameter.isEnabled(),
+            jobParameter.getLockDurationSeconds(),
+            jobParameter.getJitter()
+        );
+    }
+
     public ExtensionJobParameter(StreamInput in) throws IOException {
         this.extensionJobName = in.readString();
         if (in.readEnum(ExtensionJobParameter.ScheduleType.class) == ScheduleType.CRON) {

--- a/src/main/java/org/opensearch/jobscheduler/model/ExtensionJobParameter.java
+++ b/src/main/java/org/opensearch/jobscheduler/model/ExtensionJobParameter.java
@@ -22,9 +22,8 @@ import org.opensearch.jobscheduler.spi.schedule.Schedule;
 import org.opensearch.jobscheduler.spi.ScheduledJobParameter;
 
 /**
- * A {@link Writeable} {@link ScheduledJobParameter} used to transport job parameters between OpenSearch and Extensions
+ * A {@link Writeable} ScheduledJobParameter used to transport job parameters between OpenSearch and Extensions
  *
- * @opensearch.internal
  */
 public class ExtensionJobParameter implements ScheduledJobParameter, Writeable {
 

--- a/src/main/java/org/opensearch/jobscheduler/transport/ExtensionJobActionRequest.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/ExtensionJobActionRequest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.jobscheduler.transport;
+
+import java.io.IOException;
+
+import org.opensearch.common.bytes.BytesReference;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.io.stream.Writeable;
+import org.opensearch.extensions.action.ExtensionActionRequest;
+
+/**
+ * Request to extensions to invoke a job action, converts request params to a byte array
+ */
+public class ExtensionJobActionRequest<T extends Writeable> extends ExtensionActionRequest {
+
+    public ExtensionJobActionRequest(String extensionActionName, T actionParams) throws IOException {
+        super(extensionActionName, convertParamsToBytes(actionParams));
+    }
+
+    public static <T extends Writeable> byte[] convertParamsToBytes(T actionParams) throws IOException {
+        // Write all to output stream
+        BytesStreamOutput out = new BytesStreamOutput();
+        actionParams.writeTo(out);
+        out.flush();
+
+        // convert bytes stream to byte array
+        return BytesReference.toBytes(out.bytes());
+    }
+}

--- a/src/main/java/org/opensearch/jobscheduler/transport/ExtensionJobActionRequest.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/ExtensionJobActionRequest.java
@@ -18,7 +18,6 @@ import org.opensearch.extensions.action.ExtensionActionRequest;
 /**
  * Request to extensions to invoke a job action, converts request params to a byte array
  *
- * @opensearch.internal
  */
 public class ExtensionJobActionRequest<T extends Writeable> extends ExtensionActionRequest {
 
@@ -27,6 +26,7 @@ public class ExtensionJobActionRequest<T extends Writeable> extends ExtensionAct
      *
      * @param extensionActionName the extension action to invoke
      * @param actionParams the request object holding the action parameters
+     * @throws IOExeption if serialization fails
      */
     public ExtensionJobActionRequest(String extensionActionName, T actionParams) throws IOException {
         super(extensionActionName, convertParamsToBytes(actionParams));
@@ -35,8 +35,8 @@ public class ExtensionJobActionRequest<T extends Writeable> extends ExtensionAct
     /**
      * Takes in an object of type T that extends {@link Writeable} and converts the request to a byte array
      *
-     * @param jobParameter the ScheduledJobParameter to convert into a writeable ExtensionJobParameter
-     * @param jobExecutionContext the context used to facilitate a job run
+     * @param actionParams the action parameters to be serialized
+     * @throws IOException if serialization fails
      */
     public static <T extends Writeable> byte[] convertParamsToBytes(T actionParams) throws IOException {
         // Write all to output stream

--- a/src/main/java/org/opensearch/jobscheduler/transport/ExtensionJobActionRequest.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/ExtensionJobActionRequest.java
@@ -9,11 +9,9 @@
 package org.opensearch.jobscheduler.transport;
 
 import java.io.IOException;
-
-import org.opensearch.common.bytes.BytesReference;
-import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.io.stream.Writeable;
 import org.opensearch.extensions.action.ExtensionActionRequest;
+import org.opensearch.jobscheduler.utils.JobDetailsService;
 
 /**
  * Request to extensions to invoke a job action, converts request params to a byte array
@@ -29,24 +27,7 @@ public class ExtensionJobActionRequest<T extends Writeable> extends ExtensionAct
      * @throws IOException if serialization fails
      */
     public ExtensionJobActionRequest(String extensionActionName, T actionParams) throws IOException {
-        super(extensionActionName, convertParamsToBytes(actionParams));
+        super(extensionActionName, JobDetailsService.convertParamsToBytes(actionParams));
     }
 
-    /**
-     * Takes in an object of type T that extends {@link Writeable} and converts the request to a byte array
-     *
-     * @param <T> a class that extends writeable
-     * @param actionParams the action parameters to be serialized
-     * @throws IOException if serialization fails
-     * @return the byte array of the parameters
-     */
-    public static <T extends Writeable> byte[] convertParamsToBytes(T actionParams) throws IOException {
-        // Write all to output stream
-        BytesStreamOutput out = new BytesStreamOutput();
-        actionParams.writeTo(out);
-        out.flush();
-
-        // convert bytes stream to byte array
-        return BytesReference.toBytes(out.bytes());
-    }
 }

--- a/src/main/java/org/opensearch/jobscheduler/transport/ExtensionJobActionRequest.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/ExtensionJobActionRequest.java
@@ -17,13 +17,27 @@ import org.opensearch.extensions.action.ExtensionActionRequest;
 
 /**
  * Request to extensions to invoke a job action, converts request params to a byte array
+ *
+ * @opensearch.internal
  */
 public class ExtensionJobActionRequest<T extends Writeable> extends ExtensionActionRequest {
 
+    /**
+     * Instantiates a new ExtensionJobActionRequest
+     *
+     * @param extensionActionName the extension action to invoke
+     * @param actionParams the request object holding the action parameters
+     */
     public ExtensionJobActionRequest(String extensionActionName, T actionParams) throws IOException {
         super(extensionActionName, convertParamsToBytes(actionParams));
     }
 
+    /**
+     * Takes in an object of type T that extends {@link Writeable} and converts the request to a byte array
+     *
+     * @param jobParameter the ScheduledJobParameter to convert into a writeable ExtensionJobParameter
+     * @param jobExecutionContext the context used to facilitate a job run
+     */
     public static <T extends Writeable> byte[] convertParamsToBytes(T actionParams) throws IOException {
         // Write all to output stream
         BytesStreamOutput out = new BytesStreamOutput();

--- a/src/main/java/org/opensearch/jobscheduler/transport/ExtensionJobActionRequest.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/ExtensionJobActionRequest.java
@@ -26,7 +26,7 @@ public class ExtensionJobActionRequest<T extends Writeable> extends ExtensionAct
      *
      * @param extensionActionName the extension action to invoke
      * @param actionParams the request object holding the action parameters
-     * @throws IOExeption if serialization fails
+     * @throws IOException if serialization fails
      */
     public ExtensionJobActionRequest(String extensionActionName, T actionParams) throws IOException {
         super(extensionActionName, convertParamsToBytes(actionParams));
@@ -35,8 +35,10 @@ public class ExtensionJobActionRequest<T extends Writeable> extends ExtensionAct
     /**
      * Takes in an object of type T that extends {@link Writeable} and converts the request to a byte array
      *
+     * @param <T> a class that extends writeable
      * @param actionParams the action parameters to be serialized
      * @throws IOException if serialization fails
+     * @return the byte array of the parameters
      */
     public static <T extends Writeable> byte[] convertParamsToBytes(T actionParams) throws IOException {
         // Write all to output stream

--- a/src/main/java/org/opensearch/jobscheduler/transport/ExtensionJobActionResponse.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/ExtensionJobActionResponse.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.jobscheduler.transport;
+
+import java.io.IOException;
+
+import org.opensearch.common.bytes.BytesReference;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.io.stream.Writeable;
+import org.opensearch.extensions.action.ExtensionActionResponse;
+
+/**
+ * Response from extension job action, converts response params to a byte array
+ *
+ */
+public class ExtensionJobActionResponse<T extends Writeable> extends ExtensionActionResponse {
+
+    /**
+     * Instantiates a new ExtensionJobActionResponse
+     *
+     * @param actionResponse the response object holding the action response parameters
+     * @throws IOException if serialization fails
+     */
+    public ExtensionJobActionResponse(T actionResponse) throws IOException {
+        super(convertResponseToBytes(actionResponse));
+    }
+
+    /**
+     * Takes in an object of type T that extends {@link Writeable} and converts the response to a byte array
+     *
+     * @param <T> a class that extends writeable
+     * @param actionResponse the action parameters to be serialized
+     * @throws IOException if serialization fails
+     * @return the byte array of the parameters
+     */
+    public static <T extends Writeable> byte[] convertResponseToBytes(T actionResponse) throws IOException {
+        // Write all to output stream
+        BytesStreamOutput out = new BytesStreamOutput();
+        actionResponse.writeTo(out);
+        out.flush();
+
+        // convert bytes stream to byte array
+        return BytesReference.toBytes(out.bytes());
+    }
+}

--- a/src/main/java/org/opensearch/jobscheduler/transport/ExtensionJobActionResponse.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/ExtensionJobActionResponse.java
@@ -9,11 +9,9 @@
 package org.opensearch.jobscheduler.transport;
 
 import java.io.IOException;
-
-import org.opensearch.common.bytes.BytesReference;
-import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.io.stream.Writeable;
 import org.opensearch.extensions.action.ExtensionActionResponse;
+import org.opensearch.jobscheduler.utils.JobDetailsService;
 
 /**
  * Response from extension job action, converts response params to a byte array
@@ -28,24 +26,7 @@ public class ExtensionJobActionResponse<T extends Writeable> extends ExtensionAc
      * @throws IOException if serialization fails
      */
     public ExtensionJobActionResponse(T actionResponse) throws IOException {
-        super(convertResponseToBytes(actionResponse));
+        super(JobDetailsService.convertParamsToBytes(actionResponse));
     }
 
-    /**
-     * Takes in an object of type T that extends {@link Writeable} and converts the response to a byte array
-     *
-     * @param <T> a class that extends writeable
-     * @param actionResponse the action parameters to be serialized
-     * @throws IOException if serialization fails
-     * @return the byte array of the parameters
-     */
-    public static <T extends Writeable> byte[] convertResponseToBytes(T actionResponse) throws IOException {
-        // Write all to output stream
-        BytesStreamOutput out = new BytesStreamOutput();
-        actionResponse.writeTo(out);
-        out.flush();
-
-        // convert bytes stream to byte array
-        return BytesReference.toBytes(out.bytes());
-    }
 }

--- a/src/main/java/org/opensearch/jobscheduler/transport/JobParameterRequest.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/JobParameterRequest.java
@@ -19,16 +19,32 @@ import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.jobscheduler.spi.JobDocVersion;
 
 /**
- * Request to extensions to parse ScheduledJobParameter
+ * Request to extensions to parse a {@link ScheduledJobParameter}
  */
 public class JobParameterRequest implements Writeable {
 
+    /**
+     * jobSource is the index entry bytes reference from the registered job index
+     */
     private final BytesReference jobSource;
 
+    /**
+     * id is the job Id
+     */
     private final String id;
 
+    /**
+     * jobDocVersion is the metadata regarding this particular registered job
+     */
     private final JobDocVersion jobDocVersion;
 
+    /**
+     * Instantiates a new Job Parameter Request
+     *
+     * @param xContentParser the parser obect to extract the jobSource {@link BytesReference} from
+     * @param id the job id
+     * @param jobDocVersion the job document version
+     */
     public JobParameterRequest(XContentParser jobParser, String id, JobDocVersion jobDocVersion) throws IOException {
 
         // Extract jobSource bytesRef from xContentParser
@@ -40,10 +56,26 @@ public class JobParameterRequest implements Writeable {
         this.jobDocVersion = jobDocVersion;
     }
 
+    /**
+     * Instantiates a new Job Parameter Request from {@link StreamInput}
+     *
+     * @param in in bytes stream input used to de-serialize the message.
+     * @throws IOException IOException when message de-serialization fails.
+     */
     public JobParameterRequest(StreamInput in) throws IOException {
         this.jobSource = in.readBytesReference();
         this.id = in.readString();
         this.jobDocVersion = new JobDocVersion(in);
+    }
+
+    /**
+     * Instantiates a new Job Parameter Request by wrapping the given byte array within a {@link StreamInput}
+     *
+     * @param requestParams in bytes array used to de-serialize the message.
+     * @throws IOException when message de-serialization fails.
+     */
+    public JobParameterRequest(byte[] requestParams) throws IOException {
+        this(StreamInput.wrap(requestParams));
     }
 
     @Override

--- a/src/main/java/org/opensearch/jobscheduler/transport/JobParameterRequest.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/JobParameterRequest.java
@@ -66,7 +66,7 @@ public class JobParameterRequest implements Writeable {
     /**
      * Instantiates a new Job Parameter Request from {@link StreamInput}
      *
-     * @param in in bytes stream input used to de-serialize the message.
+     * @param in is the byte stream input used to de-serialize the message.
      * @throws IOException IOException when message de-serialization fails.
      */
     public JobParameterRequest(StreamInput in) throws IOException {

--- a/src/main/java/org/opensearch/jobscheduler/transport/JobParameterRequest.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/JobParameterRequest.java
@@ -19,7 +19,7 @@ import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.jobscheduler.spi.JobDocVersion;
 
 /**
- * Request to extensions to parse a {@link ScheduledJobParameter}
+ * Request to extensions to parse a ScheduledJobParameter
  */
 public class JobParameterRequest implements Writeable {
 
@@ -41,9 +41,10 @@ public class JobParameterRequest implements Writeable {
     /**
      * Instantiates a new Job Parameter Request
      *
-     * @param xContentParser the parser obect to extract the jobSource {@link BytesReference} from
+     * @param jobParser the parser obect to extract the jobSource {@link BytesReference} from
      * @param id the job id
      * @param jobDocVersion the job document version
+     * @throws IOException IOException when message de-serialization fails.
      */
     public JobParameterRequest(XContentParser jobParser, String id, JobDocVersion jobDocVersion) throws IOException {
 

--- a/src/main/java/org/opensearch/jobscheduler/transport/JobParameterRequest.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/JobParameterRequest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.jobscheduler.transport;
+
+import java.io.IOException;
+
+import org.opensearch.common.bytes.BytesReference;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.common.xcontent.XContentParser;
+import org.opensearch.extensions.action.ExtensionActionRequest;
+import org.opensearch.jobscheduler.spi.JobDocVersion;
+
+/**
+ * Request toextensions to parse ScheduledJobParameter
+ */
+public class JobParameterRequest extends ExtensionActionRequest {
+
+    public JobParameterRequest(String extensionActionName, XContentParser jobParser, String id, JobDocVersion jobDocVersion)
+        throws IOException {
+        super(extensionActionName, convertParamsToBytes(jobParser, id, jobDocVersion));
+    }
+
+    public static byte[] convertParamsToBytes(XContentParser jobParser, String id, JobDocVersion jobDocVersion) throws IOException {
+
+        // Extract jobSource bytesRef from parser object
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.copyCurrentStructure(jobParser);
+        BytesReference jobSource = BytesReference.bytes(builder);
+
+        // write all to output stream
+        BytesStreamOutput out = new BytesStreamOutput();
+        out.writeBytesReference(jobSource);
+        out.writeString(id);
+        jobDocVersion.writeTo(out);
+        out.flush();
+
+        // convert bytes stream to byte array
+        return BytesReference.toBytes(out.bytes());
+    }
+}

--- a/src/main/java/org/opensearch/jobscheduler/transport/JobParameterRequest.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/JobParameterRequest.java
@@ -19,7 +19,7 @@ import org.opensearch.extensions.action.ExtensionActionRequest;
 import org.opensearch.jobscheduler.spi.JobDocVersion;
 
 /**
- * Request toextensions to parse ScheduledJobParameter
+ * Request to extensions to parse ScheduledJobParameter
  */
 public class JobParameterRequest extends ExtensionActionRequest {
 

--- a/src/main/java/org/opensearch/jobscheduler/transport/JobParameterResponse.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/JobParameterResponse.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.jobscheduler.transport;
+
+import java.io.IOException;
+
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.io.stream.Writeable;
+import org.opensearch.jobscheduler.model.ExtensionJobParameter;
+
+/**
+ * Response from extensions to parse a ScheduledJobParameter
+ */
+public class JobParameterResponse implements Writeable {
+
+    /**
+     * jobParameter is job index entry intended to be used to validate prior to job execution
+     */
+    private final ExtensionJobParameter jobParameter;
+
+    /**
+     * Instantiates a new Job Parameter Response
+     *
+     * @param jobParameter the job parameter parsed from the extension
+     */
+    public JobParameterResponse(ExtensionJobParameter jobParameter) {
+        this.jobParameter = jobParameter;
+    }
+
+    /**
+     * Instantiates a new Job Parameter Response from {@link StreamInput}
+     *
+     * @param in is the byte stream input used to de-serialize the message.
+     * @throws IOException IOException when message de-serialization fails.
+     */
+    public JobParameterResponse(StreamInput in) throws IOException {
+        this.jobParameter = new ExtensionJobParameter(in);
+    }
+
+    /**
+     * Instantiates a new Job Parameter Response by wrapping the given byte array within a {@link StreamInput}
+     *
+     * @param responseParams in bytes array used to de-serialize the message.
+     * @throws IOException when message de-serialization fails.
+     */
+    public JobParameterResponse(byte[] responseParams) throws IOException {
+        this(StreamInput.wrap(responseParams));
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        this.jobParameter.writeTo(out);
+    }
+
+    public ExtensionJobParameter getJobParameter() {
+        return this.jobParameter;
+    }
+}

--- a/src/main/java/org/opensearch/jobscheduler/transport/JobRunnerRequest.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/JobRunnerRequest.java
@@ -24,6 +24,11 @@ import org.opensearch.jobscheduler.spi.ScheduledJobParameter;
 public class JobRunnerRequest implements Writeable {
 
     /**
+     * accessToken is the placeholder for the user Identity/access token to be used to perform validation prior to invoking the extension action
+     */
+    private final String accessToken;
+
+    /**
      * jobParameter is job index entry intended to be used to validate prior to job execution
      */
     private final ExtensionJobParameter jobParameter;
@@ -39,7 +44,8 @@ public class JobRunnerRequest implements Writeable {
      * @param jobParameter the ScheduledJobParameter to convert into a writeable ExtensionJobParameter
      * @param jobExecutionContext the context used to facilitate a job run
      */
-    public JobRunnerRequest(ScheduledJobParameter jobParameter, JobExecutionContext jobExecutionContext) {
+    public JobRunnerRequest(String accessToken, ScheduledJobParameter jobParameter, JobExecutionContext jobExecutionContext) {
+        this.accessToken = accessToken;
         this.jobParameter = new ExtensionJobParameter(jobParameter);
         this.jobExecutionContext = jobExecutionContext;
     }
@@ -51,6 +57,7 @@ public class JobRunnerRequest implements Writeable {
      * @throws IOException IOException when message de-serialization fails.
      */
     public JobRunnerRequest(StreamInput in) throws IOException {
+        this.accessToken = in.readString();
         this.jobParameter = new ExtensionJobParameter(in);
         this.jobExecutionContext = new JobExecutionContext(in);
     }
@@ -67,8 +74,13 @@ public class JobRunnerRequest implements Writeable {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(this.accessToken);
         this.jobParameter.writeTo(out);
         this.jobExecutionContext.writeTo(out);
+    }
+
+    public String getAccessToken() {
+        return this.accessToken;
     }
 
     public ExtensionJobParameter getJobParameter() {

--- a/src/main/java/org/opensearch/jobscheduler/transport/JobRunnerRequest.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/JobRunnerRequest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.jobscheduler.transport;
+
+import java.io.IOException;
+
+import org.opensearch.common.bytes.BytesReference;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.extensions.action.ExtensionActionRequest;
+import org.opensearch.jobscheduler.model.ExtensionJobParameter;
+import org.opensearch.jobscheduler.spi.JobExecutionContext;
+import org.opensearch.jobscheduler.spi.ScheduledJobParameter;
+import org.opensearch.jobscheduler.spi.schedule.Schedule;
+
+import java.time.Instant;
+
+/**
+ * Request to extensions to invoke their ScheduledJobRunner implementation
+ */
+public class JobRunnerRequest extends ExtensionActionRequest {
+
+    public JobRunnerRequest(String extensionActionName, ScheduledJobParameter jobParameter, JobExecutionContext jobExecutionContext)
+        throws IOException {
+        super(extensionActionName, convertParamsToBytes(jobParameter, jobExecutionContext));
+    }
+
+    public static byte[] convertParamsToBytes(ScheduledJobParameter jobParameter, JobExecutionContext jobExecutionContext)
+        throws IOException {
+
+        // Convert job Parameter into writeable ExtensionJobParameter
+        String jobName = jobParameter.getName();
+        Instant lastUpdateTime = jobParameter.getLastUpdateTime();
+        Instant enabledTime = jobParameter.getEnabledTime();
+        Schedule schedule = jobParameter.getSchedule();
+        boolean isEnabled = jobParameter.isEnabled();
+        Long lockDurationSeconds = jobParameter.getLockDurationSeconds();
+        Double jitter = jobParameter.getJitter();
+
+        ExtensionJobParameter extensionJobParameter = new ExtensionJobParameter(
+            jobName,
+            schedule,
+            lastUpdateTime,
+            enabledTime,
+            isEnabled,
+            lockDurationSeconds,
+            jitter
+        );
+
+        // Write all params to an output stream
+        BytesStreamOutput out = new BytesStreamOutput();
+        extensionJobParameter.writeTo(out);
+        jobExecutionContext.writeTo(out);
+        out.flush();
+
+        // Convert bytes stream to byte array
+        return BytesReference.toBytes(out.bytes());
+    }
+}

--- a/src/main/java/org/opensearch/jobscheduler/transport/JobRunnerRequest.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/JobRunnerRequest.java
@@ -18,9 +18,8 @@ import org.opensearch.jobscheduler.spi.JobExecutionContext;
 import org.opensearch.jobscheduler.spi.ScheduledJobParameter;
 
 /**
- * Request to extensions to invoke their {@link ScheduledJobRunner} implementation
+ * Request to extensions to invoke their ScheduledJobRunner implementation
  *
- * @opensearch.internal
  */
 public class JobRunnerRequest implements Writeable {
 

--- a/src/main/java/org/opensearch/jobscheduler/transport/JobRunnerRequest.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/JobRunnerRequest.java
@@ -13,9 +13,7 @@ import java.io.IOException;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.io.stream.Writeable;
-import org.opensearch.jobscheduler.model.ExtensionJobParameter;
 import org.opensearch.jobscheduler.spi.JobExecutionContext;
-import org.opensearch.jobscheduler.spi.ScheduledJobParameter;
 
 /**
  * Request to extensions to invoke their ScheduledJobRunner implementation
@@ -29,9 +27,9 @@ public class JobRunnerRequest implements Writeable {
     private final String accessToken;
 
     /**
-     * jobParameter is job index entry intended to be used to validate prior to job execution
+     * jobParameterDocumentId is job index entry id
      */
-    private final ExtensionJobParameter jobParameter;
+    private final String jobParameterDocumentId;
 
     /**
      * jobExecutionContext holds the metadata to configure a job execution
@@ -41,12 +39,13 @@ public class JobRunnerRequest implements Writeable {
     /**
      * Instantiates a new Job Runner Request
      *
-     * @param jobParameter the ScheduledJobParameter to convert into a writeable ExtensionJobParameter
+     * @param accessToken the access token of this request
+     * @param jobParameterDocumentId the document id of the job parameter
      * @param jobExecutionContext the context used to facilitate a job run
      */
-    public JobRunnerRequest(String accessToken, ScheduledJobParameter jobParameter, JobExecutionContext jobExecutionContext) {
+    public JobRunnerRequest(String accessToken, String jobParameterDocumentId, JobExecutionContext jobExecutionContext) {
         this.accessToken = accessToken;
-        this.jobParameter = new ExtensionJobParameter(jobParameter);
+        this.jobParameterDocumentId = jobParameterDocumentId;
         this.jobExecutionContext = jobExecutionContext;
     }
 
@@ -58,7 +57,7 @@ public class JobRunnerRequest implements Writeable {
      */
     public JobRunnerRequest(StreamInput in) throws IOException {
         this.accessToken = in.readString();
-        this.jobParameter = new ExtensionJobParameter(in);
+        this.jobParameterDocumentId = in.readString();
         this.jobExecutionContext = new JobExecutionContext(in);
     }
 
@@ -75,7 +74,7 @@ public class JobRunnerRequest implements Writeable {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(this.accessToken);
-        this.jobParameter.writeTo(out);
+        out.writeString(this.jobParameterDocumentId);
         this.jobExecutionContext.writeTo(out);
     }
 
@@ -83,8 +82,8 @@ public class JobRunnerRequest implements Writeable {
         return this.accessToken;
     }
 
-    public ExtensionJobParameter getJobParameter() {
-        return this.jobParameter;
+    public String getJobParameterDocumentId() {
+        return this.jobParameterDocumentId;
     }
 
     public JobExecutionContext getJobExecutionContext() {

--- a/src/main/java/org/opensearch/jobscheduler/transport/JobRunnerRequest.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/JobRunnerRequest.java
@@ -18,21 +18,52 @@ import org.opensearch.jobscheduler.spi.JobExecutionContext;
 import org.opensearch.jobscheduler.spi.ScheduledJobParameter;
 
 /**
- * Request to extensions to invoke their ScheduledJobRunner implementation
+ * Request to extensions to invoke their {@link ScheduledJobRunner} implementation
+ *
+ * @opensearch.internal
  */
 public class JobRunnerRequest implements Writeable {
 
+    /**
+     * jobParameter is job index entry intended to be used to validate prior to job execution
+     */
     private final ExtensionJobParameter jobParameter;
+
+    /**
+     * jobExecutionContext holds the metadata to configure a job execution
+     */
     private final JobExecutionContext jobExecutionContext;
 
+    /**
+     * Instantiates a new Job Runner Request
+     *
+     * @param jobParameter the ScheduledJobParameter to convert into a writeable ExtensionJobParameter
+     * @param jobExecutionContext the context used to facilitate a job run
+     */
     public JobRunnerRequest(ScheduledJobParameter jobParameter, JobExecutionContext jobExecutionContext) {
         this.jobParameter = new ExtensionJobParameter(jobParameter);
         this.jobExecutionContext = jobExecutionContext;
     }
 
+    /**
+     * Instantiates a new Job Runner Request from {@link StreamInput}
+     *
+     * @param in in bytes stream input used to de-serialize the message.
+     * @throws IOException IOException when message de-serialization fails.
+     */
     public JobRunnerRequest(StreamInput in) throws IOException {
         this.jobParameter = new ExtensionJobParameter(in);
         this.jobExecutionContext = new JobExecutionContext(in);
+    }
+
+    /**
+     * Instantiates a new Job Runner Request by wrapping the given byte array within a {@link StreamInput}
+     *
+     * @param requestParams in bytes array used to de-serialize the message.
+     * @throws IOException when message de-serialization fails.
+     */
+    public JobRunnerRequest(byte[] requestParams) throws IOException {
+        this(StreamInput.wrap(requestParams));
     }
 
     @Override

--- a/src/main/java/org/opensearch/jobscheduler/transport/JobRunnerRequest.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/JobRunnerRequest.java
@@ -53,7 +53,7 @@ public class JobRunnerRequest implements Writeable {
     /**
      * Instantiates a new Job Runner Request from {@link StreamInput}
      *
-     * @param in in bytes stream input used to de-serialize the message.
+     * @param in is the byte stream input used to de-serialize the message.
      * @throws IOException IOException when message de-serialization fails.
      */
     public JobRunnerRequest(StreamInput in) throws IOException {

--- a/src/main/java/org/opensearch/jobscheduler/transport/JobRunnerResponse.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/JobRunnerResponse.java
@@ -28,7 +28,7 @@ public class JobRunnerResponse implements Writeable {
     /**
      * Instantiates a new Job Runner Response
      *
-     * @param jobParameter the job parameter parsed from the extension
+     * @param jobRunnerStatus the run status of the extension job runner
      */
     public JobRunnerResponse(boolean jobRunnerStatus) {
         this.jobRunnerStatus = jobRunnerStatus;

--- a/src/main/java/org/opensearch/jobscheduler/transport/JobRunnerResponse.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/JobRunnerResponse.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.jobscheduler.transport;
+
+import java.io.IOException;
+
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.io.stream.Writeable;
+
+/**
+ * Response from extensions indicating the status of the ScheduledJobRunner invocation
+ *
+ */
+public class JobRunnerResponse implements Writeable {
+
+    /**
+     * jobRunnerStatus indicates if the extension job runner has been executed
+     */
+    private final boolean jobRunnerStatus;
+
+    /**
+     * Instantiates a new Job Runner Response
+     *
+     * @param jobParameter the job parameter parsed from the extension
+     */
+    public JobRunnerResponse(boolean jobRunnerStatus) {
+        this.jobRunnerStatus = jobRunnerStatus;
+    }
+
+    /**
+     * Instantiates a new Job Runner Response from {@link StreamInput}
+     *
+     * @param in is the byte stream input used to de-serialize the message.
+     * @throws IOException IOException when message de-serialization fails.
+     */
+    public JobRunnerResponse(StreamInput in) throws IOException {
+        this.jobRunnerStatus = in.readBoolean();
+    }
+
+    /**
+     * Instantiates a new Job Runner Response by wrapping the given byte array within a {@link StreamInput}
+     *
+     * @param responseParams in bytes array used to de-serialize the message.
+     * @throws IOException when message de-serialization fails.
+     */
+    public JobRunnerResponse(byte[] responseParams) throws IOException {
+        this(StreamInput.wrap(responseParams));
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeBoolean(this.jobRunnerStatus);
+    }
+
+    public boolean getJobRunnerStatus() {
+        return this.jobRunnerStatus;
+    }
+
+}

--- a/src/main/java/org/opensearch/jobscheduler/utils/JobDetailsService.java
+++ b/src/main/java/org/opensearch/jobscheduler/utils/JobDetailsService.java
@@ -99,6 +99,11 @@ public class JobDetailsService implements IndexingOperationListener {
         this.indicesToListen.add(jobIndexName);
     }
 
+    /**
+     * Creates a proxy {@link ScheduledJobProvier} that facilitates callbacks between extensions and JobScheduler
+     *
+     * @param jobDetails the extension job information
+     */
     private void updateIndexToJobProviders(JobDetails jobDetails) {
 
         // Extract jobIndex and jobType

--- a/src/main/java/org/opensearch/jobscheduler/utils/JobDetailsService.java
+++ b/src/main/java/org/opensearch/jobscheduler/utils/JobDetailsService.java
@@ -95,6 +95,10 @@ public class JobDetailsService implements IndexingOperationListener {
         return JobDetailsService.indexToJobDetails;
     }
 
+    public Map<String, ScheduledJobProvider> getIndexToJobProviders() {
+        return this.indexToJobProviders;
+    }
+
     public boolean jobDetailsIndexExist() {
         return clusterService.state().routingTable().hasIndex(JOB_DETAILS_INDEX_NAME);
     }
@@ -108,7 +112,7 @@ public class JobDetailsService implements IndexingOperationListener {
      *
      * @param jobDetails the extension job information
      */
-    private void updateIndexToJobProviders(JobDetails jobDetails) {
+    void updateIndexToJobProviders(JobDetails jobDetails) {
 
         String extensionJobIndex = jobDetails.getJobIndex();
         String extensionJobType = jobDetails.getJobType();

--- a/src/main/java/org/opensearch/jobscheduler/utils/JobDetailsService.java
+++ b/src/main/java/org/opensearch/jobscheduler/utils/JobDetailsService.java
@@ -153,7 +153,7 @@ public class JobDetailsService implements IndexingOperationListener {
                 CompletableFuture<ExtensionJobParameter[]> inProgressFuture = new CompletableFuture<>();
 
                 // TODO : Replace the placeholder with the provided access token from the inital job detials request
-                
+
                 // Prepare JobParameterRequest
                 JobParameterRequest jobParamRequest = new JobParameterRequest("placeholder", xContentParser, id, jobDocVersion);
 

--- a/src/main/java/org/opensearch/jobscheduler/utils/JobDetailsService.java
+++ b/src/main/java/org/opensearch/jobscheduler/utils/JobDetailsService.java
@@ -153,6 +153,7 @@ public class JobDetailsService implements IndexingOperationListener {
                 CompletableFuture<ExtensionJobParameter[]> inProgressFuture = new CompletableFuture<>();
 
                 // TODO : Replace the placeholder with the provided access token from the inital job detials request
+                
                 // Prepare JobParameterRequest
                 JobParameterRequest jobParamRequest = new JobParameterRequest("placeholder", xContentParser, id, jobDocVersion);
 
@@ -168,8 +169,10 @@ public class JobDetailsService implements IndexingOperationListener {
                         inProgressFuture.complete(extensionJobParameterHolder);
 
                     }, exception -> {
+
                         logger.error("Could not parse job parameter", exception);
                         inProgressFuture.completeExceptionally(exception);
+
                     })
                 );
 
@@ -196,7 +199,7 @@ public class JobDetailsService implements IndexingOperationListener {
      * Creates a proxy ScheduledJobRunner that triggers an extension's jobRunner action
      *
      * @param extensionUniqueId the extension to trigger the job runner action
-     * @param extensionJobRunnerAction the job parameter action name
+     * @param extensionJobRunnerAction the job runner action name
      */
     private ScheduledJobRunner createProxyScheduledJobRunner(String extensionUniqueId, String extensionJobRunnerAction) {
         return new ScheduledJobRunner() {
@@ -210,8 +213,10 @@ public class JobDetailsService implements IndexingOperationListener {
 
                 try {
                     // TODO : Replace the placeholder with the provided access token from the inital job detials request
+
                     // Prepare JobRunnerRequest
                     JobRunnerRequest jobRunnerRequest = new JobRunnerRequest("placeholder", jobParameter, context);
+
                     // Invoke extension job runner action
                     client.execute(
                         ExtensionProxyAction.INSTANCE,
@@ -224,8 +229,10 @@ public class JobDetailsService implements IndexingOperationListener {
                             inProgressFuture.complete(extensionJobRunnerStatus);
 
                         }, exception -> {
+
                             logger.error("Failed to run job due to exception ", exception);
                             inProgressFuture.completeExceptionally(exception);
+
                         })
                     );
 

--- a/src/main/java/org/opensearch/jobscheduler/utils/JobDetailsService.java
+++ b/src/main/java/org/opensearch/jobscheduler/utils/JobDetailsService.java
@@ -123,8 +123,9 @@ public class JobDetailsService implements IndexingOperationListener {
                 final ExtensionJobParameter[] extensionJobParameterHolder = new ExtensionJobParameter[1];
                 CompletableFuture<ExtensionJobParameter[]> inProgressFuture = new CompletableFuture<>();
 
+                // TODO : Replace the placeholder with the provided access token from the inital job detials request
                 // Prepare JobParameterRequest
-                JobParameterRequest jobParamRequest = new JobParameterRequest(xContentParser, id, jobDocVersion);
+                JobParameterRequest jobParamRequest = new JobParameterRequest("placeholder", xContentParser, id, jobDocVersion);
 
                 // Invoke extension job parameter action and return ScheduledJobParameter
                 client.execute(
@@ -168,8 +169,9 @@ public class JobDetailsService implements IndexingOperationListener {
                 CompletableFuture<Boolean> inProgressFuture = new CompletableFuture<>();
 
                 try {
+                    // TODO : Replace the placeholder with the provided access token from the inital job detials request
                     // Prepare JobRunnerRequest
-                    JobRunnerRequest jobRunnerRequest = new JobRunnerRequest(jobParameter, context);
+                    JobRunnerRequest jobRunnerRequest = new JobRunnerRequest("placeholder", jobParameter, context);
                     // Invoke extension job runner action
                     client.execute(
                         ExtensionProxyAction.INSTANCE,

--- a/src/test/java/org/opensearch/jobscheduler/utils/JobDetailsServiceIT.java
+++ b/src/test/java/org/opensearch/jobscheduler/utils/JobDetailsServiceIT.java
@@ -245,6 +245,32 @@ public class JobDetailsServiceIT extends OpenSearchIntegTestCase {
 
     }
 
+    public void testUpdateIndexToJobProviders() {
+        JobDetailsService jobDetailsService = new JobDetailsService(
+            client(),
+            this.clusterService,
+            this.indicesToListen,
+            this.indexToJobProviders
+        );
+        JobDetails jobDetails = new JobDetails(
+            expectedJobIndex,
+            expectedJobType,
+            expectedJobParamAction,
+            expectedJobRunnerAction,
+            expectedExtensionUniqueId
+        );
+
+        // Create job provider for given job details entry
+        jobDetailsService.updateIndexToJobProviders(jobDetails);
+
+        // Ensure that the indexToJobProviders is updated
+        ScheduledJobProvider provider = jobDetailsService.getIndexToJobProviders().get(jobDetails.getJobIndex());
+        assertEquals(expectedJobIndex, provider.getJobIndexName());
+        assertEquals(expectedJobType, provider.getJobType());
+        assertNotNull(provider.getJobParser());
+        assertNotNull(provider.getJobRunner());
+    }
+
     private void compareExtensionJobParameters(
         ExtensionJobParameter extensionJobParameter,
         ExtensionJobParameter deserializedJobParameter
@@ -333,7 +359,7 @@ public class JobDetailsServiceIT extends OpenSearchIntegTestCase {
         JobRunnerResponse jobRunnerResponse = new JobRunnerResponse(true);
         ExtensionActionResponse actionResponse = new ExtensionJobActionResponse<JobRunnerResponse>(jobRunnerResponse);
 
-        // Test ExtensionActionRequest deserialization
+        // Test ExtensionActionResponse deserialization
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             actionResponse.writeTo(out);
             out.flush();
@@ -355,7 +381,7 @@ public class JobDetailsServiceIT extends OpenSearchIntegTestCase {
         JobParameterResponse jobParameterResponse = new JobParameterResponse(this.extensionJobParameter);
         ExtensionActionResponse actionResponse = new ExtensionJobActionResponse<JobParameterResponse>(jobParameterResponse);
 
-        // Test ExtensionActionRequest deserialization
+        // Test ExtensionActionReseponse deserialization
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             actionResponse.writeTo(out);
             out.flush();

--- a/src/test/java/org/opensearch/jobscheduler/utils/JobDetailsServiceIT.java
+++ b/src/test/java/org/opensearch/jobscheduler/utils/JobDetailsServiceIT.java
@@ -270,20 +270,29 @@ public class JobDetailsServiceIT extends OpenSearchIntegTestCase {
         JobRunnerRequest jobRunnerRequest = new JobRunnerRequest("placeholder", this.extensionJobParameter, jobExecutionContext);
         ExtensionActionRequest actionRequest = new ExtensionJobActionRequest<JobRunnerRequest>("actionName", jobRunnerRequest);
 
-        // Test deserialization of action request params
-        JobRunnerRequest deserializedRequest = new JobRunnerRequest(actionRequest.getRequestBytes());
+        // Test ExtensionActionRequest deserialization
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            actionRequest.writeTo(out);
+            out.flush();
+            try (BytesStreamInput in = new BytesStreamInput(BytesReference.toBytes(out.bytes()))) {
 
-        // Test deserialization of extension job parameter
-        ExtensionJobParameter deserializedJobParameter = deserializedRequest.getJobParameter();
-        compareExtensionJobParameters(this.extensionJobParameter, deserializedJobParameter);
+                actionRequest = new ExtensionActionRequest(in);
 
-        // Test deserialization of job execution context
-        JobExecutionContext deserializedJobExecutionContext = deserializedRequest.getJobExecutionContext();
-        assertEquals(jobExecutionContext.getJobId(), deserializedJobExecutionContext.getJobId());
-        assertEquals(jobExecutionContext.getJobIndexName(), deserializedJobExecutionContext.getJobIndexName());
-        assertEquals(jobExecutionContext.getExpectedExecutionTime(), deserializedJobExecutionContext.getExpectedExecutionTime());
-        assertEquals(0, jobExecutionContext.getJobVersion().compareTo(deserializedJobExecutionContext.getJobVersion()));
+                // Test deserialization of action request params
+                JobRunnerRequest deserializedRequest = new JobRunnerRequest(actionRequest.getRequestBytes());
 
+                // Test deserialization of extension job parameter
+                ExtensionJobParameter deserializedJobParameter = deserializedRequest.getJobParameter();
+                compareExtensionJobParameters(this.extensionJobParameter, deserializedJobParameter);
+
+                // Test deserialization of job execution context
+                JobExecutionContext deserializedJobExecutionContext = deserializedRequest.getJobExecutionContext();
+                assertEquals(jobExecutionContext.getJobId(), deserializedJobExecutionContext.getJobId());
+                assertEquals(jobExecutionContext.getJobIndexName(), deserializedJobExecutionContext.getJobIndexName());
+                assertEquals(jobExecutionContext.getExpectedExecutionTime(), deserializedJobExecutionContext.getExpectedExecutionTime());
+                assertEquals(0, jobExecutionContext.getJobVersion().compareTo(deserializedJobExecutionContext.getJobVersion()));
+            }
+        }
     }
 
     public void testJobParameterExtensionJobActionRequest() throws IOException {
@@ -297,13 +306,22 @@ public class JobDetailsServiceIT extends OpenSearchIntegTestCase {
         JobParameterRequest jobParamRequest = new JobParameterRequest("placeholder", parser, "id", jobDocVersion);
         ExtensionActionRequest actionRequest = new ExtensionJobActionRequest<JobParameterRequest>("actionName", jobParamRequest);
 
-        // Test deserialization of action request params
-        JobParameterRequest deserializedRequest = new JobParameterRequest(actionRequest.getRequestBytes());
-        assertEquals(jobParamRequest.getId(), deserializedRequest.getId());
-        assertEquals(jobParamRequest.getJobSource(), deserializedRequest.getJobSource());
+        // Test ExtensionActionRequest deserialization
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            actionRequest.writeTo(out);
+            out.flush();
+            try (BytesStreamInput in = new BytesStreamInput(BytesReference.toBytes(out.bytes()))) {
+                actionRequest = new ExtensionActionRequest(in);
 
-        // Test deserialization of job doc version
-        assertEquals(0, jobParamRequest.getJobDocVersion().compareTo(deserializedRequest.getJobDocVersion()));
+                // Test deserialization of action request params
+                JobParameterRequest deserializedRequest = new JobParameterRequest(actionRequest.getRequestBytes());
+                assertEquals(jobParamRequest.getId(), deserializedRequest.getId());
+                assertEquals(jobParamRequest.getJobSource(), deserializedRequest.getJobSource());
+
+                // Test deserialization of job doc version
+                assertEquals(0, jobParamRequest.getJobDocVersion().compareTo(deserializedRequest.getJobDocVersion()));
+            }
+        }
     }
 
     public void testJobRunnerExtensionJobActionResponse() throws IOException {
@@ -312,9 +330,20 @@ public class JobDetailsServiceIT extends OpenSearchIntegTestCase {
         JobRunnerResponse jobRunnerResponse = new JobRunnerResponse(true);
         ExtensionActionResponse actionResponse = new ExtensionJobActionResponse<JobRunnerResponse>(jobRunnerResponse);
 
-        // Test deserialization of action response params
-        JobRunnerResponse deserializedResponse = new JobRunnerResponse(actionResponse.getResponseBytes());
-        assertEquals(jobRunnerResponse.getJobRunnerStatus(), deserializedResponse.getJobRunnerStatus());
+        // Test ExtensionActionRequest deserialization
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            actionRequest.writeTo(out);
+            out.flush();
+            try (BytesStreamInput in = new BytesStreamInput(BytesReference.toBytes(out.bytes()))) {
+
+                actionResponse = new ExtensionActionRequest(in);
+
+                // Test deserialization of action response params
+                JobRunnerResponse deserializedResponse = new JobRunnerResponse(actionResponse.getResponseBytes());
+                assertEquals(jobRunnerResponse.getJobRunnerStatus(), deserializedResponse.getJobRunnerStatus());
+            }
+        }
+
     }
 
     public void testJobParameterExtensionJobActionResponse() throws IOException {
@@ -323,9 +352,19 @@ public class JobDetailsServiceIT extends OpenSearchIntegTestCase {
         JobParameterResponse jobParameterResponse = new JobParameterResponse(this.extensionJobParameter);
         ExtensionActionResponse actionResponse = new ExtensionJobActionResponse<JobParameterResponse>(jobParameterResponse);
 
-        // Test deserialization of action response params
-        JobParameterResponse deserializedResponse = new JobParameterResponse(actionResponse.getResponseBytes());
-        compareExtensionJobParameters(this.extensionJobParameter, deserializedResponse.getJobParameter());
+        // Test ExtensionActionRequest deserialization
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            actionRequest.writeTo(out);
+            out.flush();
+            try (BytesStreamInput in = new BytesStreamInput(BytesReference.toBytes(out.bytes()))) {
+
+                actionResponse = new ExtensionActionRequest(in);
+
+                // Test deserialization of action response params
+                JobParameterResponse deserializedResponse = new JobParameterResponse(actionResponse.getResponseBytes());
+                compareExtensionJobParameters(this.extensionJobParameter, deserializedResponse.getJobParameter());
+            }
+        }
     }
 
 }

--- a/src/test/java/org/opensearch/jobscheduler/utils/JobDetailsServiceIT.java
+++ b/src/test/java/org/opensearch/jobscheduler/utils/JobDetailsServiceIT.java
@@ -8,7 +8,9 @@
  */
 package org.opensearch.jobscheduler.utils;
 
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -20,11 +22,13 @@ import org.opensearch.action.ActionListener;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.jobscheduler.model.JobDetails;
 import org.opensearch.test.OpenSearchIntegTestCase;
+import org.opensearch.jobscheduler.ScheduledJobProvider;
 
 public class JobDetailsServiceIT extends OpenSearchIntegTestCase {
 
     private ClusterService clusterService;
     private Set<String> indicesToListen;
+    private Map<String, ScheduledJobProvider> indexToJobProviders;
 
     private String expectedJobIndex;
     private String expectedJobType;
@@ -43,6 +47,7 @@ public class JobDetailsServiceIT extends OpenSearchIntegTestCase {
             .thenReturn(true);
 
         this.indicesToListen = new HashSet<>();
+        this.indexToJobProviders = new HashMap<>();
 
         this.expectedJobIndex = "sample-job-index";
         this.expectedJobType = "sample-job-type";
@@ -56,7 +61,12 @@ public class JobDetailsServiceIT extends OpenSearchIntegTestCase {
 
     public void testGetJobDetailsSanity() throws ExecutionException, InterruptedException, TimeoutException {
         CompletableFuture<Boolean> inProgressFuture = new CompletableFuture<>();
-        JobDetailsService jobDetailsService = new JobDetailsService(client(), this.clusterService, this.indicesToListen);
+        JobDetailsService jobDetailsService = new JobDetailsService(
+            client(),
+            this.clusterService,
+            this.indicesToListen,
+            this.indexToJobProviders
+        );
 
         jobDetailsService.processJobDetails(
             null,
@@ -87,7 +97,12 @@ public class JobDetailsServiceIT extends OpenSearchIntegTestCase {
 
     public void testUpdateJobDetailsSanity() throws ExecutionException, InterruptedException, TimeoutException {
         CompletableFuture<String> inProgressFuture = new CompletableFuture<>();
-        JobDetailsService jobDetailsService = new JobDetailsService(client(), this.clusterService, this.indicesToListen);
+        JobDetailsService jobDetailsService = new JobDetailsService(
+            client(),
+            this.clusterService,
+            this.indicesToListen,
+            this.indexToJobProviders
+        );
 
         // Create initial index request
         jobDetailsService.processJobDetails(
@@ -124,7 +139,12 @@ public class JobDetailsServiceIT extends OpenSearchIntegTestCase {
     }
 
     public void testDeleteJobDetailsWithOutDocumentIdCreation() throws ExecutionException, InterruptedException, TimeoutException {
-        JobDetailsService jobDetailsService = new JobDetailsService(client(), this.clusterService, this.indicesToListen);
+        JobDetailsService jobDetailsService = new JobDetailsService(
+            client(),
+            this.clusterService,
+            this.indicesToListen,
+            this.indexToJobProviders
+        );
         jobDetailsService.deleteJobDetails(
             expectedDocumentId,
             ActionListener.wrap(
@@ -135,7 +155,12 @@ public class JobDetailsServiceIT extends OpenSearchIntegTestCase {
     }
 
     public void testDeleteNonExistingJobDetails() throws ExecutionException, InterruptedException, TimeoutException {
-        JobDetailsService jobDetailsService = new JobDetailsService(client(), this.clusterService, this.indicesToListen);
+        JobDetailsService jobDetailsService = new JobDetailsService(
+            client(),
+            this.clusterService,
+            this.indicesToListen,
+            this.indexToJobProviders
+        );
         jobDetailsService.createJobDetailsIndex(ActionListener.wrap(created -> {
             if (created) {
                 jobDetailsService.deleteJobDetails(
@@ -154,7 +179,12 @@ public class JobDetailsServiceIT extends OpenSearchIntegTestCase {
 
     public void testUpdateIndexToJobDetails() throws ExecutionException, InterruptedException, TimeoutException {
 
-        JobDetailsService jobDetailsService = new JobDetailsService(client(), this.clusterService, this.indicesToListen);
+        JobDetailsService jobDetailsService = new JobDetailsService(
+            client(),
+            this.clusterService,
+            this.indicesToListen,
+            this.indexToJobProviders
+        );
         JobDetails jobDetails = new JobDetails(
             expectedJobIndex,
             expectedJobType,

--- a/src/test/java/org/opensearch/jobscheduler/utils/JobDetailsServiceIT.java
+++ b/src/test/java/org/opensearch/jobscheduler/utils/JobDetailsServiceIT.java
@@ -261,7 +261,7 @@ public class JobDetailsServiceIT extends OpenSearchIntegTestCase {
         );
 
         // Create job provider for given job details entry
-        jobDetailsService.updateIndexToJobProviders(jobDetails);
+        jobDetailsService.updateIndexToJobProviders("documentId", jobDetails);
 
         // Ensure that the indexToJobProviders is updated
         ScheduledJobProvider provider = jobDetailsService.getIndexToJobProviders().get(jobDetails.getJobIndex());
@@ -294,9 +294,10 @@ public class JobDetailsServiceIT extends OpenSearchIntegTestCase {
             "indexName",
             "id"
         );
+        String documentId = "documentId";
 
         // Create JobRunner Request
-        JobRunnerRequest jobRunnerRequest = new JobRunnerRequest("placeholder", this.extensionJobParameter, jobExecutionContext);
+        JobRunnerRequest jobRunnerRequest = new JobRunnerRequest("placeholder", documentId, jobExecutionContext);
         ExtensionActionRequest actionRequest = new ExtensionJobActionRequest<JobRunnerRequest>("actionName", jobRunnerRequest);
 
         // Test ExtensionActionRequest deserialization
@@ -310,9 +311,9 @@ public class JobDetailsServiceIT extends OpenSearchIntegTestCase {
                 // Test deserialization of action request params
                 JobRunnerRequest deserializedRequest = new JobRunnerRequest(actionRequest.getRequestBytes());
 
-                // Test deserialization of extension job parameter
-                ExtensionJobParameter deserializedJobParameter = deserializedRequest.getJobParameter();
-                compareExtensionJobParameters(this.extensionJobParameter, deserializedJobParameter);
+                // Test deserialization of extension job parameter document Id
+                String deserializedDocumentId = deserializedRequest.getJobParameterDocumentId();
+                assertEquals(documentId, deserializedDocumentId);
 
                 // Test deserialization of job execution context
                 JobExecutionContext deserializedJobExecutionContext = deserializedRequest.getJobExecutionContext();

--- a/src/test/java/org/opensearch/jobscheduler/utils/JobDetailsServiceIT.java
+++ b/src/test/java/org/opensearch/jobscheduler/utils/JobDetailsServiceIT.java
@@ -339,7 +339,7 @@ public class JobDetailsServiceIT extends OpenSearchIntegTestCase {
             out.flush();
             try (BytesStreamInput in = new BytesStreamInput(BytesReference.toBytes(out.bytes()))) {
 
-                actionResponse = new ExtensionActionRequest(in);
+                actionResponse = new ExtensionActionResponse(in);
 
                 // Test deserialization of action response params
                 JobRunnerResponse deserializedResponse = new JobRunnerResponse(actionResponse.getResponseBytes());
@@ -361,7 +361,7 @@ public class JobDetailsServiceIT extends OpenSearchIntegTestCase {
             out.flush();
             try (BytesStreamInput in = new BytesStreamInput(BytesReference.toBytes(out.bytes()))) {
 
-                actionResponse = new ExtensionActionRequest(in);
+                actionResponse = new ExtensionActionResponse(in);
 
                 // Test deserialization of action response params
                 JobParameterResponse deserializedResponse = new JobParameterResponse(actionResponse.getResponseBytes());

--- a/src/test/java/org/opensearch/jobscheduler/utils/JobDetailsServiceIT.java
+++ b/src/test/java/org/opensearch/jobscheduler/utils/JobDetailsServiceIT.java
@@ -23,6 +23,9 @@ import org.junit.Before;
 import org.mockito.Mockito;
 import org.opensearch.action.ActionListener;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.bytes.BytesReference;
+import org.opensearch.common.io.stream.BytesStreamInput;
+import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
 import org.opensearch.common.xcontent.XContentParser;
@@ -332,7 +335,7 @@ public class JobDetailsServiceIT extends OpenSearchIntegTestCase {
 
         // Test ExtensionActionRequest deserialization
         try (BytesStreamOutput out = new BytesStreamOutput()) {
-            actionRequest.writeTo(out);
+            actionResponse.writeTo(out);
             out.flush();
             try (BytesStreamInput in = new BytesStreamInput(BytesReference.toBytes(out.bytes()))) {
 
@@ -354,7 +357,7 @@ public class JobDetailsServiceIT extends OpenSearchIntegTestCase {
 
         // Test ExtensionActionRequest deserialization
         try (BytesStreamOutput out = new BytesStreamOutput()) {
-            actionRequest.writeTo(out);
+            actionResponse.writeTo(out);
             out.flush();
             try (BytesStreamInput in = new BytesStreamInput(BytesReference.toBytes(out.bytes()))) {
 


### PR DESCRIPTION
### Description
Updates the `indexToJobProviders` with a proxy `ScheduledJobProvider` entry for an extension. Whenever a `JobDetails` entry is indexed, the entry is pulled and registered within an `indexToJobDetails`, updates the `indicesToListen` set with the registered job index, creates a Proxy `ScheduledJobRunner` to invoke the extension's `runJob` implementation, and a Proxy `ScheduledJobParser` to invoke the extension's `parse` implementation.

These actions are invoked via the `ExtensionProxyAction`, which is registered by the `ExtensionsManager` during bootstrap and delegates these requests to the originating extension. 
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-sdk-java/issues/309
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
