### PR TITLE
Call listner.onFailure when lock creation failed

### DIFF
--- a/spi/src/main/java/org/opensearch/jobscheduler/spi/utils/LockService.java
+++ b/spi/src/main/java/org/opensearch/jobscheduler/spi/utils/LockService.java
@@ -236,17 +236,16 @@ public final class LockService {
                     exception -> {
                         if (exception instanceof VersionConflictEngineException) {
                             logger.debug("Lock is already created. {}", exception.getMessage());
+                            listener.onResponse(null);
+                            return;
                         }
-                        if (exception instanceof IOException) {
-                            logger.error("IOException occurred creating lock", exception);
-                        }
-                        listener.onResponse(null);
+                        listener.onFailure(exception);
                     }
                 )
             );
         } catch (IOException e) {
             logger.error("IOException occurred creating lock", e);
-            listener.onResponse(null);
+            listener.onFailure(e);
         }
     }
 


### PR DESCRIPTION
### Description
When lockId is too long, it silently call `onResponse` of listener with `null`. In such case, we don't know if lock acquire is failed because the lock is being hold by other processor, or lock creation itself is failed. We should call `onFailure` with `exception` so that caller can handle such case accordingly.
 
### Issues Resolved
N/A
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
