### PR TITLE
Bumping 3.x BWC test version to 2.11.0

### DIFF
--- a/sample-extension-plugin/build.gradle
+++ b/sample-extension-plugin/build.gradle
@@ -129,7 +129,7 @@ testClusters.integTest {
 }
 
 String baseName = "jobSchedulerBwcCluster"
-String bwcOpenSearchVersion = "2.10.0"
+String bwcOpenSearchVersion = "2.11.0"
 String bwcPluginVersion = bwcOpenSearchVersion + ".0"
 String bwcFilePath = "src/test/resources/bwc/job-scheduler/"
 bwcOpenSearchVersion += "-SNAPSHOT"


### PR DESCRIPTION
### Description
Re-opening since previous PR was closed. 

2.x has been bumped to 2.11 (https://github.com/opensearch-project/job-scheduler/pull/490), updating main branch BWC test version to match
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
