### PR TITLE
[Extensions] Exposes a GetLock REST API to enable extensions to acquire a lock model for their job execution

### DIFF
--- a/spi/src/main/java/org/opensearch/jobscheduler/spi/LockModel.java
+++ b/spi/src/main/java/org/opensearch/jobscheduler/spi/LockModel.java
@@ -32,6 +32,13 @@ public final class LockModel implements ToXContentObject {
     public static final String LOCK_DURATION = "lock_duration_seconds";
     public static final String RELEASED = "released";
 
+    // Rest Fields
+    public static final String GET_LOCK_ACTION = "get_lock_action";
+    public static final String SEQUENCE_NUMBER = "seq_no";
+    public static final String PRIMARY_TERM = "primary_term";
+    public static final String LOCK_ID = "lock_id";
+    public static final String LOCK_MODEL = "lock_model";
+
     private final String lockId;
     private final String jobIndexName;
     private final String jobId;

--- a/src/main/java/org/opensearch/jobscheduler/JobSchedulerPlugin.java
+++ b/src/main/java/org/opensearch/jobscheduler/JobSchedulerPlugin.java
@@ -16,6 +16,7 @@ import org.opensearch.common.settings.IndexScopedSettings;
 import org.opensearch.common.settings.SettingsFilter;
 
 import org.opensearch.jobscheduler.rest.RestGetJobDetailsAction;
+import org.opensearch.jobscheduler.rest.RestGetLockAction;
 import org.opensearch.jobscheduler.scheduler.JobScheduler;
 import org.opensearch.jobscheduler.spi.JobSchedulerExtension;
 import org.opensearch.jobscheduler.spi.ScheduledJobParser;
@@ -228,7 +229,8 @@ public class JobSchedulerPlugin extends Plugin implements ActionPlugin, Extensib
         Supplier<DiscoveryNodes> nodesInCluster
     ) {
         RestGetJobDetailsAction restGetJobDetailsAction = new RestGetJobDetailsAction(jobDetailsService);
-        return ImmutableList.of(restGetJobDetailsAction);
+        RestGetLockAction restGetLockAction = new RestGetLockAction(lockService);
+        return ImmutableList.of(restGetJobDetailsAction, restGetLockAction);
     }
 
 }

--- a/src/main/java/org/opensearch/jobscheduler/rest/RestGetLockAction.java
+++ b/src/main/java/org/opensearch/jobscheduler/rest/RestGetLockAction.java
@@ -37,16 +37,18 @@ import com.google.common.collect.ImmutableList;
 import static org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.rest.RestRequest.Method.GET;
 
+import static org.opensearch.jobscheduler.spi.LockModel.GET_LOCK_ACTION;
+import static org.opensearch.jobscheduler.spi.LockModel.SEQUENCE_NUMBER;
+import static org.opensearch.jobscheduler.spi.LockModel.SEQUENCE_NUMBER;
+import static org.opensearch.jobscheduler.spi.LockModel.PRIMARY_TERM;
+import static org.opensearch.jobscheduler.spi.LockModel.LOCK_ID;
+import static org.opensearch.jobscheduler.spi.LockModel.LOCK_MODEL;
+
 /**
  * This class consists of the REST handler to GET a lock model for extensions
  */
 public class RestGetLockAction extends BaseRestHandler {
 
-    public static final String GET_LOCK_ACTION = "get_lock_action";
-    public static final String SEQUENCE_NUMBER = "seq_no";
-    public static final String PRIMARY_TERM = "primary_term";
-    public static final String LOCK_ID = "lock_id";
-    public static final String LOCK_MODEL = "lock_model";
     public static LockModel lockModelResponseHolder;
 
     private final Logger logger = LogManager.getLogger(RestGetLockAction.class);
@@ -109,12 +111,12 @@ public class RestGetLockAction extends BaseRestHandler {
         }
 
         return channel -> {
-            // Prepare response
-            XContentBuilder builder = channel.newBuilder();
-            RestStatus restStatus = RestStatus.OK;
-            String restResponseString = lockModelResponseHolder != null ? "success" : "failed";
             BytesRestResponse bytesRestResponse;
-            try {
+            try (XContentBuilder builder = channel.newBuilder()) {
+                // Prepare response
+                RestStatus restStatus = RestStatus.OK;
+                String restResponseString = lockModelResponseHolder != null ? "success" : "failed";
+
                 builder.startObject();
                 builder.field("response", restResponseString);
                 if (restResponseString.equals("success")) {
@@ -133,10 +135,9 @@ public class RestGetLockAction extends BaseRestHandler {
                 }
                 builder.endObject();
                 bytesRestResponse = new BytesRestResponse(restStatus, builder);
-            } finally {
-                builder.close();
+                channel.sendResponse(bytesRestResponse);
             }
-            channel.sendResponse(bytesRestResponse);
+
         };
     }
 }

--- a/src/main/java/org/opensearch/jobscheduler/rest/RestGetLockAction.java
+++ b/src/main/java/org/opensearch/jobscheduler/rest/RestGetLockAction.java
@@ -83,7 +83,8 @@ public class RestGetLockAction extends BaseRestHandler {
         lockService.acquireLockWithId(jobIndexName, lockDurationSeconds, jobIndexName, new ActionListener<>() {
             @Override
             public void onResponse(LockModel lockModel) {
-                // set lockModelResponse
+
+                // set lockModel Response
                 lockModelResponseHolder[0] = lockModel;
                 inProgressFuture.complete(lockModelResponseHolder);
             }

--- a/src/main/java/org/opensearch/jobscheduler/rest/RestGetLockAction.java
+++ b/src/main/java/org/opensearch/jobscheduler/rest/RestGetLockAction.java
@@ -50,7 +50,7 @@ public class RestGetLockAction extends BaseRestHandler {
 
     private final Logger logger = LogManager.getLogger(RestGetLockAction.class);
 
-    public LockService lockService;
+    private LockService lockService;
 
     public RestGetLockAction(final LockService lockService) {
         this.lockService = lockService;

--- a/src/main/java/org/opensearch/jobscheduler/rest/RestGetLockAction.java
+++ b/src/main/java/org/opensearch/jobscheduler/rest/RestGetLockAction.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.jobscheduler.rest;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.ActionListener;
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentParser;
+import org.opensearch.jobscheduler.JobSchedulerPlugin;
+
+import org.opensearch.jobscheduler.transport.AcquireLockRequest;
+import org.opensearch.jobscheduler.utils.JobDetailsService;
+import org.opensearch.jobscheduler.spi.LockModel;
+import org.opensearch.jobscheduler.spi.utils.LockService;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.BytesRestResponse;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.rest.RestStatus;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Locale;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import com.google.common.collect.ImmutableList;
+import static org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.opensearch.rest.RestRequest.Method.GET;
+
+/**
+ * This class consists of the REST handler to GET a lock model for extensions
+ */
+public class RestGetLockAction extends BaseRestHandler {
+
+    private static final String GET_LOCK_ACTION = "get_lock_action";
+    public static final String SEQUENCE_NUMBER = "seq_no";
+    public static final String PRIMARY_TERM = "primary_term";
+    public static final String LOCK_MODEL = "lock_model";
+
+    private final Logger logger = LogManager.getLogger(RestGetLockAction.class);
+
+    public LockService lockService;
+
+    public RestGetLockAction(final LockService lockService) {
+        this.lockService = lockService;
+    }
+
+    @Override
+    public String getName() {
+        return GET_LOCK_ACTION;
+    }
+
+    @Override
+    public List<Route> routes() {
+        return ImmutableList.of(new Route(GET, String.format(Locale.ROOT, "%s/%s", JobSchedulerPlugin.JS_BASE_URI, "_get/_lock")));
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
+        XContentParser parser = restRequest.contentParser();
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+
+        AcquireLockRequest acquireLockRequest = AcquireLockRequest.parse(parser);
+
+        final LockModel[] lockModelResponseHolder = new LockModel[1];
+
+        String jobId = acquireLockRequest.getJobId();
+        String jobIndexName = acquireLockRequest.getJobIndexName();
+        long lockDurationSeconds = acquireLockRequest.getLockDurationSeconds();
+
+        CompletableFuture<LockModel[]> inProgressFuture = new CompletableFuture<>();
+
+        lockService.acquireLockWithId(jobIndexName, lockDurationSeconds, jobIndexName, new ActionListener<>() {
+            @Override
+            public void onResponse(LockModel lockModel) {
+                // set lockModelResponse
+                lockModelResponseHolder[0] = lockModel;
+                inProgressFuture.complete(lockModelResponseHolder);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                logger.info("Could not acquire lock with ID : " + jobId, e);
+                inProgressFuture.completeExceptionally(e);
+            }
+        });
+
+        try {
+            inProgressFuture.orTimeout(JobDetailsService.TIME_OUT_FOR_REQUEST, TimeUnit.SECONDS).join();
+        } catch (CompletionException e) {
+            if (e.getCause() instanceof TimeoutException) {
+                logger.info(" Request timed out with an exception ", e);
+            } else {
+                throw e;
+            }
+        } catch (Exception e) {
+            logger.info(" Could not process acquire lock request due to exception ", e);
+        }
+
+        return channel -> {
+            XContentBuilder builder = channel.newBuilder();
+            RestStatus restStatus = RestStatus.OK;
+            String restResponseString = lockModelResponseHolder[0] != null ? "success" : "failed";
+            BytesRestResponse bytesRestResponse;
+            try {
+                builder.startObject();
+                builder.field("response", restResponseString);
+                if (restResponseString.equals("success")) {
+                    builder.field(LOCK_MODEL, lockModelResponseHolder[0].toString());
+                    builder.field(SEQUENCE_NUMBER, lockModelResponseHolder[0].getSeqNo());
+                    builder.field(PRIMARY_TERM, lockModelResponseHolder[0].getPrimaryTerm());
+                } else {
+                    restStatus = RestStatus.INTERNAL_SERVER_ERROR;
+                }
+                builder.endObject();
+                bytesRestResponse = new BytesRestResponse(restStatus, builder);
+            } finally {
+                builder.close();
+            }
+            channel.sendResponse(bytesRestResponse);
+        };
+    }
+}

--- a/src/main/java/org/opensearch/jobscheduler/rest/RestGetLockAction.java
+++ b/src/main/java/org/opensearch/jobscheduler/rest/RestGetLockAction.java
@@ -42,7 +42,7 @@ import static org.opensearch.rest.RestRequest.Method.GET;
  */
 public class RestGetLockAction extends BaseRestHandler {
 
-    private static final String GET_LOCK_ACTION = "get_lock_action";
+    public static final String GET_LOCK_ACTION = "get_lock_action";
     public static final String SEQUENCE_NUMBER = "seq_no";
     public static final String PRIMARY_TERM = "primary_term";
     public static final String LOCK_ID = "lock_id";
@@ -50,7 +50,7 @@ public class RestGetLockAction extends BaseRestHandler {
 
     private final Logger logger = LogManager.getLogger(RestGetLockAction.class);
 
-    private LockService lockService;
+    public LockService lockService;
 
     public RestGetLockAction(final LockService lockService) {
         this.lockService = lockService;

--- a/src/main/java/org/opensearch/jobscheduler/transport/AcquireLockRequest.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/AcquireLockRequest.java
@@ -17,30 +17,55 @@ import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.common.xcontent.XContentParserUtils;
 
+/**
+ * Request from extensions to acquire a lock for scheduled job execution
+ */
 public class AcquireLockRequest extends ActionRequest {
 
+    /**
+     * the id of the job
+     */
     private final String jobId;
 
+    /**
+     * the name of the job index
+     */
     private final String jobIndexName;
 
+    /**
+     * the duration for which this lock will be acquired
+     */
     private final long lockDurationSeconds;
 
     public static final String JOB_ID = "job_id";
     public static final String JOB_INDEX_NAME = "job_index_name";
     public static final String LOCK_DURATION_SECONDS = "lock_duration_seconds";
 
-    public AcquireLockRequest(StreamInput in) throws IOException {
-        super(in);
-        this.jobId = in.readString();
-        this.jobIndexName = in.readString();
-        this.lockDurationSeconds = in.readLong();
-    }
-
+    /**
+     * Instantiates a new AcquireLockRequest
+     *
+     * @param jobId the id of the job in which the lock will be given to
+     * @param jobIndexName the name of the job index
+     * @param lockDurationSeconds the duration for which this lock will be acquired
+     */
     public AcquireLockRequest(String jobId, String jobIndexName, long lockDurationSeconds) {
         super();
         this.jobId = Objects.requireNonNull(jobId);
         this.jobIndexName = Objects.requireNonNull(jobIndexName);
         this.lockDurationSeconds = Objects.requireNonNull(lockDurationSeconds);
+    }
+
+    /**
+     * Instantiates a new AcquireLockRequest from {@link StreamInput}
+     *
+     * @param in is the byte stream input used to de-serialize the message.
+     * @throws IOException IOException when message de-serialization fails.
+     */
+    public AcquireLockRequest(StreamInput in) throws IOException {
+        super(in);
+        this.jobId = in.readString();
+        this.jobIndexName = in.readString();
+        this.lockDurationSeconds = in.readLong();
     }
 
     @Override

--- a/src/main/java/org/opensearch/jobscheduler/transport/AcquireLockRequest.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/AcquireLockRequest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.jobscheduler.transport;
+
+import java.io.IOException;
+import java.util.Objects;
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.xcontent.XContentParser;
+import org.opensearch.common.xcontent.XContentParserUtils;
+
+public class AcquireLockRequest extends ActionRequest {
+
+    private final String jobId;
+
+    private final String jobIndexName;
+
+    private final long lockDurationSeconds;
+
+    public static final String JOB_ID = "job_id";
+    public static final String JOB_INDEX_NAME = "job_index_name";
+    public static final String LOCK_DURATION_SECONDS = "lock_duration_seconds";
+
+    public AcquireLockRequest(StreamInput in) throws IOException {
+        super(in);
+        this.jobId = in.readString();
+        this.jobIndexName = in.readString();
+        this.lockDurationSeconds = in.readLong();
+    }
+
+    public AcquireLockRequest(String jobId, String jobIndexName, long lockDurationSeconds) {
+        super();
+        this.jobId = Objects.requireNonNull(jobId);
+        this.jobIndexName = Objects.requireNonNull(jobIndexName);
+        this.lockDurationSeconds = Objects.requireNonNull(lockDurationSeconds);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(this.jobId);
+        out.writeString(this.jobIndexName);
+        out.writeLong(this.lockDurationSeconds);
+    }
+
+    public String getJobId() {
+        return this.jobId;
+    }
+
+    public String getJobIndexName() {
+        return this.jobIndexName;
+    }
+
+    public long getLockDurationSeconds() {
+        return this.lockDurationSeconds;
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        return null;
+    }
+
+    public static AcquireLockRequest parse(XContentParser parser) throws IOException {
+
+        String jobId = null;
+        String jobIndexName = null;
+        Long lockDurationSeconds = null;
+
+        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
+        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            String fieldName = parser.currentName();
+            parser.nextToken();
+
+            switch (fieldName) {
+                case JOB_ID:
+                    jobId = parser.text();
+                    break;
+                case JOB_INDEX_NAME:
+                    jobIndexName = parser.text();
+                    break;
+                case LOCK_DURATION_SECONDS:
+                    lockDurationSeconds = parser.longValue();
+                    break;
+                default:
+                    parser.skipChildren();
+                    break;
+            }
+        }
+        return new AcquireLockRequest(jobId, jobIndexName, lockDurationSeconds);
+    }
+
+}

--- a/src/test/java/org/opensearch/jobscheduler/TestHelpers.java
+++ b/src/test/java/org/opensearch/jobscheduler/TestHelpers.java
@@ -29,7 +29,7 @@ import org.opensearch.common.xcontent.XContentFactory;
 public class TestHelpers {
 
     public static final String GET_JOB_DETAILS_BASE_URI = "/_plugins/_job_scheduler/_get/_job_details";
-    public static final String GET_LOCK_BASE_URI = "/_plugins/_job_scheduler/_get/_lock";
+    public static final String GET_LOCK_BASE_URI = "/_plugins/_job_scheduler/_lock";
 
     public static String xContentBuilderToString(XContentBuilder builder) {
         return BytesReference.bytes(builder).utf8ToString();

--- a/src/test/java/org/opensearch/jobscheduler/TestHelpers.java
+++ b/src/test/java/org/opensearch/jobscheduler/TestHelpers.java
@@ -29,6 +29,7 @@ import org.opensearch.common.xcontent.XContentFactory;
 public class TestHelpers {
 
     public static final String GET_JOB_DETAILS_BASE_URI = "/_plugins/_job_scheduler/_get/_job_details";
+    public static final String GET_LOCK_BASE_URI = "/_plugins/_job_scheduler/_get/_lock";
 
     public static String xContentBuilderToString(XContentBuilder builder) {
         return BytesReference.bytes(builder).utf8ToString();

--- a/src/test/java/org/opensearch/jobscheduler/multinode/GetLockMultiNodeRestIT.java
+++ b/src/test/java/org/opensearch/jobscheduler/multinode/GetLockMultiNodeRestIT.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.jobscheduler.multinode;
+
+import com.google.common.collect.ImmutableMap;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Map;
+import org.opensearch.client.Response;
+import org.opensearch.jobscheduler.ODFERestTestCase;
+import org.opensearch.jobscheduler.TestHelpers;
+import org.opensearch.jobscheduler.rest.RestGetLockAction;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE, numDataNodes = 2)
+public class GetLockMultiNodeRestIT extends ODFERestTestCase {
+
+    public void testGetLockRestAPI() throws Exception {
+
+        String intialJobId = "testjobId";
+        String initialJobIndexName = "testJobIndexName";
+
+        // Send initial request to ensure lock index has been created
+        Response response = TestHelpers.makeRequest(
+            client(),
+            "GET",
+            TestHelpers.GET_LOCK_BASE_URI,
+            ImmutableMap.of(),
+            TestHelpers.toHttpEntity(generateRequestBody(initialJobIndexName, intialJobId)),
+            null
+        );
+
+        String initialLockId = validateResponseAndGetLockId(entityAsMap(response));
+        assertEquals(generateExpectedLockId(initialJobIndexName, intialJobId), initialLockId);
+
+        // Submit 100 requests to generate new lock models for different job indexes
+        for (int i = 0; i < 100; i++) {
+            Response getLockResponse = TestHelpers.makeRequest(
+                client(),
+                "GET",
+                TestHelpers.GET_LOCK_BASE_URI,
+                ImmutableMap.of(),
+                TestHelpers.toHttpEntity(generateRequestBody(String.valueOf(i), String.valueOf(i))),
+                null
+            );
+
+            String lockId = validateResponseAndGetLockId(entityAsMap(getLockResponse));
+            assertEquals(generateExpectedLockId(String.valueOf(i), String.valueOf(i)), lockId);
+        }
+    }
+
+    private String validateResponseAndGetLockId(Map<String, Object> responseMap) {
+        assertEquals("success", responseMap.get("response"));
+        return (String) responseMap.get(RestGetLockAction.LOCK_ID);
+    }
+
+    private String generateRequestBody(String jobIndexName, String jobId) {
+        return "{\"job_id\":\"" + jobId + "\",\"job_index_name\":\"" + jobIndexName + "\",\"lock_duration_seconds\":\"30.0\"}";
+    }
+
+    private String generateExpectedLockId(String jobIndexName, String jobId) {
+        return jobIndexName + "-" + jobId;
+    }
+
+}

--- a/src/test/java/org/opensearch/jobscheduler/multinode/GetLockMultiNodeRestIT.java
+++ b/src/test/java/org/opensearch/jobscheduler/multinode/GetLockMultiNodeRestIT.java
@@ -18,7 +18,7 @@ import org.junit.Before;
 import org.opensearch.client.Response;
 import org.opensearch.jobscheduler.ODFERestTestCase;
 import org.opensearch.jobscheduler.TestHelpers;
-import org.opensearch.jobscheduler.rest.RestGetLockAction;
+import org.opensearch.jobscheduler.spi.LockModel;
 import org.opensearch.test.OpenSearchIntegTestCase;
 
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE, numDataNodes = 2)
@@ -67,7 +67,7 @@ public class GetLockMultiNodeRestIT extends ODFERestTestCase {
 
     private String validateResponseAndGetLockId(Map<String, Object> responseMap) {
         assertEquals("success", responseMap.get("response"));
-        return (String) responseMap.get(RestGetLockAction.LOCK_ID);
+        return (String) responseMap.get(LockModel.LOCK_ID);
     }
 
     private String generateRequestBody(String jobIndexName, String jobId) {

--- a/src/test/java/org/opensearch/jobscheduler/multinode/GetLockMultiNodeRestIT.java
+++ b/src/test/java/org/opensearch/jobscheduler/multinode/GetLockMultiNodeRestIT.java
@@ -13,6 +13,8 @@ import com.google.common.collect.ImmutableMap;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Map;
+
+import org.junit.Before;
 import org.opensearch.client.Response;
 import org.opensearch.jobscheduler.ODFERestTestCase;
 import org.opensearch.jobscheduler.TestHelpers;
@@ -22,26 +24,33 @@ import org.opensearch.test.OpenSearchIntegTestCase;
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE, numDataNodes = 2)
 public class GetLockMultiNodeRestIT extends ODFERestTestCase {
 
-    public void testGetLockRestAPI() throws Exception {
+    private String initialJobId;
+    private String initialJobIndexName;
+    private Response initialGetLockResponse;
 
-        String intialJobId = "testjobId";
-        String initialJobIndexName = "testJobIndexName";
-
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        this.initialJobId = "testJobId";
+        this.initialJobIndexName = "testJobIndexName";
         // Send initial request to ensure lock index has been created
-        Response response = TestHelpers.makeRequest(
+        this.initialGetLockResponse = TestHelpers.makeRequest(
             client(),
             "GET",
             TestHelpers.GET_LOCK_BASE_URI,
             ImmutableMap.of(),
-            TestHelpers.toHttpEntity(generateRequestBody(initialJobIndexName, intialJobId)),
+            TestHelpers.toHttpEntity(generateRequestBody(this.initialJobIndexName, this.initialJobId)),
             null
         );
+    }
 
-        String initialLockId = validateResponseAndGetLockId(entityAsMap(response));
-        assertEquals(generateExpectedLockId(initialJobIndexName, intialJobId), initialLockId);
+    public void testGetLockRestAPI() throws Exception {
 
-        // Submit 100 requests to generate new lock models for different job indexes
-        for (int i = 0; i < 100; i++) {
+        String initialLockId = validateResponseAndGetLockId(entityAsMap(this.initialGetLockResponse));
+        assertEquals(generateExpectedLockId(initialJobIndexName, initialJobId), initialLockId);
+
+        // Submit 10 requests to generate new lock models for different job indexes
+        for (int i = 0; i < 10; i++) {
             Response getLockResponse = TestHelpers.makeRequest(
                 client(),
                 "GET",

--- a/src/test/java/org/opensearch/jobscheduler/rest/RestGetLockActionIT.java
+++ b/src/test/java/org/opensearch/jobscheduler/rest/RestGetLockActionIT.java
@@ -59,7 +59,13 @@ public class RestGetLockActionIT extends OpenSearchTestCase {
         this.testJobId = "testJobId";
         this.testJobIndexName = "testJobIndexName";
         this.testLockDurationSeconds = 1L;
-        this.requestBody = "{\"job_id\":\"test\",\"job_index_name\":\"test\",\"lock_duration_seconds\":\"1\"}";
+        this.requestBody = "{\"job_id\":\""
+            + this.testJobId
+            + "\",\"job_index_name\":\""
+            + this.testJobIndexName
+            + "\",\"lock_duration_seconds\":\""
+            + this.testLockDurationSeconds
+            + "\"}";
     }
 
     public void testGetNames() {

--- a/src/test/java/org/opensearch/jobscheduler/rest/RestGetLockActionIT.java
+++ b/src/test/java/org/opensearch/jobscheduler/rest/RestGetLockActionIT.java
@@ -55,7 +55,7 @@ public class RestGetLockActionIT extends OpenSearchTestCase {
         Mockito.when(this.clusterService.state().routingTable().hasIndex(".opendistro-job-scheduler-lock")).thenReturn(true);
         this.lockService = new LockService(Mockito.mock(NodeClient.class), clusterService);
         this.getLockAction = new RestGetLockAction(this.lockService);
-        this.getLockPath = String.format(Locale.ROOT, "%s/%s", JobSchedulerPlugin.JS_BASE_URI, "_get/_lock");
+        this.getLockPath = String.format(Locale.ROOT, "%s/%s", JobSchedulerPlugin.JS_BASE_URI, "_lock");
         this.testJobId = "testJobId";
         this.testJobIndexName = "testJobIndexName";
         this.testLockDurationSeconds = 1L;

--- a/src/test/java/org/opensearch/jobscheduler/rest/RestGetLockActionIT.java
+++ b/src/test/java/org/opensearch/jobscheduler/rest/RestGetLockActionIT.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.jobscheduler.rest;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.junit.Before;
+import org.mockito.Mockito;
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.bytes.BytesArray;
+import org.opensearch.common.xcontent.LoggingDeprecationHandler;
+import org.opensearch.common.xcontent.NamedXContentRegistry;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.common.xcontent.XContentParser;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.jobscheduler.JobSchedulerPlugin;
+import org.opensearch.jobscheduler.TestHelpers;
+import org.opensearch.jobscheduler.spi.utils.LockService;
+import org.opensearch.jobscheduler.transport.AcquireLockRequest;
+import org.opensearch.rest.RestHandler;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.test.rest.FakeRestChannel;
+import org.opensearch.test.rest.FakeRestRequest;
+
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class RestGetLockActionIT extends OpenSearchTestCase {
+
+    private ClusterService clusterService;
+    private LockService lockService;
+    private RestGetLockAction getLockAction;
+    private String getLockPath;
+    private String testJobId;
+    private String testJobIndexName;
+    private long testLockDurationSeconds;
+    private String requestBody;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        this.clusterService = Mockito.mock(ClusterService.class, Mockito.RETURNS_DEEP_STUBS);
+        Mockito.when(this.clusterService.state().routingTable().hasIndex(".opendistro-job-scheduler-lock")).thenReturn(true);
+        this.lockService = new LockService(Mockito.mock(NodeClient.class), clusterService);
+        this.getLockAction = new RestGetLockAction(this.lockService);
+        this.getLockPath = String.format(Locale.ROOT, "%s/%s", JobSchedulerPlugin.JS_BASE_URI, "_get/_lock");
+        this.testJobId = "testJobId";
+        this.testJobIndexName = "testJobIndexName";
+        this.testLockDurationSeconds = 1L;
+        this.requestBody = "{\"job_id\":\"test\",\"job_index_name\":\"test\",\"lock_duration_seconds\":\"1\"}";
+    }
+
+    public void testGetNames() {
+        String name = getLockAction.getName();
+        assertEquals(RestGetLockAction.GET_LOCK_ACTION, name);
+    }
+
+    public void testGetRoutes() {
+        List<RestHandler.Route> routes = getLockAction.routes();
+        assertEquals(getLockPath, routes.get(0).getPath());
+    }
+
+    public void testAcquireLockRequest() throws IOException {
+
+        // Create AcquireLockRequest
+        AcquireLockRequest acquireLockRequest = new AcquireLockRequest(testJobId, testJobIndexName, testLockDurationSeconds);
+
+        // Generate Xcontent from request
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        builder.field(AcquireLockRequest.JOB_ID, acquireLockRequest.getJobId());
+        builder.field(AcquireLockRequest.JOB_INDEX_NAME, acquireLockRequest.getJobIndexName());
+        builder.field(AcquireLockRequest.LOCK_DURATION_SECONDS, acquireLockRequest.getLockDurationSeconds());
+        builder.endObject();
+
+        // Test request serde logic
+        XContentParser parser = XContentType.JSON.xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, TestHelpers.xContentBuilderToString(builder));
+        parser.nextToken();
+        acquireLockRequest = AcquireLockRequest.parse(parser);
+        assertEquals(this.testJobId, acquireLockRequest.getJobId());
+        assertEquals(this.testJobIndexName, acquireLockRequest.getJobIndexName());
+        assertEquals(this.testLockDurationSeconds, acquireLockRequest.getLockDurationSeconds());
+    }
+
+    public void testPrepareGetLockRequest() throws IOException {
+
+        // Prepare rest request
+        Map<String, String> params = new HashMap<>();
+        FakeRestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.GET)
+            .withPath(this.getLockPath)
+            .withParams(params)
+            .withContent(new BytesArray(this.requestBody), XContentType.JSON)
+            .build();
+
+        final FakeRestChannel channel = new FakeRestChannel(request, true, 0);
+
+        this.getLockAction.prepareRequest(request, Mockito.mock(NodeClient.class));
+        assertEquals(channel.responses().get(), 0);
+        assertEquals(channel.errors().get(), 0);
+    }
+
+}

--- a/src/test/java/org/opensearch/jobscheduler/rest/RestGetLockActionIT.java
+++ b/src/test/java/org/opensearch/jobscheduler/rest/RestGetLockActionIT.java
@@ -28,6 +28,7 @@ import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.jobscheduler.JobSchedulerPlugin;
 import org.opensearch.jobscheduler.TestHelpers;
+import org.opensearch.jobscheduler.spi.LockModel;
 import org.opensearch.jobscheduler.spi.utils.LockService;
 import org.opensearch.jobscheduler.transport.AcquireLockRequest;
 import org.opensearch.rest.RestHandler;
@@ -70,7 +71,7 @@ public class RestGetLockActionIT extends OpenSearchTestCase {
 
     public void testGetNames() {
         String name = getLockAction.getName();
-        assertEquals(RestGetLockAction.GET_LOCK_ACTION, name);
+        assertEquals(LockModel.GET_LOCK_ACTION, name);
     }
 
     public void testGetRoutes() {


### PR DESCRIPTION
### Description
Exposes a GetLock Rest API to enable extensions to acquire a lock model for their job execution
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-sdk-java/issues/363
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
