### PR TITLE
Maven Artifact path update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -136,6 +136,13 @@ publishing {
                 groupId = "org.opensearch.plugin"
             }
         }
+        pluginZip1(MavenPublication) { publication ->
+            pom {
+                name = "opensearch-job-scheduler"
+                description = "OpenSearch Job Scheduler plugin"
+                groupId = "org.opensearch"
+            }
+        }
     }
     repositories {
         maven {


### PR DESCRIPTION
### Description
Updated build.gradle with publishingArtifactPath. 

The maven artifacts were not getting updated in the sonatype for "org.opensearch.opendistro-job-scheduler" path. I have added a pluginZip1 parameter and added the path mentioned above. Please find the test result below.
 
Now, the both the paths "org.opensearch.plugin.opendistro-job-scheduler" and "org.opensearch.opendistro-job-scheduler" are getting updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
