### PR TITLE
Force DOCUMENT replication on lock index

### DIFF
--- a/spi/src/main/java/org/opensearch/jobscheduler/spi/utils/LockService.java
+++ b/spi/src/main/java/org/opensearch/jobscheduler/spi/utils/LockService.java
@@ -24,6 +24,7 @@ import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.ToXContent;
@@ -41,6 +42,9 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+
+import static org.opensearch.indices.replication.common.ReplicationType.DOCUMENT;
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REPLICATION_TYPE;
 
 public final class LockService {
     private static final Logger logger = LogManager.getLogger(LockService.class);
@@ -80,7 +84,10 @@ public final class LockService {
         if (lockIndexExist()) {
             listener.onResponse(true);
         } else {
-            final CreateIndexRequest request = new CreateIndexRequest(LOCK_INDEX_NAME).mapping(lockMapping());
+            // Temporarily force DOCUMENT replication until SEGMENT supports GET by id
+            // https://github.com/opensearch-project/OpenSearch/issues/8536
+            Settings replicationSettings = Settings.builder().put(SETTING_REPLICATION_TYPE, DOCUMENT.name()).build();
+            final CreateIndexRequest request = new CreateIndexRequest(LOCK_INDEX_NAME, replicationSettings).mapping(lockMapping());
             client.admin()
                 .indices()
                 .create(request, ActionListener.wrap(response -> listener.onResponse(response.isAcknowledged()), exception -> {

--- a/src/test/java/org/opensearch/jobscheduler/multinode/GetLockMultiNodeRestIT.java
+++ b/src/test/java/org/opensearch/jobscheduler/multinode/GetLockMultiNodeRestIT.java
@@ -23,7 +23,7 @@ import org.opensearch.test.OpenSearchIntegTestCase;
 
 import com.google.common.collect.ImmutableMap;
 
-@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 21)
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE, numDataNodes = 2)
 public class GetLockMultiNodeRestIT extends ODFERestTestCase {
 
     private String initialJobId;
@@ -53,7 +53,7 @@ public class GetLockMultiNodeRestIT extends ODFERestTestCase {
         assertEquals(TestHelpers.generateExpectedLockId(initialJobIndexName, initialJobId), initialLockId);
 
         // Submit 10 requests to generate new lock models for different job indexes
-        for (int i = 0; i < 10000; i++) {
+        for (int i = 0; i < 10; i++) {
             String expectedLockId = TestHelpers.generateExpectedLockId(String.valueOf(i), String.valueOf(i));
             Response getLockResponse = TestHelpers.makeRequest(
                 client(),


### PR DESCRIPTION
### Description

 - Adds an integration test to test that the lock was added to the index.
 - As a temporary workaround, forces the lock index to use DOCUMENT replication until SegRep supports Get by ID
 
### Issues Resolved

In support of #407 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
