### PR TITLE
Setting JobSweeper search preference against primary shard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         java: [11, 17]

--- a/src/main/java/org/opensearch/jobscheduler/sweeper/JobSweeper.java
+++ b/src/main/java/org/opensearch/jobscheduler/sweeper/JobSweeper.java
@@ -389,7 +389,7 @@ public class JobSweeper extends LifecycleListener implements IndexingOperationLi
         String searchAfter = startAfter == null ? "" : startAfter;
         while (searchAfter != null) {
             SearchRequest jobSearchRequest = new SearchRequest().indices(shardId.getIndexName())
-                .preference("_shards:" + shardId.id() + "|_primary")
+                .preference("_shards:" + shardId.id() + "|_primary_first")
                 .source(
                     new SearchSourceBuilder().version(true)
                         .seqNoAndPrimaryTerm(true)

--- a/src/main/java/org/opensearch/jobscheduler/sweeper/JobSweeper.java
+++ b/src/main/java/org/opensearch/jobscheduler/sweeper/JobSweeper.java
@@ -389,7 +389,7 @@ public class JobSweeper extends LifecycleListener implements IndexingOperationLi
         String searchAfter = startAfter == null ? "" : startAfter;
         while (searchAfter != null) {
             SearchRequest jobSearchRequest = new SearchRequest().indices(shardId.getIndexName())
-                .preference("_shards:" + shardId.id() + "|_primary_first")
+                .preference("_shards:" + shardId.id() + "|_primary")
                 .source(
                     new SearchSourceBuilder().version(true)
                         .seqNoAndPrimaryTerm(true)

--- a/src/main/java/org/opensearch/jobscheduler/sweeper/JobSweeper.java
+++ b/src/main/java/org/opensearch/jobscheduler/sweeper/JobSweeper.java
@@ -389,7 +389,7 @@ public class JobSweeper extends LifecycleListener implements IndexingOperationLi
         String searchAfter = startAfter == null ? "" : startAfter;
         while (searchAfter != null) {
             SearchRequest jobSearchRequest = new SearchRequest().indices(shardId.getIndexName())
-                .preference("_shards:" + shardId.id() + "|_only_local")
+                .preference("_shards:" + shardId.id() + "|_primary")
                 .source(
                     new SearchSourceBuilder().version(true)
                         .seqNoAndPrimaryTerm(true)


### PR DESCRIPTION
### Description
Sets the search preference of the JobSweeper against primary shards
 
### Issues Resolved
https://github.com/opensearch-project/job-scheduler/issues/471
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
