### PR TITLE
Add CI workflow step to upload reports to Github

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,10 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: ${{ matrix.os }}-JDK${{ matrix.java }}-reports
+          path: |
+            ./build/reports/


### PR DESCRIPTION
### Description

Adds a CI workflow step to upload reports to Github.

<img width="1775" alt="Screenshot 2023-08-04 at 11 43 46 AM" src="https://github.com/opensearch-project/job-scheduler/assets/17432265/2f9e9a77-a01c-4b63-8520-df508b27da1e">
 
### Issues Resolved

Related: https://github.com/opensearch-project/job-scheduler/issues/52
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
