### PR TITLE
Fix the Maven publish

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -36,4 +36,9 @@ jobs:
           export SONATYPE_PASSWORD=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-password --query SecretString --output text)
           echo "::add-mask::$SONATYPE_USERNAME"
           echo "::add-mask::$SONATYPE_PASSWORD"
-          ./gradlew publishAllPublicationsToSnapshotsRepository
+          # For JS-SPI jar
+          ./gradlew publishShadowPublicationToSnapshotsRepository
+          # For JS jar
+          ./gradlew publishNebulaPublicationToSnapshotsRepository
+          # For JS plugin zip
+          ./gradlew publishPluginZipPublicationToSnapshotsRepository

--- a/build.gradle
+++ b/build.gradle
@@ -52,40 +52,6 @@ forbiddenApisTest.ignoreFailures = true
 validateNebulaPom.enabled = false
 loggerUsageCheck.enabled = false
 
-// Order is publish nebula, then jar then zip
-
-tasks.whenTaskAdded {task ->
-    if(task.name.contains("validatePluginJarPom") || task.name.contains("validatePluginZipPom")) {
-        task.enabled = false
-    }
-}
-
-tasks.matching {it.path in [
-        ":generatePomFileForPluginJarPublication"
-]}.all { task ->
-    task.mustRunAfter 'publishNebulaPublicationToMavenLocal', 'publishNebulaPublicationToSnapshotsRepository', 'publishNebulaPublicationToStagingRepository'
-}
-
-tasks.matching {it.path in [
-        ":publishPluginJarPublicationToMavenLocal",
-        ":validatePluginJarPom"
-]}.all { task ->
-    task.dependsOn 'generatePomFileForPluginJarPublication'
-}
-
-tasks.matching {it.path in [
-        ":generatePomFileForPluginZipPublication"
-]}.all { task ->
-    task.mustRunAfter 'publishPluginJarPublicationToMavenLocal', 'publishPluginJarPublicationToSnapshotsRepository', 'publishPluginJarPublicationToStagingRepository'
-}
-
-tasks.matching {it.path in [
-        ":publishPluginZipPublicationToMavenLocal",
-        ":validatePluginZipPom"
-]}.all { task ->
-    task.dependsOn 'generatePomFileForPluginZipPublication'
-}
-
 opensearchplugin {
     name 'opensearch-job-scheduler'
     description 'OpenSearch Job Scheduler plugin'
@@ -123,48 +89,46 @@ allprojects {
     // Default to the apache license
     project.ext.licenseName = 'The Apache Software License, Version 2.0'
     project.ext.licenseUrl = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+    plugins.withType(ShadowPlugin).whenPluginAdded {
+        publishing {
+            repositories {
+                maven {
+                    name = 'staging'
+                    url = "${rootProject.buildDir}/local-staging-repo"
+                }
+            }
+            publications {
+                // add license information to generated poms
+                all {
+                    pom {
+                        name = "opensearch-job-scheduler"
+                        description = "OpenSearch Job Scheduler plugin"
+                    }
+                    pom.withXml { XmlProvider xml ->
+                        Node node = xml.asNode()
+                        node.appendNode('inceptionYear', '2021')
+
+                        Node license = node.appendNode('licenses').appendNode('license')
+                        license.appendNode('name', project.licenseName)
+                        license.appendNode('url', project.licenseUrl)
+
+                        Node developer = node.appendNode('developers').appendNode('developer')
+                        developer.appendNode('name', 'OpenSearch')
+                        developer.appendNode('url', 'https://github.com/opensearch-project/job-scheduler')
+                    }
+                }
+            }
+        }
+    }
 }
 
 publishing {
     publications {
-        pluginZip(MavenPublication) {
+        pluginZip(MavenPublication) { publication ->
             pom {
                 name = "opensearch-job-scheduler"
                 description = "OpenSearch Job Scheduler plugin"
-                packaging = "zip"
                 groupId = "org.opensearch.plugin"
-            }
-            pom.withXml { XmlProvider xml ->
-                Node node = xml.asNode()
-                node.appendNode('inceptionYear', '2021')
-
-                Node license = node.appendNode('licenses').appendNode('license')
-                license.appendNode('name', project.licenseName)
-                license.appendNode('url', project.licenseUrl)
-
-                Node developer = node.appendNode('developers').appendNode('developer')
-                developer.appendNode('name', 'OpenSearch')
-                developer.appendNode('url', 'https://github.com/opensearch-project/job-scheduler')
-            }
-        }
-        pluginJar(MavenPublication){
-            pom {
-                name = "opensearch-job-scheduler"
-                description = "OpenSearch Job Scheduler plugin"
-                packaging = "jar"
-                groupId = "org.opensearch"
-            }
-            pom.withXml { XmlProvider xml ->
-                Node node = xml.asNode()
-                node.appendNode('inceptionYear', '2021')
-
-                Node license = node.appendNode('licenses').appendNode('license')
-                license.appendNode('name', project.licenseName)
-                license.appendNode('url', project.licenseUrl)
-
-                Node developer = node.appendNode('developers').appendNode('developer')
-                developer.appendNode('name', 'OpenSearch')
-                developer.appendNode('url', 'https://github.com/opensearch-project/job-scheduler')
             }
         }
     }
@@ -176,10 +140,6 @@ publishing {
                 username "$System.env.SONATYPE_USERNAME"
                 password "$System.env.SONATYPE_PASSWORD"
             }
-        }
-        maven {
-            name = 'Staging'
-            url = "${rootProject.buildDir}/local-staging-repo"
         }
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,3 +10,4 @@ project(":spi").name = rootProject.name + "-spi"
 
 include "sample-extension-plugin"
 project(":sample-extension-plugin").name = rootProject.name + "-sample-extension"
+startParameter.excludedTaskNames=["publishPluginZipPublicationToMavenLocal", "publishPluginZipPublicationToStagingRepository"]


### PR DESCRIPTION
### Description
Fixes the JS, JS-SPI and JS plugin zip maven publication.
 
### Issues Resolved
https://github.com/opensearch-project/job-scheduler/issues/374
https://github.com/opensearch-project/job-scheduler/pull/377#issuecomment-1536865210
 
### Testing Output:

For testing purposes I have used `url 'file://Users/pgodithi/.m2/repository'` for `Snapshots` Repo

#### For JS-SPI
```
./gradlew publishShadowPublicationToSnapshotsRepository
Picked up JAVA_TOOL_OPTIONS: -Dlog4j2.formatMsgNoLookups=true
=======================================
OpenSearch Build Hamster says Hello!
  Gradle Version        : 8.0.2
  OS Info               : Mac OS X 13.3.1 (aarch64)
  JDK Version           : 11 (Homebrew JDK)
  JAVA_HOME             : /opt/homebrew/Cellar/openjdk@11/11.0.16.1/libexec/openjdk.jdk/Contents/Home
  Random Testing Seed   : 259E5FD293BAE552
  In FIPS 140 mode      : false
=======================================

> Task :opensearch-job-scheduler-spi:publishShadowPublicationToSnapshotsRepository
file:/Users/pgodithi/.m2/repository//org/opensearch/opensearch-job-scheduler-spi/3.0.0.0-SNAPSHOT/opensearch-job-scheduler-spi.jar
file:/Users/pgodithi/.m2/repository//org/opensearch/opensearch-job-scheduler-spi/3.0.0.0-SNAPSHOT/opensearch-job-scheduler-spi-sources.jar
file:/Users/pgodithi/.m2/repository//org/opensearch/opensearch-job-scheduler-spi/3.0.0.0-SNAPSHOT/opensearch-job-scheduler-spi-javadoc.jar

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/8.0.2/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 1s
8 actionable tasks: 2 executed, 6 up-to-date

```

#### For JS
```
./gradlew publishNebulaPublicationToSnapshotsRepository
Picked up JAVA_TOOL_OPTIONS: -Dlog4j2.formatMsgNoLookups=true
=======================================
OpenSearch Build Hamster says Hello!
  Gradle Version        : 8.0.2
  OS Info               : Mac OS X 13.3.1 (aarch64)
  JDK Version           : 11 (Homebrew JDK)
  JAVA_HOME             : /opt/homebrew/Cellar/openjdk@11/11.0.16.1/libexec/openjdk.jdk/Contents/Home
  Random Testing Seed   : 8CC5B5F3E22974FD
  In FIPS 140 mode      : false
=======================================

> Task :compileJava
Note: /Users/pgodithi/git/job-scheduler/src/main/java/org/opensearch/jobscheduler/JobSchedulerPlugin.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :javadoc
Picked up JAVA_TOOL_OPTIONS: -Dlog4j2.formatMsgNoLookups=true

> Task :publishNebulaPublicationToSnapshotsRepository
file:/Users/pgodithi/.m2/repository//org/opensearch/opensearch-job-scheduler/3.0.0.0-SNAPSHOT/opensearch-job-scheduler-sources.jar
file:/Users/pgodithi/.m2/repository//org/opensearch/opensearch-job-scheduler/3.0.0.0-SNAPSHOT/opensearch-job-scheduler-javadoc.jar
file:/Users/pgodithi/.m2/repository//org/opensearch/opensearch-job-scheduler/3.0.0.0-SNAPSHOT/opensearch-job-scheduler.jar

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/8.0.2/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 2s
12 actionable tasks: 9 executed, 3 up-to-date

```
#### For JS plugin zip
```
./gradlew publishPluginZipPublicationToSnapshotsRepository 
Picked up JAVA_TOOL_OPTIONS: -Dlog4j2.formatMsgNoLookups=true
=======================================
OpenSearch Build Hamster says Hello!
  Gradle Version        : 8.0.2
  OS Info               : Mac OS X 13.3.1 (aarch64)
  JDK Version           : 11 (Homebrew JDK)
  JAVA_HOME             : /opt/homebrew/Cellar/openjdk@11/11.0.16.1/libexec/openjdk.jdk/Contents/Home
  Random Testing Seed   : 6D40A80242B82066
  In FIPS 140 mode      : false
=======================================

> Task :publishPluginZipPublicationToSnapshotsRepository
file:/Users/pgodithi/.m2/repository//org/opensearch/plugin/opensearch-job-scheduler/3.0.0.0-SNAPSHOT/opensearch-job-scheduler.zip

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/8.0.2/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 724ms
12 actionable tasks: 6 executed, 6 up-to-date
```

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
