### PR TITLE
[Extensions] Remove requestByte trimming for JobParameter/Runner requests

### DIFF
--- a/src/main/java/org/opensearch/jobscheduler/transport/request/ExtensionJobActionRequest.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/request/ExtensionJobActionRequest.java
@@ -11,7 +11,6 @@ package org.opensearch.jobscheduler.transport.request;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.io.stream.BytesStreamOutput;
@@ -35,33 +34,6 @@ public class ExtensionJobActionRequest<T extends Writeable> extends ExtensionAct
      */
     public ExtensionJobActionRequest(String extensionActionName, T actionParams) throws IOException {
         super(extensionActionName, convertParamsToBytes(actionParams));
-    }
-
-    /**
-     * Finds the index of the specified byte value within the given byte array
-     *
-     * @param bytes the byte array to process
-     * @param value the byte to identify index of
-     * @return the index of the byte value
-     */
-    private static int indexOf(byte[] bytes, byte value) {
-        for (int offset = 0; offset < bytes.length; ++offset) {
-            if (bytes[offset] == value) {
-                return offset;
-            }
-        }
-        return -1;
-    }
-
-    /**
-     * Trims off the fully qualified request class name bytes and null byte from the ExtensionActionRequest requestBytes
-     *
-     * @param requestBytes the request bytes of an ExtensionActionRequest
-     * @return the trimmed array of bytes
-     */
-    public static byte[] trimRequestBytes(byte[] requestBytes) {
-        int nullPos = indexOf(requestBytes, ExtensionJobActionRequest.UNIT_SEPARATOR);
-        return Arrays.copyOfRange(requestBytes, nullPos + 1, requestBytes.length);
     }
 
     /**

--- a/src/main/java/org/opensearch/jobscheduler/transport/request/JobParameterRequest.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/request/JobParameterRequest.java
@@ -83,7 +83,7 @@ public class JobParameterRequest implements Writeable {
      * @throws IOException when message de-serialization fails.
      */
     public JobParameterRequest(byte[] requestParams) throws IOException {
-        this(StreamInput.wrap(ExtensionJobActionRequest.trimRequestBytes(requestParams)));
+        this(StreamInput.wrap(requestParams));
     }
 
     @Override

--- a/src/main/java/org/opensearch/jobscheduler/transport/request/JobRunnerRequest.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/request/JobRunnerRequest.java
@@ -68,7 +68,7 @@ public class JobRunnerRequest implements Writeable {
      * @throws IOException when message de-serialization fails.
      */
     public JobRunnerRequest(byte[] requestParams) throws IOException {
-        this(StreamInput.wrap(ExtensionJobActionRequest.trimRequestBytes(requestParams)));
+        this(StreamInput.wrap(requestParams));
     }
 
     @Override


### PR DESCRIPTION
### Description
Part of https://github.com/opensearch-project/job-scheduler/pull/349

Fixes serialization/deserialization logic for JobParameterRequest/JobRunnerRequest. Removes extra trimming of request bytes for the streaminput constructor for the JobParameter/RunnerRequest, as this is already trimmed by the SDK prior to forwarding the actionrequest to the transport action [here](https://github.com/opensearch-project/opensearch-sdk-java/blob/e13aed8eaaf17f448a9783b8fcb6a3f20ef6d5bb/src/main/java/org/opensearch/sdk/handlers/ExtensionActionRequestHandler.java#L94). This change requires modifications to the corresponding test classes to emulate the processing done by the SDK
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
