### PR TITLE
Upgrade guava from 31.0.1-jre to latest 32.1.1-jre.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -150,13 +150,17 @@ repositories {
     maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
 }
 
-dependencies {
-    implementation project(path: ":${rootProject.name}-spi", configuration: 'shadow')
-    constraints {
-        implementation("com.google.guava:guava:32.1.1-jre") {
-            because 'versions below 32.0.1 have active CVE'
+configurations {
+    all {
+        resolutionStrategy {
+            force 'com.google.guava:guava:32.0.1-jre'
         }
     }
+}
+
+dependencies {
+    implementation project(path: ":${rootProject.name}-spi", configuration: 'shadow')
+    implementation group: 'com.google.guava', name: 'guava', version:'32.0.1-jre'
     implementation group: 'com.google.guava', name: 'failureaccess', version:'1.0.1'
     javaRestTestImplementation project.sourceSets.main.runtimeClasspath
     //spotless

--- a/build.gradle
+++ b/build.gradle
@@ -152,9 +152,18 @@ repositories {
 
 dependencies {
     implementation project(path: ":${rootProject.name}-spi", configuration: 'shadow')
+    constraints {
+        implementation("com.google.guava:guava:32.1.1-jre") {
+            because 'versions below 32.0.1 have active CVE'
+        }
+    }
     implementation group: 'com.google.guava', name: 'guava', version:'32.1.1-jre'
     implementation group: 'com.google.guava', name: 'failureaccess', version:'1.0.1'
     javaRestTestImplementation project.sourceSets.main.runtimeClasspath
+    //spotless
+    implementation('com.google.googlejavaformat:google-java-format:1.15.0') {
+        exclude group: 'com.google.guava'
+    }
 }
 
 // RPM & Debian build

--- a/build.gradle
+++ b/build.gradle
@@ -152,7 +152,7 @@ repositories {
 
 dependencies {
     implementation project(path: ":${rootProject.name}-spi", configuration: 'shadow')
-    implementation group: 'com.google.guava', name: 'guava', version:'31.0.1-jre'
+    implementation group: 'com.google.guava', name: 'guava', version:'32.1.1-jre'
     implementation group: 'com.google.guava', name: 'failureaccess', version:'1.0.1'
     javaRestTestImplementation project.sourceSets.main.runtimeClasspath
 }

--- a/build.gradle
+++ b/build.gradle
@@ -157,7 +157,6 @@ dependencies {
             because 'versions below 32.0.1 have active CVE'
         }
     }
-    implementation group: 'com.google.guava', name: 'guava', version:'32.1.1-jre'
     implementation group: 'com.google.guava', name: 'failureaccess', version:'1.0.1'
     javaRestTestImplementation project.sourceSets.main.runtimeClasspath
     //spotless


### PR DESCRIPTION
### Description
This PR Upgrades guava from 31.0.1-jre to latest 32.1.1-jre to fix the [CVE-2023-2976](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2976)
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
