### PR TITLE
fix: time out of range

### DIFF
--- a/src/main/java/org/opensearch/jobscheduler/scheduler/JobScheduler.java
+++ b/src/main/java/org/opensearch/jobscheduler/scheduler/JobScheduler.java
@@ -148,7 +148,18 @@ public class JobScheduler {
             log.info("No next execution time for job {}", jobParameter.getName());
             return true;
         }
-        Duration duration = Duration.between(this.clock.instant(), nextExecutionTime);
+        Instant now = this.clock.instant();
+        Duration duration = Duration.between(now, nextExecutionTime);
+        if (duration.toNanos() < 0) {
+            log.info(
+                "job {} expect time: {} < current time: {}, set next excute time to current",
+                jobParameter.getName(),
+                nextExecutionTime.toEpochMilli(),
+                now.toEpochMilli()
+            );
+            nextExecutionTime = now;
+            duration = Duration.ZERO;
+        }
 
         // Too many jobs start at the same time point will bring burst. Add random jitter delay to spread out load.
         // Example, if interval is 10 minutes, jitter is 0.6, next job run will be randomly delayed by 0 to 10*0.6 minutes.

--- a/src/main/java/org/opensearch/jobscheduler/scheduler/JobScheduler.java
+++ b/src/main/java/org/opensearch/jobscheduler/scheduler/JobScheduler.java
@@ -119,7 +119,7 @@ public class JobScheduler {
         jobInfo.setExpectedPreviousExecutionTime(null);
         Scheduler.ScheduledCancellable scheduledCancellable = jobInfo.getScheduledCancellable();
 
-        if (scheduledCancellable != null && scheduledCancellable.cancel() == false) {
+        if (scheduledCancellable != null && !scheduledCancellable.cancel()) {
             return false;
         }
         this.scheduledJobInfo.removeJob(indexName, id);
@@ -147,9 +147,9 @@ public class JobScheduler {
         }
         Instant now = this.clock.instant();
         Duration duration = Duration.between(now, nextExecutionTime);
-        if (duration.toNanos() < 0) {
+        if (duration.isNegative()) {
             log.info(
-                "job {} expect time: {} < current time: {}, set next excute time to current",
+                "job {} expected time: {} < current time: {}, setting next execute time to current",
                 jobParameter.getName(),
                 nextExecutionTime.toEpochMilli(),
                 now.toEpochMilli()

--- a/src/main/java/org/opensearch/jobscheduler/scheduler/JobScheduler.java
+++ b/src/main/java/org/opensearch/jobscheduler/scheduler/JobScheduler.java
@@ -119,13 +119,10 @@ public class JobScheduler {
         jobInfo.setExpectedPreviousExecutionTime(null);
         Scheduler.ScheduledCancellable scheduledCancellable = jobInfo.getScheduledCancellable();
 
-        if (scheduledCancellable != null) {
-            if (scheduledCancellable.cancel()) {
-                this.scheduledJobInfo.removeJob(indexName, id);
-            } else {
-                return false;
-            }
+        if (scheduledCancellable != null && scheduledCancellable.cancel() == false) {
+            return false;
         }
+        this.scheduledJobInfo.removeJob(indexName, id);
 
         return true;
     }


### PR DESCRIPTION
We found that when current time greater than `nextExecutionTime`, the `TimeValue` in `threadPool.schedule` will throw an `IllegalArgumentException` as following
```[2023-06-06T22:10:04,144][ERROR][o.e.b.ElasticsearchUncaughtExceptionHandler] [es-data-y850og2ns2zzcu5n-5] uncaught exception in thread [elasticsearch[es-data-y850og2ns2zzcu5n-5][open_distro_job_scheduler][T#8]]
java.lang.IllegalArgumentException: duration cannot be negative, was given [-2965077933106]
        at org.elasticsearch.common.unit.TimeValue.<init>(TimeValue.java:52) ~[elasticsearch-core-7.10.2.jar:7.10.2]
        at com.amazon.opendistroforelasticsearch.jobscheduler.scheduler.JobScheduler.reschedule(JobScheduler.java:190) ~[?:?]
        at com.amazon.opendistroforelasticsearch.jobscheduler.scheduler.JobScheduler.lambda$reschedule$0(JobScheduler.java:177) ~[?:?]
        at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:684) ~[elasticsearch-7.10.2.jar:7.10.2]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630) ~[?:?]
        at java.lang.Thread.run(Thread.java:832) [?:?]
```

Then the job will not be scheduled anymore. 
This change fixes this, by setting the `nextExecutionTime` to current time.

Thanks my colleague @kkewwei solve this out.

Signed-off-by: fudongying <[fudongying@bytedance.com](mailto:fudongying@bytedance.com)>
Signed-off-by: kewei.11 <[kewei.11@bytedance.com](mailto:kewei.11@bytedance.com)>