### PR TITLE
[Backport 2.x] Use to use the build CI image in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,26 +8,74 @@ on:
       - "*"
 
 jobs:
-  build:
+  Get-CI-Image-Tag:
+    uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@main
+    with:
+      product: opensearch
+
+  build-job-scheduler-linux:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
         java: [11, 17]
 
-    name: Build and Test
-    runs-on: ${{ matrix.os }}
+    name: Build job-scheduler Plugin on Linux using Container Image
+    runs-on: ubuntu-latest
+    needs: Get-CI-Image-Tag
+    container:
+      # using the same image which is used by opensearch-build team to build the OpenSearch Distribution
+      # this image tag is subject to change as more dependencies and updates will arrive over time
+      image: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-version-linux }}
+      # need to switch to root so that github actions can install runner binary on container without permission issues.
+      options: --user root
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - name: Checkout job-scheduler
+        uses: actions/checkout@v2
+      - name: Setup Java ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+
+      - name: Run build
+        # switching the user, as OpenSearch cluster can only be started as root/Administrator on linux-deb/linux-rpm/windows-zip.
+        run: |
+          chown -R 1000:1000 `pwd`
+          su `id -un 1000` -c "./gradlew build -x bwcTestSuite && ./gradlew publishToMavenLocal"
+
+      - name: Upload Coverage Report
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: linux-JDK${{ matrix.java }}-reports
+          path: |
+            ./build/reports/
+
+
+  build-job-scheduler-MacOS:
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [ 11, 17 ]
+
+    name: Build job-scheduler Plugin on MacOS
+    needs: Get-CI-Image-Tag
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout job-scheduler
+        uses: actions/checkout@v2
 
       - name: Setup Java ${{ matrix.java }}
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
 
-      - name: Build and Test
+      - name: Run build
         run: |
           ./gradlew build -x bwcTestSuite
 
@@ -39,3 +87,50 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: macos-JDK${{ matrix.java }}-reports
+          path: |
+            ./build/reports/
+
+
+  build-job-scheduler-Windows:
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [ 11, 17 ]
+
+    name: Build job-scheduler Plugin on Windows
+    needs: Get-CI-Image-Tag
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout job-scheduler
+        uses: actions/checkout@v2
+
+      - name: Setup Java ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+
+      - name: Run build
+        run: |
+          ./gradlew.bat build -x bwcTestSuite
+
+      - name: Publish to Maven Local
+        run: |
+          ./gradlew.bat publishToMavenLocal
+
+      - name: Upload Coverage Report
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: windows-JDK${{ matrix.java }}-reports
+          path: |
+            ./build/reports/


### PR DESCRIPTION
### Description
Backport of https://github.com/opensearch-project/job-scheduler/pull/534 
Use to use the build CI image in ci.yml.
 
### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-build/issues/3966
Closes https://github.com/opensearch-project/job-scheduler/issues/524
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
