### PR TITLE
Reverts Document Replication lock index setting

### DIFF
--- a/spi/src/main/java/org/opensearch/jobscheduler/spi/utils/LockService.java
+++ b/spi/src/main/java/org/opensearch/jobscheduler/spi/utils/LockService.java
@@ -24,7 +24,6 @@ import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.service.ClusterService;
-import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.ToXContent;
@@ -42,9 +41,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
-
-import static org.opensearch.indices.replication.common.ReplicationType.DOCUMENT;
-import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REPLICATION_TYPE;
 
 public final class LockService {
     private static final Logger logger = LogManager.getLogger(LockService.class);
@@ -84,10 +80,7 @@ public final class LockService {
         if (lockIndexExist()) {
             listener.onResponse(true);
         } else {
-            // Temporarily force DOCUMENT replication until SEGMENT supports GET by id
-            // https://github.com/opensearch-project/OpenSearch/issues/8536
-            Settings replicationSettings = Settings.builder().put(SETTING_REPLICATION_TYPE, DOCUMENT.name()).build();
-            final CreateIndexRequest request = new CreateIndexRequest(LOCK_INDEX_NAME, replicationSettings).mapping(lockMapping());
+            final CreateIndexRequest request = new CreateIndexRequest(LOCK_INDEX_NAME).mapping(lockMapping());
             client.admin()
                 .indices()
                 .create(request, ActionListener.wrap(response -> listener.onResponse(response.isAcknowledged()), exception -> {


### PR DESCRIPTION
### Description
Reverts temporary changes ([PR](https://github.com/opensearch-project/job-scheduler/pull/417)) to enforce document replication on lock index now that SegRep supports retrieval by document ID

### Issues Resolved
https://github.com/opensearch-project/job-scheduler/issues/471
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
