### PR TITLE
Add pluginJar publication to publish to org.opensearch group

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,9 @@ tasks.matching {it.path in [
     ":publishPluginZipPublicationToSnapshotsRepository",
     ":publishNebulaPublicationToSnapshotsRepository",
     ":publishPluginJarPublicationToMavenLocal",
-    ":publishNebulaPublicationToMavenLocal"
+    ":publishNebulaPublicationToMavenLocal",
+    ":validatePluginJarPom",
+    ":validatePluginZipPom"
 ]}.all { task ->
     task.dependsOn 'generatePomFileForPluginZipPublication', 'generatePomFileForPluginJarPublication', 'generatePomFileForNebulaPublication'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -52,8 +52,14 @@ forbiddenApisTest.ignoreFailures = true
 validateNebulaPom.enabled = false
 loggerUsageCheck.enabled = false
 
-tasks.matching {it.path in [":publishNebulaPublicationToSnapshotsRepository"]}.all { task ->
-    task.dependsOn 'generatePomFileForPluginZipPublication'
+tasks.matching {it.path in [
+    ":publishPluginJarPublicationToSnapshotsRepository",
+    ":publishPluginZipPublicationToSnapshotsRepository",
+    ":publishNebulaPublicationToSnapshotsRepository",
+    ":publishPluginJarPublicationToMavenLocal",
+    ":publishNebulaPublicationToMavenLocal"
+]}.all { task ->
+    task.dependsOn 'generatePomFileForPluginZipPublication', 'generatePomFileForPluginJarPublication', 'generatePomFileForNebulaPublication'
 }
 
 opensearchplugin {
@@ -134,6 +140,13 @@ publishing {
                 name = "opensearch-job-scheduler"
                 description = "OpenSearch Job Scheduler plugin"
                 groupId = "org.opensearch.plugin"
+            }
+        }
+        pluginJar(MavenPublication) { publication ->
+            pom {
+                name = "opensearch-job-scheduler"
+                description = "OpenSearch Job Scheduler plugin"
+                groupId = "org.opensearch"
             }
         }
     }


### PR DESCRIPTION
### Description

Opening this up as a draft PR while testing the change. I believe its possible to add a section in the publication area of the build.gradle to publish the jar for `opensearch-job-scheduler` to the `org.opensearch` group. 

### Issues Resolved

Attempts to fix: https://github.com/opensearch-project/job-scheduler/issues/374
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
