### PR TITLE
[Extensions] Fixes serde logic for proxy scheduled jobrunner/parser requests/responses

### DIFF
--- a/src/main/java/org/opensearch/jobscheduler/transport/request/ExtensionJobActionRequest.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/request/ExtensionJobActionRequest.java
@@ -9,15 +9,22 @@
 package org.opensearch.jobscheduler.transport.request;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import org.opensearch.common.bytes.BytesReference;
+import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.io.stream.Writeable;
 import org.opensearch.extensions.action.ExtensionActionRequest;
-import org.opensearch.jobscheduler.utils.JobDetailsService;
 
 /**
  * Request to extensions to invoke a job action, converts request params to a byte array
  *
  */
 public class ExtensionJobActionRequest<T extends Writeable> extends ExtensionActionRequest {
+
+    public static final byte UNIT_SEPARATOR = (byte) '\u001F';
 
     /**
      * Instantiates a new ExtensionJobActionRequest
@@ -27,7 +34,63 @@ public class ExtensionJobActionRequest<T extends Writeable> extends ExtensionAct
      * @throws IOException if serialization fails
      */
     public ExtensionJobActionRequest(String extensionActionName, T actionParams) throws IOException {
-        super(extensionActionName, JobDetailsService.convertParamsToBytes(actionParams));
+        super(extensionActionName, convertParamsToBytes(actionParams));
+    }
+
+    /**
+     * Finds the index of the specified byte value within the given byte array
+     *
+     * @param bytes the byte array to process
+     * @param value the byte to identify index of
+     * @return the index of the byte value
+     */
+    private static int indexOf(byte[] bytes, byte value) {
+        for (int offset = 0; offset < bytes.length; ++offset) {
+            if (bytes[offset] == value) {
+                return offset;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Trims off the fully qualified request class name bytes and null byte from the ExtensionActionRequest requestBytes
+     *
+     * @param requestBytes the request bytes of an ExtensionActionRequest
+     * @return the trimmed array of bytes
+     */
+    public static byte[] trimRequestBytes(byte[] requestBytes) {
+        int nullPos = indexOf(requestBytes, ExtensionJobActionRequest.UNIT_SEPARATOR);
+        return Arrays.copyOfRange(requestBytes, nullPos + 1, requestBytes.length);
+    }
+
+    /**
+     * Converts an object of type T that extends {@link Writeable} into a byte array and prepends the fully qualified class name bytes
+     *
+     * @param <T> a class that extends writeable
+     * @param actionParams the action parameters to be serialized
+     * @throws IOException if serialization fails
+     * @return the byte array of the parameters
+     */
+    private static <T extends Writeable> byte[] convertParamsToBytes(T actionParams) throws IOException {
+
+        // Write inner request to output stream and convert to byte array
+        BytesStreamOutput out = new BytesStreamOutput();
+        actionParams.writeTo(out);
+        out.flush();
+        byte[] requestBytes = BytesReference.toBytes(out.bytes());
+
+        // Convert fully qualifed class name to byte array
+        byte[] requestClassBytes = ExtensionActionRequest.class.getName().getBytes(StandardCharsets.UTF_8);
+
+        // Generate ExtensionActionRequest responseByte array
+        byte[] proxyRequestBytes = ByteBuffer.allocate(requestClassBytes.length + 1 + requestBytes.length)
+            .put(requestClassBytes)
+            .put(ExtensionJobActionRequest.UNIT_SEPARATOR)
+            .put(requestBytes)
+            .array();
+
+        return proxyRequestBytes;
     }
 
 }

--- a/src/main/java/org/opensearch/jobscheduler/transport/request/JobParameterRequest.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/request/JobParameterRequest.java
@@ -83,7 +83,7 @@ public class JobParameterRequest implements Writeable {
      * @throws IOException when message de-serialization fails.
      */
     public JobParameterRequest(byte[] requestParams) throws IOException {
-        this(StreamInput.wrap(requestParams));
+        this(StreamInput.wrap(ExtensionJobActionRequest.trimRequestBytes(requestParams)));
     }
 
     @Override

--- a/src/main/java/org/opensearch/jobscheduler/transport/request/JobRunnerRequest.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/request/JobRunnerRequest.java
@@ -68,7 +68,7 @@ public class JobRunnerRequest implements Writeable {
      * @throws IOException when message de-serialization fails.
      */
     public JobRunnerRequest(byte[] requestParams) throws IOException {
-        this(StreamInput.wrap(requestParams));
+        this(StreamInput.wrap(ExtensionJobActionRequest.trimRequestBytes(requestParams)));
     }
 
     @Override

--- a/src/main/java/org/opensearch/jobscheduler/transport/response/ExtensionJobActionResponse.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/response/ExtensionJobActionResponse.java
@@ -9,9 +9,11 @@
 package org.opensearch.jobscheduler.transport.response;
 
 import java.io.IOException;
+
+import org.opensearch.common.bytes.BytesReference;
+import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.io.stream.Writeable;
 import org.opensearch.extensions.action.ExtensionActionResponse;
-import org.opensearch.jobscheduler.utils.JobDetailsService;
 
 /**
  * Response from extension job action, converts response params to a byte array
@@ -26,7 +28,25 @@ public class ExtensionJobActionResponse<T extends Writeable> extends ExtensionAc
      * @throws IOException if serialization fails
      */
     public ExtensionJobActionResponse(T actionResponse) throws IOException {
-        super(JobDetailsService.convertParamsToBytes(actionResponse));
+        super(convertParamsToBytes(actionResponse));
+    }
+
+    /**
+     * Takes in an object of type T that extends {@link Writeable} and converts the writeable fields to a byte array
+     *
+     * @param <T> a class that extends writeable
+     * @param actionParams the action parameters to be serialized
+     * @throws IOException if serialization fails
+     * @return the byte array of the parameters
+     */
+    private static <T extends Writeable> byte[] convertParamsToBytes(T actionParams) throws IOException {
+        // Write all to output stream
+        BytesStreamOutput out = new BytesStreamOutput();
+        actionParams.writeTo(out);
+        out.flush();
+
+        // convert bytes stream to byte array
+        return BytesReference.toBytes(out.bytes());
     }
 
 }

--- a/src/main/java/org/opensearch/jobscheduler/utils/JobDetailsService.java
+++ b/src/main/java/org/opensearch/jobscheduler/utils/JobDetailsService.java
@@ -31,9 +31,6 @@ import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.extensions.action.ExtensionProxyAction;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
-import org.opensearch.common.bytes.BytesReference;
-import org.opensearch.common.io.stream.BytesStreamOutput;
-import org.opensearch.common.io.stream.Writeable;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.engine.DocumentMissingException;
@@ -501,24 +498,6 @@ public class JobDetailsService implements IndexingOperationListener {
             logger.error("IOException occurred updating job details for documentId " + documentId, e);
             listener.onResponse(null);
         }
-    }
-
-    /**
-     * Takes in an object of type T that extends {@link Writeable} and converts the writeable fields to a byte array
-     *
-     * @param <T> a class that extends writeable
-     * @param actionParams the action parameters to be serialized
-     * @throws IOException if serialization fails
-     * @return the byte array of the parameters
-     */
-    public static <T extends Writeable> byte[] convertParamsToBytes(T actionParams) throws IOException {
-        // Write all to output stream
-        BytesStreamOutput out = new BytesStreamOutput();
-        actionParams.writeTo(out);
-        out.flush();
-
-        // convert bytes stream to byte array
-        return BytesReference.toBytes(out.bytes());
     }
 
     private String jobDetailsMapping() {


### PR DESCRIPTION
### Description
Coming from modifications to the `ExtensionProxyAction` workflow [here](https://github.com/opensearch-project/OpenSearch/pull/6734).

The `JobDetailsService` used to facilitate job execution for extensions creates proxy `ScheduledJobRunner` and `ScheduledJobParser` objects that utilize the node client to execute remote extension actions. 

Here is an example of the new workflow : 

1. An extension registers its Job Details and Job Scheduler creates a `ScheduledJobProvider`, which contains a `ScheduledJobParser` that delegates parsing of the extension job index entry to the extension by executing the extension parse action
2. Job Scheduler is notified of an index operation on the extension job index, pulls that entry and it's proxy `ScheduledJobParser` invokes [ExtensionProxyAction](https://github.com/opensearch-project/OpenSearch/blob/9febe1041724c84409b18d2ca4f6946f5616e99c/server/src/main/java/org/opensearch/extensions/action/ExtensionProxyAction.java#L18) to send this to the extension to parse
3. The `ExtensionProxyJobAction` attaches the fully qualified class name of the `ExtensionProxyAction` as bytes in the `responseByte` field, along with the bytes provided by the inner `JobParserRequest` that contains the job index entry source
4. This request is sent to the SDK's [REQUEST_EXTENSION_HANDLE_TRANSPORT_ACTION handler](https://github.com/opensearch-project/opensearch-sdk-java/blob/ebc684ae223e87f1e05712e086fc1dab911a3b5f/src/main/java/org/opensearch/sdk/ExtensionsRunner.java#L407)
5. This request is then handled by the `ExtensionActionRequestHandler` [here](https://github.com/opensearch-project/opensearch-sdk-java/blob/ebc684ae223e87f1e05712e086fc1dab911a3b5f/src/main/java/org/opensearch/sdk/handlers/ExtensionActionRequestHandler.java#L59), which delegates the request handling to the `handleRemoteExtensionActionRequest` [method](https://github.com/opensearch-project/opensearch-sdk-java/blob/ebc684ae223e87f1e05712e086fc1dab911a3b5f/src/main/java/org/opensearch/sdk/handlers/ExtensionActionRequestHandler.java#LL73C42-L73C76).
6. Within this method, the `requestBytes` are processed and the request class name is identified [here](https://github.com/opensearch-project/opensearch-sdk-java/blob/ebc684ae223e87f1e05712e086fc1dab911a3b5f/src/main/java/org/opensearch/sdk/handlers/ExtensionActionRequestHandler.java#L87) which is used to identify and create the constructor for this particular `ActionRequest`
7. The action is then executed using the `SDKClient` and this request is forwarded to the corresponding `TransportAction`
8. The response is then sent back to Job Scheduler

This PR ensures that request bytes for the `ExtensionActionRequest` sent from Job Scheduler are in the correct format to be processed by the SDK.

 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
