### PR TITLE
Fixes issue with publishing Job Scheduler artifacts to correct maven coordinates

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -36,4 +36,4 @@ jobs:
           export SONATYPE_PASSWORD=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-password --query SecretString --output text)
           echo "::add-mask::$SONATYPE_USERNAME"
           echo "::add-mask::$SONATYPE_PASSWORD"
-          ./gradlew opensearch-job-scheduler-spi:publishAllPublicationsToSnapshotsRepository && ./gradlew publishPluginZipPublicationToSnapshotsRepository && ./gradlew publishMavenJavaToSnapshotsRepository
+          ./gradlew opensearch-job-scheduler-spi:publishAllPublicationsToSnapshotsRepository && ./gradlew publishPluginZipPublicationToSnapshotsRepository && ./gradlew publishPluginJarToSnapshotsRepository

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -36,4 +36,4 @@ jobs:
           export SONATYPE_PASSWORD=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-password --query SecretString --output text)
           echo "::add-mask::$SONATYPE_USERNAME"
           echo "::add-mask::$SONATYPE_PASSWORD"
-          ./gradlew opensearch-job-scheduler-spi:publishAllPublicationsToSnapshotsRepository && ./gradlew publishPluginZipPublicationToSnapshotsRepository && ./gradlew publishPluginJarToSnapshotsRepository
+          ./gradlew publishAllPublicationsToSnapshotsRepository

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -36,4 +36,4 @@ jobs:
           export SONATYPE_PASSWORD=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-password --query SecretString --output text)
           echo "::add-mask::$SONATYPE_USERNAME"
           echo "::add-mask::$SONATYPE_PASSWORD"
-          ./gradlew publishAllPublicationsToSnapshotsRepository
+          ./gradlew opensearch-job-scheduler-spi:publishAllPublicationsToSnapshotsRepository && ./gradlew publishPluginZipPublicationToSnapshotsRepository && ./gradlew publishMavenJavaToSnapshotsRepository

--- a/build.gradle
+++ b/build.gradle
@@ -103,25 +103,25 @@ allprojects {
             }
             publications {
                 // add license information to generated poms
-                all {
-                    pom {
-                        name = "opensearch-job-scheduler"
-                        description = "OpenSearch Job Scheduler plugin"
-                        groupId = "org.opensearch.plugin"
-                    }
-                    pom.withXml { XmlProvider xml ->
-                        Node node = xml.asNode()
-                        node.appendNode('inceptionYear', '2021')
-
-                        Node license = node.appendNode('licenses').appendNode('license')
-                        license.appendNode('name', project.licenseName)
-                        license.appendNode('url', project.licenseUrl)
-
-                        Node developer = node.appendNode('developers').appendNode('developer')
-                        developer.appendNode('name', 'OpenSearch')
-                        developer.appendNode('url', 'https://github.com/opensearch-project/job-scheduler')
-                    }
-                }
+//               all {
+//                    pom {
+//                        name = "opensearch-job-scheduler"
+//                        description = "OpenSearch Job Scheduler plugin"
+//                        groupId = "org.opensearch.plugin"
+//                    }
+//                    pom.withXml { XmlProvider xml ->
+//                        Node node = xml.asNode()
+//                        node.appendNode('inceptionYear', '2021')
+//
+//                        Node license = node.appendNode('licenses').appendNode('license')
+//                        license.appendNode('name', project.licenseName)
+//                        license.appendNode('url', project.licenseUrl)
+//
+//                        Node developer = node.appendNode('developers').appendNode('developer')
+//                        developer.appendNode('name', 'OpenSearch')
+//                        developer.appendNode('url', 'https://github.com/opensearch-project/job-scheduler')
+//                    }
+//                }
             }
         }
     }
@@ -136,11 +136,31 @@ publishing {
                 groupId = "org.opensearch.plugin"
             }
         }
+        mavenJava(MavenPublication){ publication ->
+            pom {
+                name = "opensearch-job-scheduler"
+                description = "OpenSearch Job Scheduler plugin"
+                packaging = "jar"
+                groupId = "org.opensearch"
+            }
+            pom.withXml { XmlProvider xml ->
+                Node node = xml.asNode()
+                node.appendNode('inceptionYear', '2021')
+
+                Node license = node.appendNode('licenses').appendNode('license')
+                license.appendNode('name', project.licenseName)
+                license.appendNode('url', project.licenseUrl)
+
+                Node developer = node.appendNode('developers').appendNode('developer')
+                developer.appendNode('name', 'OpenSearch')
+                developer.appendNode('url', 'https://github.com/opensearch-project/job-scheduler')
+            }
+        }
     }
     repositories {
         maven {
             name = "Snapshots" //  optional target repository name
-            url = "https://aws.oss.sonatype.org/content/repositories/snapshots"
+            url = "https://aws.oss.sonatype.org/content/repositories/snapshots/snapshots"
             credentials {
                 username "$System.env.SONATYPE_USERNAME"
                 password "$System.env.SONATYPE_PASSWORD"

--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ tasks.whenTaskAdded {task ->
 tasks.matching {it.path in [
         ":generatePomFileForPluginJarPublication"
 ]}.all { task ->
-    task.mustRunAfter 'publishNebulaPublicationToMavenLocal', 'publishNebulaPublicationToSnapshotsRepository'
+    task.mustRunAfter 'publishNebulaPublicationToMavenLocal', 'publishNebulaPublicationToSnapshotsRepository', 'publishNebulaPublicationToStagingRepository'
 }
 
 tasks.matching {it.path in [
@@ -76,7 +76,7 @@ tasks.matching {it.path in [
 tasks.matching {it.path in [
         ":generatePomFileForPluginZipPublication"
 ]}.all { task ->
-    task.mustRunAfter 'publishPluginJarPublicationToMavenLocal', 'publishPluginJarPublicationToSnapshotsRepository'
+    task.mustRunAfter 'publishPluginJarPublicationToMavenLocal', 'publishPluginJarPublicationToSnapshotsRepository', 'publishPluginJarPublicationToStagingRepository'
 }
 
 tasks.matching {it.path in [
@@ -176,6 +176,10 @@ publishing {
                 username "$System.env.SONATYPE_USERNAME"
                 password "$System.env.SONATYPE_PASSWORD"
             }
+        }
+        maven {
+            name = 'Staging'
+            url = "${rootProject.buildDir}/local-staging-repo"
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ buildscript {
 }
 
 plugins {
-    id 'com.netflix.nebula.ospackage' version "11.0.0"
+    id 'com.netflix.nebula.ospackage' version "11.3.0"
     id 'java-library'
     id "com.diffplug.spotless" version "6.17.0" apply false
 }
@@ -52,8 +52,37 @@ forbiddenApisTest.ignoreFailures = true
 validateNebulaPom.enabled = false
 loggerUsageCheck.enabled = false
 
-tasks.matching {it.path in [":publishNebulaPublicationToSnapshotsRepository",":validatePluginJarPom",":validatePluginZipPom"]}.all { task ->
-    task.dependsOn 'generatePomFileForPluginZipPublication','generatePomFileForNebulaPublication','generatePomFileForPluginJarPublication'
+tasks.matching {it.path in [
+    ":publishPluginZipPublicationToMavenLocal",
+    ":validatePluginZipPom"
+]}.all { task ->
+    task.dependsOn 'generatePomFileForPluginZipPublication'
+}
+
+tasks.matching {it.path in [
+        ":publishPluginJarPublicationToMavenLocal",
+        ":validatePluginJarPom"
+]}.all { task ->
+    task.dependsOn 'generatePomFileForPluginJarPublication'
+}
+
+tasks.matching {it.path in [
+        ":generatePomFileForPluginZipPublication"
+]}.all { task ->
+    task.mustRunAfter 'publishPluginJarPublicationToMavenLocal'
+}
+
+tasks.matching {it.path in [
+        ":publishNebulaPublicationToSnapshotsRepository",
+        ":publishNebulaPublicationToMavenLocal"
+]}.all { task ->
+    task.dependsOn 'generatePomFileForNebulaPublication'
+}
+
+tasks.matching {it.path in [
+        ":generatePomFileForPluginJarPublication"
+]}.all { task ->
+    task.mustRunAfter 'publishNebulaPublicationToMavenLocal'
 }
 
 opensearchplugin {
@@ -93,46 +122,15 @@ allprojects {
     // Default to the apache license
     project.ext.licenseName = 'The Apache Software License, Version 2.0'
     project.ext.licenseUrl = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-    plugins.withType(ShadowPlugin).whenPluginAdded {
-        publishing {
-            repositories {
-                maven {
-                    name = 'staging'
-                    url = "${rootProject.buildDir}/local-staging-repo"
-                }
-            }
-            publications {
-                // add license information to generated poms
-//               all {
-//                    pom {
-//                        name = "opensearch-job-scheduler"
-//                        description = "OpenSearch Job Scheduler plugin"
-//                        groupId = "org.opensearch.plugin"
-//                    }
-//                    pom.withXml { XmlProvider xml ->
-//                        Node node = xml.asNode()
-//                        node.appendNode('inceptionYear', '2021')
-//
-//                        Node license = node.appendNode('licenses').appendNode('license')
-//                        license.appendNode('name', project.licenseName)
-//                        license.appendNode('url', project.licenseUrl)
-//
-//                        Node developer = node.appendNode('developers').appendNode('developer')
-//                        developer.appendNode('name', 'OpenSearch')
-//                        developer.appendNode('url', 'https://github.com/opensearch-project/job-scheduler')
-//                    }
-//                }
-            }
-        }
-    }
 }
 
 publishing {
     publications {
-        pluginZip(MavenPublication) { publication ->
+        pluginZip(MavenPublication) {
             pom {
                 name = "opensearch-job-scheduler"
                 description = "OpenSearch Job Scheduler plugin"
+                packaging = "zip"
                 groupId = "org.opensearch.plugin"
             }
             pom.withXml { XmlProvider xml ->
@@ -148,7 +146,7 @@ publishing {
                 developer.appendNode('url', 'https://github.com/opensearch-project/job-scheduler')
             }
         }
-        pluginJar(MavenPublication){ publication ->
+        pluginJar(MavenPublication){
             pom {
                 name = "opensearch-job-scheduler"
                 description = "OpenSearch Job Scheduler plugin"

--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ tasks.whenTaskAdded {task ->
 tasks.matching {it.path in [
         ":generatePomFileForPluginJarPublication"
 ]}.all { task ->
-    task.mustRunAfter 'publishNebulaPublicationToMavenLocal'
+    task.mustRunAfter 'publishNebulaPublicationToMavenLocal', 'publishNebulaPublicationToSnapshotsRepository'
 }
 
 tasks.matching {it.path in [
@@ -76,7 +76,7 @@ tasks.matching {it.path in [
 tasks.matching {it.path in [
         ":generatePomFileForPluginZipPublication"
 ]}.all { task ->
-    task.mustRunAfter 'publishPluginJarPublicationToMavenLocal'
+    task.mustRunAfter 'publishPluginJarPublicationToMavenLocal', 'publishPluginJarPublicationToSnapshotsRepository'
 }
 
 tasks.matching {it.path in [

--- a/build.gradle
+++ b/build.gradle
@@ -52,11 +52,18 @@ forbiddenApisTest.ignoreFailures = true
 validateNebulaPom.enabled = false
 loggerUsageCheck.enabled = false
 
+// Order is publish nebula, then jar then zip
+
+tasks.whenTaskAdded {task ->
+    if(task.name.contains("validatePluginJarPom") || task.name.contains("validatePluginZipPom")) {
+        task.enabled = false
+    }
+}
+
 tasks.matching {it.path in [
-    ":publishPluginZipPublicationToMavenLocal",
-    ":validatePluginZipPom"
+        ":generatePomFileForPluginJarPublication"
 ]}.all { task ->
-    task.dependsOn 'generatePomFileForPluginZipPublication'
+    task.mustRunAfter 'publishNebulaPublicationToMavenLocal'
 }
 
 tasks.matching {it.path in [
@@ -73,16 +80,10 @@ tasks.matching {it.path in [
 }
 
 tasks.matching {it.path in [
-        ":publishNebulaPublicationToSnapshotsRepository",
-        ":publishNebulaPublicationToMavenLocal"
+        ":publishPluginZipPublicationToMavenLocal",
+        ":validatePluginZipPom"
 ]}.all { task ->
-    task.dependsOn 'generatePomFileForNebulaPublication'
-}
-
-tasks.matching {it.path in [
-        ":generatePomFileForPluginJarPublication"
-]}.all { task ->
-    task.mustRunAfter 'publishNebulaPublicationToMavenLocal'
+    task.dependsOn 'generatePomFileForPluginZipPublication'
 }
 
 opensearchplugin {

--- a/build.gradle
+++ b/build.gradle
@@ -52,8 +52,8 @@ forbiddenApisTest.ignoreFailures = true
 validateNebulaPom.enabled = false
 loggerUsageCheck.enabled = false
 
-tasks.matching {it.path in [":publishNebulaPublicationToSnapshotsRepository"]}.all { task ->
-    task.dependsOn 'generatePomFileForPluginZipPublication'
+tasks.matching {it.path in [":publishNebulaPublicationToSnapshotsRepository",":validatePluginJarPom",":validatePluginZipPom"]}.all { task ->
+    task.dependsOn 'generatePomFileForPluginZipPublication','generatePomFileForNebulaPublication','generatePomFileForPluginJarPublication'
 }
 
 opensearchplugin {
@@ -135,8 +135,20 @@ publishing {
                 description = "OpenSearch Job Scheduler plugin"
                 groupId = "org.opensearch.plugin"
             }
+            pom.withXml { XmlProvider xml ->
+                Node node = xml.asNode()
+                node.appendNode('inceptionYear', '2021')
+
+                Node license = node.appendNode('licenses').appendNode('license')
+                license.appendNode('name', project.licenseName)
+                license.appendNode('url', project.licenseUrl)
+
+                Node developer = node.appendNode('developers').appendNode('developer')
+                developer.appendNode('name', 'OpenSearch')
+                developer.appendNode('url', 'https://github.com/opensearch-project/job-scheduler')
+            }
         }
-        mavenJava(MavenPublication){ publication ->
+        pluginJar(MavenPublication){ publication ->
             pom {
                 name = "opensearch-job-scheduler"
                 description = "OpenSearch Job Scheduler plugin"
@@ -160,7 +172,7 @@ publishing {
     repositories {
         maven {
             name = "Snapshots" //  optional target repository name
-            url = "https://aws.oss.sonatype.org/content/repositories/snapshots/snapshots"
+            url = "https://aws.oss.sonatype.org/content/repositories/snapshots"
             credentials {
                 username "$System.env.SONATYPE_USERNAME"
                 password "$System.env.SONATYPE_PASSWORD"

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,4 +10,3 @@ project(":spi").name = rootProject.name + "-spi"
 
 include "sample-extension-plugin"
 project(":sample-extension-plugin").name = rootProject.name + "-sample-extension"
-startParameter.excludedTaskNames=["publishPluginZipPublicationToMavenLocal", "publishPluginZipPublicationToStagingRepository"]


### PR DESCRIPTION
### Description

Updates JS build.gradle to publish jars to `org.opensearch` and zips to `org.opensearch.plugin`. This also fixes an issue with the local maven publication to publish the artifacts in the correct places when performing `./gradlew publishToMavenLocal`
 
### Issues Resolved

https://github.com/opensearch-project/job-scheduler/issues/374
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
