### PR TITLE
Publishing jars to org.opensearch.opensearch-job-scheduler

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -36,4 +36,4 @@ jobs:
           export SONATYPE_PASSWORD=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-password --query SecretString --output text)
           echo "::add-mask::$SONATYPE_USERNAME"
           echo "::add-mask::$SONATYPE_PASSWORD"
-          ./gradlew opensearch-job-scheduler-spi:publishAllPublicationsToSnapshotsRepository && ./gradlew publishPluginZipPublicationToSnapshotsRepository
+          ./gradlew publishAllPublicationsToSnapshotsRepository


### PR DESCRIPTION
### Description
Updates org.opensearch.opensearch-job-scheduler with maven jars
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
