### PR TITLE
Increasing JobDetailsService request timeout from 10 to 15

### DIFF
--- a/src/main/java/org/opensearch/jobscheduler/utils/JobDetailsService.java
+++ b/src/main/java/org/opensearch/jobscheduler/utils/JobDetailsService.java
@@ -72,7 +72,7 @@ public class JobDetailsService implements IndexingOperationListener {
     public static final String JOB_DETAILS_INDEX_NAME = ".opensearch-job-scheduler-job-details";
     private static final String PLUGINS_JOB_DETAILS_MAPPING_FILE = "/mappings/opensearch_job_scheduler_job_details.json";
 
-    public static Long TIME_OUT_FOR_REQUEST = 10L;
+    public static Long TIME_OUT_FOR_REQUEST = 15L;
     private final Client client;
     private final ClusterService clusterService;
     private Set<String> indicesToListen;


### PR DESCRIPTION
### Description
When `startdetector` is invoked for Anomaly Detection Extension, AD first sends a REST request to JobScheduler to register its Job Details (Job Index Name, Job Type, Scheduled Job Parameter parser action name,  Scheduled Job Runner Action Name). Job Scheduler receives this request and first determines if the Job Details metadata index exists, and if not, it initializes it. Then the request is processed and indexed into the metadata index.

Testing this workflow has uncovered that the timeout value for this request consistently causes the request to fail, since the meta data index takes some time to initialize. The following logs note that the `MasterService` itself takes 10 seconds to compute the cluster state update for the created index, which is what I suspect is the main source of this issue. 
```
[2023-03-21T22:45:47,134][INFO ][o.o.e.r.RestSendToExtensionAction] [dev-dsk-jpalis-2c-27c8aa11.us-west-2.amazon.com] Forwarding the request POST /detectors/i69ZBocBJFI2LLZIRd57/_start to {ad-extension}{ad-extension-1}{9FqaCzf-QAyzONIKxmlYyA}{127.0.0.1}{127.0.0.1:4532}{dimrs}
[2023-03-21T22:45:47,157][INFO ][o.o.p.PluginsService     ] [dev-dsk-jpalis-2c-27c8aa11.us-west-2.amazon.com] PluginService:onIndexModule index:[.opensearch-job-scheduler-job-details/jHEdk373Ti2k5ogEpmKmdg]
[2023-03-21T22:45:47,157][INFO ][o.o.j.JobSchedulerPlugin ] [dev-dsk-jpalis-2c-27c8aa11.us-west-2.amazon.com] JobDetailsService started listening to operations on index .opensearch-job-scheduler-job-details
[2023-03-21T22:45:47,157][INFO ][o.o.e.ExtensionsManager  ] [dev-dsk-jpalis-2c-27c8aa11.us-west-2.amazon.com] onIndexModule index:[.opensearch-job-scheduler-job-details/jHEdk373Ti2k5ogEpmKmdg]
[2023-03-21T22:45:47,158][INFO ][o.o.e.ExtensionsManager  ] [dev-dsk-jpalis-2c-27c8aa11.us-west-2.amazon.com] Sending extension request type: indices:internal/extensions
[2023-03-21T22:45:57,143][INFO ][o.o.e.ExtensionsManager  ] [dev-dsk-jpalis-2c-27c8aa11.us-west-2.amazon.com] received IndicesModuleResponse{supportsIndexEventListenertrue addIndexOperationListenertrue addSearchOperationListenertrue}
[2023-03-21T22:45:57,145][INFO ][o.o.e.ExtensionsManager  ] [dev-dsk-jpalis-2c-27c8aa11.us-west-2.amazon.com] Received response from Extension
[2023-03-21T22:45:57,154][INFO ][o.o.c.m.MetadataCreateIndexService] [dev-dsk-jpalis-2c-27c8aa11.us-west-2.amazon.com] [.opensearch-job-scheduler-job-details] creating index, cause [api], templates [], shards [1]/[1]
[2023-03-21T22:45:57,158][WARN ][o.o.c.s.MasterService    ] [dev-dsk-jpalis-2c-27c8aa11.us-west-2.amazon.com] took [10s], which is over [10s], to compute cluster state update for [create-index [.opensearch-job-scheduler-job-details], cause [api]]
[2023-03-21T22:45:57,150][ERROR][o.o.j.r.a.RestGetJobDetailsAction] [dev-dsk-jpalis-2c-27c8aa11.us-west-2.amazon.com] Exception occured in get job details 
java.util.concurrent.ExecutionException: java.util.concurrent.TimeoutException
        at java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:396) ~[?:?]
        at java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2073) ~[?:?]
```

To resolve this issue, I have increased the timeout value for requests coming into `JobDetailsService`


### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
