### PR TITLE
Consuming breaking changes from moving ExtensionActionRequest

### DIFF
--- a/src/main/java/org/opensearch/jobscheduler/transport/request/ExtensionJobActionRequest.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/request/ExtensionJobActionRequest.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 
+import com.google.protobuf.ByteString;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.io.stream.Writeable;
@@ -33,7 +34,7 @@ public class ExtensionJobActionRequest<T extends Writeable> extends ExtensionAct
      * @throws IOException if serialization fails
      */
     public ExtensionJobActionRequest(String extensionActionName, T actionParams) throws IOException {
-        super(extensionActionName, convertParamsToBytes(actionParams));
+        super(extensionActionName, convertParamsToByteString(actionParams));
     }
 
     /**
@@ -44,7 +45,7 @@ public class ExtensionJobActionRequest<T extends Writeable> extends ExtensionAct
      * @throws IOException if serialization fails
      * @return the byte array of the parameters
      */
-    private static <T extends Writeable> byte[] convertParamsToBytes(T actionParams) throws IOException {
+    private static <T extends Writeable> ByteString convertParamsToByteString(T actionParams) throws IOException {
 
         // Write inner request to output stream and convert to byte array
         BytesStreamOutput out = new BytesStreamOutput();
@@ -62,7 +63,7 @@ public class ExtensionJobActionRequest<T extends Writeable> extends ExtensionAct
             .put(requestBytes)
             .array();
 
-        return proxyRequestBytes;
+        return ByteString.copyFrom(proxyRequestBytes);
     }
 
 }

--- a/src/test/java/org/opensearch/jobscheduler/utils/JobDetailsServiceIT.java
+++ b/src/test/java/org/opensearch/jobscheduler/utils/JobDetailsServiceIT.java
@@ -347,7 +347,7 @@ public class JobDetailsServiceIT extends OpenSearchIntegTestCase {
                 actionRequest = new ExtensionActionRequest(in);
 
                 // Trim request class bytes from requestBytes
-                byte[] trimmedRequestBytes = trimRequestBytes(actionRequest.getRequestBytes());
+                byte[] trimmedRequestBytes = trimRequestBytes(actionRequest.getRequestBytes().toByteArray());
 
                 // Test deserialization of action request params
                 JobRunnerRequest deserializedRequest = new JobRunnerRequest(trimmedRequestBytes);
@@ -385,7 +385,7 @@ public class JobDetailsServiceIT extends OpenSearchIntegTestCase {
                 actionRequest = new ExtensionActionRequest(in);
 
                 // Trim request class bytes from requestBytes
-                byte[] trimmedRequestBytes = trimRequestBytes(actionRequest.getRequestBytes());
+                byte[] trimmedRequestBytes = trimRequestBytes(actionRequest.getRequestBytes().toByteArray());
 
                 // Test deserialization of action request params
                 JobParameterRequest deserializedRequest = new JobParameterRequest(trimmedRequestBytes);


### PR DESCRIPTION
### Description
Companion PR of: https://github.com/opensearch-project/OpenSearch/pull/7468 as the signature of API changed. 
 
### Issues Resolved
Unblocks: https://github.com/opensearch-project/anomaly-detection/actions/runs/4929882106/jobs/8810089919?pr=890
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
