### PR TITLE
Publish snapshots on all release branches

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -5,8 +5,8 @@ on:
   push:
     branches:
       - main
-      - '1.3'
-      - 2.x
+      - '[0-9]+.[0-9]+'
+      - '[0-9]+.x'
 
 jobs:
   build-and-publish-snapshots:


### PR DESCRIPTION
### Description

Publish snapshots on all release branches. This matches the patterns in core's maven publish snapshots: https://github.com/opensearch-project/OpenSearch/blob/main/.github/workflows/publish-maven-snapshots.yml
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
