### PR TITLE
Converts .opendistro-job-scheduler-lock index into a system index

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ on:
 jobs:
   build:
     strategy:
-      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         java: [11, 17]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         java: [11, 17]

--- a/spi/src/main/java/org/opensearch/jobscheduler/spi/utils/LockService.java
+++ b/spi/src/main/java/org/opensearch/jobscheduler/spi/utils/LockService.java
@@ -8,6 +8,7 @@
  */
 package org.opensearch.jobscheduler.spi.utils;
 
+import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.jobscheduler.spi.JobExecutionContext;
 import org.opensearch.jobscheduler.spi.LockModel;
 import org.opensearch.jobscheduler.spi.ScheduledJobParameter;
@@ -44,7 +45,7 @@ import java.time.Instant;
 
 public final class LockService {
     private static final Logger logger = LogManager.getLogger(LockService.class);
-    private static final String LOCK_INDEX_NAME = ".opendistro-job-scheduler-lock";
+    public static final String LOCK_INDEX_NAME = ".opendistro-job-scheduler-lock";
 
     private final Client client;
     private final ClusterService clusterService;
@@ -77,20 +78,25 @@ public final class LockService {
 
     @VisibleForTesting
     void createLockIndex(ActionListener<Boolean> listener) {
-        if (lockIndexExist()) {
-            listener.onResponse(true);
-        } else {
-            final CreateIndexRequest request = new CreateIndexRequest(LOCK_INDEX_NAME).mapping(lockMapping());
-            client.admin()
-                .indices()
-                .create(request, ActionListener.wrap(response -> listener.onResponse(response.isAcknowledged()), exception -> {
-                    if (exception instanceof ResourceAlreadyExistsException
-                        || exception.getCause() instanceof ResourceAlreadyExistsException) {
-                        listener.onResponse(true);
-                    } else {
-                        listener.onFailure(exception);
-                    }
-                }));
+        try (ThreadContext.StoredContext ignore = client.threadPool().getThreadContext().stashContext()) {
+            if (lockIndexExist()) {
+                listener.onResponse(true);
+            } else {
+                final CreateIndexRequest request = new CreateIndexRequest(LOCK_INDEX_NAME).mapping(lockMapping());
+                client.admin()
+                    .indices()
+                    .create(request, ActionListener.wrap(response -> listener.onResponse(response.isAcknowledged()), exception -> {
+                        if (exception instanceof ResourceAlreadyExistsException
+                            || exception.getCause() instanceof ResourceAlreadyExistsException) {
+                            listener.onResponse(true);
+                        } else {
+                            listener.onFailure(exception);
+                        }
+                    }));
+            }
+        } catch (Exception e) {
+            logger.error(e);
+            listener.onFailure(e);
         }
     }
 
@@ -180,7 +186,7 @@ public final class LockService {
     }
 
     private void updateLock(final LockModel updateLock, ActionListener<LockModel> listener) {
-        try {
+        try (ThreadContext.StoredContext ignore = client.threadPool().getThreadContext().stashContext()) {
             UpdateRequest updateRequest = new UpdateRequest().index(LOCK_INDEX_NAME)
                 .id(updateLock.getLockId())
                 .setIfSeqNo(updateLock.getSeqNo())
@@ -212,11 +218,14 @@ public final class LockService {
         } catch (IOException e) {
             logger.error("IOException occurred updating lock.", e);
             listener.onResponse(null);
+        } catch (Exception e) {
+            logger.error(e);
+            listener.onFailure(e);
         }
     }
 
     private void createLock(final LockModel tempLock, ActionListener<LockModel> listener) {
-        try {
+        try (ThreadContext.StoredContext ignore = client.threadPool().getThreadContext().stashContext()) {
             final IndexRequest request = new IndexRequest(LOCK_INDEX_NAME).id(tempLock.getLockId())
                 .source(tempLock.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS))
                 .setIfSeqNo(SequenceNumbers.UNASSIGNED_SEQ_NO)
@@ -239,29 +248,37 @@ public final class LockService {
         } catch (IOException e) {
             logger.error("IOException occurred creating lock", e);
             listener.onFailure(e);
+        } catch (Exception e) {
+            logger.error(e);
+            listener.onFailure(e);
         }
     }
 
     public void findLock(final String lockId, ActionListener<LockModel> listener) {
-        GetRequest getRequest = new GetRequest(LOCK_INDEX_NAME).id(lockId);
-        client.get(getRequest, ActionListener.wrap(response -> {
-            if (!response.isExists()) {
-                listener.onResponse(null);
-            } else {
-                try {
-                    XContentParser parser = XContentType.JSON.xContent()
-                        .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, response.getSourceAsString());
-                    parser.nextToken();
-                    listener.onResponse(LockModel.parse(parser, response.getSeqNo(), response.getPrimaryTerm()));
-                } catch (IOException e) {
-                    logger.error("IOException occurred finding lock", e);
+        try (ThreadContext.StoredContext ignore = client.threadPool().getThreadContext().stashContext()) {
+            GetRequest getRequest = new GetRequest(LOCK_INDEX_NAME).id(lockId);
+            client.get(getRequest, ActionListener.wrap(response -> {
+                if (!response.isExists()) {
                     listener.onResponse(null);
+                } else {
+                    try {
+                        XContentParser parser = XContentType.JSON.xContent()
+                            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, response.getSourceAsString());
+                        parser.nextToken();
+                        listener.onResponse(LockModel.parse(parser, response.getSeqNo(), response.getPrimaryTerm()));
+                    } catch (IOException e) {
+                        logger.error("IOException occurred finding lock", e);
+                        listener.onResponse(null);
+                    }
                 }
-            }
-        }, exception -> {
-            logger.error("Exception occurred finding lock", exception);
-            listener.onFailure(exception);
-        }));
+            }, exception -> {
+                logger.error("Exception occurred finding lock", exception);
+                listener.onFailure(exception);
+            }));
+        } catch (Exception e) {
+            logger.error(e);
+            listener.onFailure(e);
+        }
     }
 
     /**
@@ -293,19 +310,24 @@ public final class LockService {
      *                 or not the delete was successful
      */
     public void deleteLock(final String lockId, ActionListener<Boolean> listener) {
-        DeleteRequest deleteRequest = new DeleteRequest(LOCK_INDEX_NAME).id(lockId);
-        client.delete(deleteRequest, ActionListener.wrap(response -> {
-            listener.onResponse(
-                response.getResult() == DocWriteResponse.Result.DELETED || response.getResult() == DocWriteResponse.Result.NOT_FOUND
-            );
-        }, exception -> {
-            if (exception instanceof IndexNotFoundException || exception.getCause() instanceof IndexNotFoundException) {
-                logger.debug("Index is not found to delete lock. {}", exception.getMessage());
-                listener.onResponse(true);
-            } else {
-                listener.onFailure(exception);
-            }
-        }));
+        try (ThreadContext.StoredContext ignore = client.threadPool().getThreadContext().stashContext()) {
+            DeleteRequest deleteRequest = new DeleteRequest(LOCK_INDEX_NAME).id(lockId);
+            client.delete(deleteRequest, ActionListener.wrap(response -> {
+                listener.onResponse(
+                    response.getResult() == DocWriteResponse.Result.DELETED || response.getResult() == DocWriteResponse.Result.NOT_FOUND
+                );
+            }, exception -> {
+                if (exception instanceof IndexNotFoundException || exception.getCause() instanceof IndexNotFoundException) {
+                    logger.debug("Index is not found to delete lock. {}", exception.getMessage());
+                    listener.onResponse(true);
+                } else {
+                    listener.onFailure(exception);
+                }
+            }));
+        } catch (Exception e) {
+            logger.error(e);
+            listener.onFailure(e);
+        }
     }
 
     /**

--- a/spi/src/main/java/org/opensearch/jobscheduler/spi/utils/LockService.java
+++ b/spi/src/main/java/org/opensearch/jobscheduler/spi/utils/LockService.java
@@ -220,7 +220,7 @@ public final class LockService {
             listener.onResponse(null);
         } catch (Exception e) {
             logger.error(e);
-            listener.onFailure(e);
+            listener.onResponse(null);
         }
     }
 

--- a/spi/src/main/java/org/opensearch/jobscheduler/spi/utils/LockService.java
+++ b/spi/src/main/java/org/opensearch/jobscheduler/spi/utils/LockService.java
@@ -220,7 +220,7 @@ public final class LockService {
             listener.onResponse(null);
         } catch (Exception e) {
             logger.error(e);
-            listener.onResponse(null);
+            listener.onFailure(e);
         }
     }
 

--- a/src/main/java/org/opensearch/jobscheduler/JobSchedulerPlugin.java
+++ b/src/main/java/org/opensearch/jobscheduler/JobSchedulerPlugin.java
@@ -37,10 +37,12 @@ import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.env.Environment;
 import org.opensearch.env.NodeEnvironment;
 import org.opensearch.index.IndexModule;
+import org.opensearch.indices.SystemIndexDescriptor;
 import org.opensearch.jobscheduler.utils.JobDetailsService;
 import org.opensearch.plugins.ActionPlugin;
 import org.opensearch.plugins.ExtensiblePlugin;
 import org.opensearch.plugins.Plugin;
+import org.opensearch.plugins.SystemIndexPlugin;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.rest.RestController;
 import org.opensearch.script.ScriptService;
@@ -61,7 +63,7 @@ import java.util.function.Supplier;
 
 import com.google.common.collect.ImmutableList;
 
-public class JobSchedulerPlugin extends Plugin implements ActionPlugin, ExtensiblePlugin {
+public class JobSchedulerPlugin extends Plugin implements ActionPlugin, ExtensiblePlugin, SystemIndexPlugin {
 
     public static final String OPEN_DISTRO_JOB_SCHEDULER_THREAD_POOL_NAME = "open_distro_job_scheduler";
     public static final String JS_BASE_URI = "/_plugins/_job_scheduler";
@@ -79,6 +81,13 @@ public class JobSchedulerPlugin extends Plugin implements ActionPlugin, Extensib
     public JobSchedulerPlugin() {
         this.indicesToListen = new HashSet<>();
         this.indexToJobProviders = new HashMap<>();
+    }
+
+    @Override
+    public Collection<SystemIndexDescriptor> getSystemIndexDescriptors(Settings settings) {
+        return Collections.singletonList(
+            new SystemIndexDescriptor(LockService.LOCK_INDEX_NAME, "Stores lock documents used for plugin job execution")
+        );
     }
 
     @Override


### PR DESCRIPTION
### Description
Actioning two issues to convert the `.opendistro-job-scheduler-lock` index into a system index.
This PR makes the following modifications :
- makes `JobSchedulerPlugin` implement the `SystemIndexPlugin` and overrides the `getSystemIndexDescriptors` extension point
- ~wraps each instance in which the plugin interacts with the system index within the `LockService` to stash the threadcontext prior to executing a CRUD operation. From a security perspective this allows the plugin to go into a local trusted mode in which they are allowed to interact with the system index~

Next steps :
- Modify the installation scripts ([sh](https://github.com/opensearch-project/security/blob/9a7e517abd9d4d0e301f918adc65cb82b8f14d88/tools/install_demo_configuration.sh#L386), [bat](https://github.com/opensearch-project/security/blob/9a7e517abd9d4d0e301f918adc65cb82b8f14d88/tools/install_demo_configuration.bat#L318C18-L318C18)) for unix/windows systems to add the system index name to the list of system indices that the security plugin maintains
- Companion PR : https://github.com/opensearch-project/security/pull/3237
 
### Issues Resolved
https://github.com/opensearch-project/job-scheduler/issues/466 - System Index Usage Verification
https://github.com/opensearch-project/job-scheduler/issues/305 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
