### PR TITLE
[Backport 2.x] Updating MAINTAINERS.md

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*    @joshpalis @saratvemulapalli @dbwiddis @kaituo @vibrantvarun
+*    @joshpalis @saratvemulapalli @dbwiddis @kaituo @vibrantvarun @cwperks

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -11,6 +11,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Dan Widdis        | [dbwiddis](https://github.com/dbwiddis)                 | Amazon      |
 | Kaituo Li         | [kaituo](https://github.com/kaituo)                     | Amazon      |
 | Varun Jain        | [vibrantvarun](https://github.com/vibrantvarun)         | Amazon      |
+| Craig Perkins     | [cwperks](https://github.com/cwperks)                   | Amazon      |
 
 ## Emeritus Maintainers
 


### PR DESCRIPTION
### Description
Manual Backport of https://github.com/opensearch-project/job-scheduler/pull/460
 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
