### PR TITLE
Adding XContentType.JSON to Strings.toString()

### DIFF
--- a/spi/src/main/java/org/opensearch/jobscheduler/spi/LockModel.java
+++ b/spi/src/main/java/org/opensearch/jobscheduler/spi/LockModel.java
@@ -13,6 +13,7 @@ import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.common.xcontent.XContentParserUtils;
+import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.seqno.SequenceNumbers;
 
 import java.io.IOException;
@@ -173,7 +174,7 @@ public final class LockModel implements ToXContentObject {
 
     @Override
     public String toString() {
-        return Strings.toString(this, false, true);
+        return Strings.toString(XContentType.JSON, this, false, true);
     }
 
     public String getLockId() {

--- a/spi/src/main/java/org/opensearch/jobscheduler/spi/schedule/CronSchedule.java
+++ b/spi/src/main/java/org/opensearch/jobscheduler/spi/schedule/CronSchedule.java
@@ -18,6 +18,7 @@ import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 import java.time.Clock;
@@ -180,7 +181,7 @@ public class CronSchedule implements Schedule {
 
     @Override
     public String toString() {
-        return Strings.toString(this, false, true);
+        return Strings.toString(XContentType.JSON, this, false, true);
     }
 
     @Override

--- a/spi/src/main/java/org/opensearch/jobscheduler/spi/schedule/IntervalSchedule.java
+++ b/spi/src/main/java/org/opensearch/jobscheduler/spi/schedule/IntervalSchedule.java
@@ -15,6 +15,7 @@ import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 import java.time.Clock;
@@ -188,7 +189,7 @@ public class IntervalSchedule implements Schedule {
 
     @Override
     public String toString() {
-        return Strings.toString(this, false, true);
+        return Strings.toString(XContentType.JSON, this, false, true);
     }
 
     @Override


### PR DESCRIPTION
Signed-off-by: Joshua Palis <jpalis@amazon.com>

### Description
Adds XContentType.JSON parameter to `Strings.toStrings` due to changes to `org.opensearch.common.Strings`.
https://github.com/opensearch-project/OpenSearch/pull/6009
 
### Issues Resolved
https://github.com/opensearch-project/job-scheduler/issues/308
 
### Check List
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
