### PR TITLE
Baseline CODEOWNERS and MAINTAINERS with current team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @opensearch-project/job-scheduler
+*   @joshpalis @saratvemulapalli @dbwiddis @kaituo @vibrantvarun

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,10 +4,20 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 ## Current Maintainers
 
-| Maintainer       | GitHub ID                                         | Affiliation |
-| ---------------- | ------------------------------------------------- | ----------- |
-| Ashish Agrawal   | [lezzago](https://github.com/lezzago)             | Amazon      |
-| Bowen Lan        | [bowenlan-amzn](https://github.com/bowenlan-amzn) | Amazon      |
-| Drew Baugher     | [dbbaughe](https://github.com/dbbaughe)           | Amazon      |
-| Mohammad Qureshi | [qreshi](https://github.com/qreshi)               | Amazon      |
-| Sriram Kosuri    | [skkosuri-amzn](https://github.com/skkosuri-amzn) | Amazon      |
+| Maintainer        | GitHub ID                                               | Affiliation |
+| ----------------- | ------------------------------------------------------- | ----------- |
+| Josh Palis        | [joshpalis](https://github.com/joshpalis)               | Amazon      |
+| Sarat Vemulapalli | [saratvemulapalli](https://github.com/saratvemulapalli) | Amazon      |
+| Dan Widdis        | [dbwiddis](https://github.com/dbwiddis)                 | Amazon      |
+| Kaituo Li         | [kaituo](https://github.com/kaituo)                     | Amazon      |
+| Varun Jain        | [vibrantvarun](https://github.com/vibrantvarun)         | Amazon      |
+
+## Emeritus Maintainers
+
+| Maintainer        | GitHub ID                                               | Affiliation |
+| ----------------- | ------------------------------------------------------- | ----------- |
+| Ashish Agrawal    | [lezzago](https://github.com/lezzago)                   | Amazon      |
+| Bowen Lan         | [bowenlan-amzn](https://github.com/bowenlan-amzn)       | Amazon      |
+| Drew Baugher      | [dbbaughe](https://github.com/dbbaughe)                 | Amazon      |
+| Mohammad Qureshi  | [qreshi](https://github.com/qreshi)                     | Amazon      |
+| Sriram Kosuri     | [skkosuri-amzn](https://github.com/skkosuri-amzn)       | Amazon      |


### PR DESCRIPTION
### Description

Updates MAINTAINERS with current team and moves prior maintainers to Emeritus status.  Aligns with CodeOwners
 
### Issues Resolved

Fixes https://github.com/opensearch-project/job-scheduler/issues/316
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
