### PR TITLE
Bump slf4j-api to 2.0.7, ospackage to 11.4.0, google-java-format to 1.17.0, guava to 32.1.2-jre and spotless to 6.20.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,9 +24,9 @@ buildscript {
 }
 
 plugins {
-    id 'com.netflix.nebula.ospackage' version "11.3.0"
+    id 'com.netflix.nebula.ospackage' version "11.4.0"
     id 'java-library'
-    id "com.diffplug.spotless" version "6.17.0" apply false
+    id "com.diffplug.spotless" version "6.20.0" apply false
 }
 
 apply plugin: 'opensearch.opensearchplugin'
@@ -153,18 +153,18 @@ repositories {
 configurations {
     all {
         resolutionStrategy {
-            force 'com.google.guava:guava:32.0.1-jre'
+            force 'com.google.guava:guava:32.1.2-jre'
         }
     }
 }
 
 dependencies {
     implementation project(path: ":${rootProject.name}-spi", configuration: 'shadow')
-    implementation group: 'com.google.guava', name: 'guava', version:'32.0.1-jre'
+    implementation group: 'com.google.guava', name: 'guava', version:'32.1.2-jre'
     implementation group: 'com.google.guava', name: 'failureaccess', version:'1.0.1'
     javaRestTestImplementation project.sourceSets.main.runtimeClasspath
     //spotless
-    implementation('com.google.googlejavaformat:google-java-format:1.15.0') {
+    implementation('com.google.googlejavaformat:google-java-format:1.17.0') {
         exclude group: 'com.google.guava'
     }
 }

--- a/spi/build.gradle
+++ b/spi/build.gradle
@@ -43,7 +43,7 @@ jacocoTestReport {
 }
 check.dependsOn jacocoTestReport
 
-def slf4j_version_of_cronutils = "1.7.36"
+def slf4j_version_of_cronutils = "2.0.7"
 dependencies {
     compileOnly "org.opensearch:opensearch:${opensearch_version}"
     // slf4j is the runtime dependency of cron-utils


### PR DESCRIPTION
### Description

Dependabot created a number of PRs to bump dependencies, but they all got autoclosed by mend. This PR manually bumps the versions.

- https://github.com/opensearch-project/job-scheduler/pull/446
- https://github.com/opensearch-project/job-scheduler/pull/447
- https://github.com/opensearch-project/job-scheduler/pull/448
- https://github.com/opensearch-project/job-scheduler/pull/449
- https://github.com/opensearch-project/job-scheduler/pull/450
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
