### PR TITLE
Update job details mapping

### DIFF
--- a/src/main/resources/mappings/opensearch_job_scheduler_job_details.json
+++ b/src/main/resources/mappings/opensearch_job_scheduler_job_details.json
@@ -1,10 +1,10 @@
 {
   "dynamic": "false",
   "properties": {
-    "job_index_name": {
+    "job_index": {
       "type": "keyword"
     },
-    "job_type_name": {
+    "job_type": {
       "type": "keyword"
     },
     "job_parser_action": {


### PR DESCRIPTION
### Description

While testing Job Scheduler for extensions, I ran into an issue where the documents being entered into the Jobs Details index (`.opensearch-job-scheduler-job-details`) looked like:

```
{
    "job_index": ".hello-world-jobs",
    "job_type": "GreetJob",
    "job_parser_action": "org.opensearch.sdk.sample.helloworld.transport.HWJobParameterAction",
    "job_runner_action": "org.opensearch.sdk.sample.helloworld.transport.HWJobRunnerAction",
    "extension_unique_id": "hw"
}
```

and I used the `GetJobDetailsRequest` to create the entry in this index. Details: https://github.com/opensearch-project/job-scheduler/blob/main/src/main/java/org/opensearch/jobscheduler/rest/request/GetJobDetailsRequest.java#L38-L43

The mappings file expects fields `job_index_name` and `job_type_name` which does not match the field name in GetJobDetailsRequest. This PR updates the mappings to match so that this index supports keyword searching.
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
