### PR TITLE
Exclude bwc test for MacOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Build and Test
         run: |
-          ./gradlew build -x bwcTestSuite
+          ./gradlew build
 
       - name: Publish to Maven Local
         run: |

--- a/sample-extension-plugin/build.gradle
+++ b/sample-extension-plugin/build.gradle
@@ -9,6 +9,7 @@ apply plugin: 'opensearch.java-rest-test'
 
 import org.opensearch.gradle.test.RestIntegTestTask
 import org.opensearch.gradle.testclusters.StandaloneRestIntegTestTask
+import org.apache.tools.ant.taskdefs.condition.Os
 
 import java.util.concurrent.Callable
 
@@ -278,7 +279,9 @@ task bwcTestSuite(type: StandaloneRestIntegTestTask) {
     dependsOn tasks.named("${baseName}#rollingUpgradeClusterTask")
     dependsOn tasks.named("${baseName}#fullRestartClusterTask")
 }
-tasks.named("check").configure {dependsOn(bwcTestSuite)}
+if (!(Os.isFamily(Os.FAMILY_MAC))) {
+    tasks.named("check").configure {dependsOn(bwcTestSuite)}
+}
 
 run {
     doFirst {

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,4 +10,4 @@ project(":spi").name = rootProject.name + "-spi"
 
 include "sample-extension-plugin"
 project(":sample-extension-plugin").name = rootProject.name + "-sample-extension"
-startParameter.excludedTaskNames=["publishPluginZipPublicationToMavenLocal", "publishPluginZipPublicationToStagingRepository"]
+startParameter.excludedTaskNames=["publishPluginZipPublicationToMavenLocal", "publishPluginZipPublicationToStagingRepository", "bwcTestSuite"]

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,4 +10,4 @@ project(":spi").name = rootProject.name + "-spi"
 
 include "sample-extension-plugin"
 project(":sample-extension-plugin").name = rootProject.name + "-sample-extension"
-startParameter.excludedTaskNames=["publishPluginZipPublicationToMavenLocal", "publishPluginZipPublicationToStagingRepository", "bwcTestSuite"]
+startParameter.excludedTaskNames=["publishPluginZipPublicationToMavenLocal", "publishPluginZipPublicationToStagingRepository"]


### PR DESCRIPTION
### Description
Exclude bwc test for MacOS as artifacts for Mac are not available in release.
 
### Issues Resolved
Part of https://github.com/opensearch-project/job-scheduler/issues/76
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
