### PR TITLE
Delete-job-details changes

### DIFF
--- a/src/main/java/org/opensearch/jobscheduler/rest/action/DeleteJobDetailsAPI.java
+++ b/src/main/java/org/opensearch/jobscheduler/rest/action/DeleteJobDetailsAPI.java
@@ -1,8 +1,11 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
-
 package org.opensearch.jobscheduler.rest.action;
 
 import com.google.common.collect.ImmutableList;
@@ -32,7 +35,6 @@ import java.util.concurrent.TimeoutException;
 import static org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.jobscheduler.rest.request.DeleteJobDetailsRequest.DOCUMENT_ID;
 import static org.opensearch.rest.RestRequest.Method.DELETE;
-import static org.opensearch.rest.RestRequest.Method.PUT;
 
 public class DeleteJobDetailsAPI extends BaseRestHandler {
 
@@ -54,11 +56,8 @@ public class DeleteJobDetailsAPI extends BaseRestHandler {
     @Override
     public List<Route> routes() {
         return ImmutableList.of(
-                // Delete Job Details Entry Request
-                new Route(
-                        DELETE,
-                        String.format(Locale.ROOT, "%s/%s/{%s}", JobSchedulerPlugin.JS_BASE_URI, "_job_details", DOCUMENT_ID)
-                )
+            // Delete Job Details Entry Request
+            new Route(DELETE, String.format(Locale.ROOT, "%s/%s/{%s}", JobSchedulerPlugin.JS_BASE_URI, "_job_details", DOCUMENT_ID))
 
         );
     }
@@ -74,22 +73,19 @@ public class DeleteJobDetailsAPI extends BaseRestHandler {
 
         CompletableFuture<Boolean> inProgressFuture = new CompletableFuture<>();
 
-        jobDetailsService.deleteJobDetails(
-                documentId,
-                new ActionListener<>() {
+        jobDetailsService.deleteJobDetails(documentId, new ActionListener<>() {
 
-                    @Override
-                    public void onResponse(Boolean aBoolean) {
-                        inProgressFuture.complete(aBoolean);
-                    }
+            @Override
+            public void onResponse(Boolean aBoolean) {
+                inProgressFuture.complete(aBoolean);
+            }
 
-                    @Override
-                    public void onFailure(Exception e) {
-                        logger.info("could not process job index", e);
-                        inProgressFuture.completeExceptionally(e);
-                    }
-                }
-        );
+            @Override
+            public void onFailure(Exception e) {
+                logger.info("could not process job index", e);
+                inProgressFuture.completeExceptionally(e);
+            }
+        });
 
         try {
             inProgressFuture.orTimeout(JobDetailsService.TIME_OUT_FOR_REQUEST, TimeUnit.SECONDS);

--- a/src/main/java/org/opensearch/jobscheduler/rest/action/DeleteJobDetailsAPI.java
+++ b/src/main/java/org/opensearch/jobscheduler/rest/action/DeleteJobDetailsAPI.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.jobscheduler.rest.action;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.ActionListener;
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.jobscheduler.JobSchedulerPlugin;
+import org.opensearch.jobscheduler.rest.request.DeleteJobDetailsRequest;
+import org.opensearch.jobscheduler.rest.request.GetJobDetailsRequest;
+import org.opensearch.jobscheduler.utils.JobDetailsService;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.BytesRestResponse;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.rest.RestStatus;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.opensearch.jobscheduler.rest.request.DeleteJobDetailsRequest.DOCUMENT_ID;
+import static org.opensearch.rest.RestRequest.Method.DELETE;
+import static org.opensearch.rest.RestRequest.Method.PUT;
+
+public class DeleteJobDetailsAPI extends BaseRestHandler {
+
+    public static final String DELETE_JOB_DETAILS_API = "delete_job_details_api";
+
+    private final Logger logger = LogManager.getLogger(RestGetJobDetailsAction.class);
+
+    public JobDetailsService jobDetailsService;
+
+    public DeleteJobDetailsAPI(final JobDetailsService jobDetailsService) {
+        this.jobDetailsService = jobDetailsService;
+    }
+
+    @Override
+    public String getName() {
+        return DELETE_JOB_DETAILS_API;
+    }
+
+    @Override
+    public List<Route> routes() {
+        return ImmutableList.of(
+                // Delete Job Details Entry Request
+                new Route(
+                        DELETE,
+                        String.format(Locale.ROOT, "%s/%s/{%s}", JobSchedulerPlugin.JS_BASE_URI, "_job_details", DOCUMENT_ID)
+                )
+
+        );
+    }
+
+    @VisibleForTesting
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient nodeClient) throws IOException {
+        XContentParser parser = restRequest.contentParser();
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+
+        DeleteJobDetailsRequest deleteJobDetailsRequest = DeleteJobDetailsRequest.parse(parser);
+        String documentId = restRequest.param(DOCUMENT_ID);
+
+        CompletableFuture<Boolean> inProgressFuture = new CompletableFuture<>();
+
+        jobDetailsService.deleteJobDetails(
+                documentId,
+                new ActionListener<>() {
+
+                    @Override
+                    public void onResponse(Boolean aBoolean) {
+                        inProgressFuture.complete(aBoolean);
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        logger.info("could not process job index", e);
+                        inProgressFuture.completeExceptionally(e);
+                    }
+                }
+        );
+
+        try {
+            inProgressFuture.orTimeout(JobDetailsService.TIME_OUT_FOR_REQUEST, TimeUnit.SECONDS);
+        } catch (CompletionException e) {
+            if (e.getCause() instanceof TimeoutException) {
+                logger.error("Delete Job Details timed out ", e);
+            }
+            if (e.getCause() instanceof RuntimeException) {
+                throw (RuntimeException) e.getCause();
+            } else if (e.getCause() instanceof Error) {
+                throw (Error) e.getCause();
+            } else {
+                throw new RuntimeException(e.getCause());
+            }
+        }
+
+        return channel -> {
+            Boolean jobDetailsResponseHolder = false;
+            try {
+                jobDetailsResponseHolder = inProgressFuture.get();
+            } catch (Exception e) {
+                logger.error("Exception occured in get job details ", e);
+            }
+            XContentBuilder builder = channel.newBuilder();
+            RestStatus restStatus = RestStatus.OK;
+            String restResponseString = jobDetailsResponseHolder != false ? "DELETED" : "NOT_FOUND";
+            BytesRestResponse bytesRestResponse;
+            try {
+                builder.startObject();
+                builder.field("response", restResponseString);
+                if (restResponseString.equals("DELETED")) {
+                    builder.field(GetJobDetailsRequest.DOCUMENT_ID, jobDetailsResponseHolder);
+                } else {
+                    restStatus = RestStatus.INTERNAL_SERVER_ERROR;
+                }
+                builder.endObject();
+                bytesRestResponse = new BytesRestResponse(restStatus, builder);
+            } finally {
+                builder.close();
+            }
+
+            channel.sendResponse(bytesRestResponse);
+        };
+
+    }
+}

--- a/src/main/java/org/opensearch/jobscheduler/rest/request/DeleteJobDetailsRequest.java
+++ b/src/main/java/org/opensearch/jobscheduler/rest/request/DeleteJobDetailsRequest.java
@@ -1,8 +1,11 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
-
 package org.opensearch.jobscheduler.rest.request;
 
 import org.opensearch.action.ActionRequest;
@@ -12,16 +15,13 @@ import org.opensearch.core.xcontent.XContentParser;
 
 import java.io.IOException;
 
-
 public class DeleteJobDetailsRequest extends ActionRequest {
 
     public static String documentId;
 
     public static final String DOCUMENT_ID = "document_id";
 
-    public DeleteJobDetailsRequest(
-            String documentId
-    ) {
+    public DeleteJobDetailsRequest(String documentId) {
         super();
         this.documentId = documentId;
     }
@@ -45,7 +45,6 @@ public class DeleteJobDetailsRequest extends ActionRequest {
         return new DeleteJobDetailsRequest(documentId);
 
     }
-
 
     @Override
     public ActionRequestValidationException validate() {

--- a/src/main/java/org/opensearch/jobscheduler/rest/request/DeleteJobDetailsRequest.java
+++ b/src/main/java/org/opensearch/jobscheduler/rest/request/DeleteJobDetailsRequest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.jobscheduler.rest.request;
+
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.common.xcontent.XContentParserUtils;
+import org.opensearch.core.xcontent.XContentParser;
+
+import java.io.IOException;
+
+
+public class DeleteJobDetailsRequest extends ActionRequest {
+
+    public static String documentId;
+
+    public static final String DOCUMENT_ID = "document_id";
+
+    public DeleteJobDetailsRequest(
+            String documentId
+    ) {
+        super();
+        this.documentId = documentId;
+    }
+
+    public static DeleteJobDetailsRequest parse(XContentParser parser) throws IOException {
+        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
+        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            String fieldName = parser.currentName();
+            parser.nextToken();
+
+            switch (fieldName) {
+                case DOCUMENT_ID:
+                    documentId = parser.textOrNull();
+                    break;
+                default:
+                    parser.skipChildren();
+                    break;
+            }
+
+        }
+        return new DeleteJobDetailsRequest(documentId);
+
+    }
+
+
+    @Override
+    public ActionRequestValidationException validate() {
+        return null;
+    }
+
+    public String getDocumentId() {
+        return documentId;
+    }
+
+    public void setDocumentId(String documentId) {
+        this.documentId = documentId;
+    }
+
+}


### PR DESCRIPTION
### Description
Create a Delete Job Details Rest API with documentId as a input parameter. It will help to delete job details objects with issues with the help of API
 
### Issues Resolved
Prerequisites

Additional context

create RestDeleteJobDetailsAction in path org.opensearch.jobscheduler.action
RestDeleteJobDetailsAction should extend abstract class BaseRestHandler
Override routes() and prepareRequest() method in RestDeleteJobDetailsAction class
Define two static strings in class
public static final String DELETE_JOB_DETAILS_ACTION = "delete_job_details_action";
public static final String DOCUMENT_ID = "document_id";
In routes method return a list of route with given Route below
new Route(DELETE, String.format(Locale.ROOT, "%s/%s/{%s}", JobSchedulerPlugin.JS_BASE_URI, "_delete_job_details", DOCUMENT_ID))
Override getName() method and return DELETE_JOB_DETAILS_ACTION
Create a public constructor in RestDeleteJobDetailsAction with JobDetailsService as argument and initialize the local variable
public RestDeleteJobDetailsAction(JobDetailsService jobDetailsService){
this.jobDetailsService=jobDetailsService;
}
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
