### PR TITLE
Fix SPI flaky Integ tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           su `id -un 1000` -c "./gradlew build && ./gradlew publishToMavenLocal"
 
       - name: Upload Coverage Report
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/spi/build.gradle
+++ b/spi/build.gradle
@@ -11,6 +11,7 @@ plugins {
     id 'jacoco'
     id 'maven-publish'
     id 'signing'
+    id "org.gradle.test-retry" version "1.5.8"
 }
 
 apply plugin: 'opensearch.java'
@@ -70,6 +71,10 @@ shadowJar {
 }
 
 test {
+    retry {
+        failOnPassedAfterRetry = false
+        maxRetries = 5
+    }
     doFirst {
         // reverse operation of https://github.com/elastic/elasticsearch/blob/7.6/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy#L736-L743
         // to fix the classpath for unit tests


### PR DESCRIPTION
### Description
Fix flaky SPI Integ tests with retry plugin. After some debugging found that the exact issue is `NodeDisconnectedException[[integTest-0][127.0.0.1:41811][indices:admin/delete] disconnected]` which is coming from OpenSearch Integ test framework used and thus causing the error:
```
    java.lang.AssertionError: Failed to release lock.
        at __randomizedtesting.SeedInfo.seed([C9B40C426EAB7723]:0)
        at org.junit.Assert.fail(Assert.java:89)
        at org.junit.Assert.assertTrue(Assert.java:42)
        at org.opensearch.jobscheduler.spi.utils.LockServiceIT.lambda$testRenewLock$71(LockServiceIT.java:471)|
``` 
 
 Initially I have tested with re-try logic and not seen any issue with `LockServiceIT.testRenewLock` after multiple runs.
 ```
 public void testRenewLock() throws Exception {
        String uniqSuffix = "_lock_renew";
        String lockID = randomAlphaOfLengthBetween(6, 15);
        int maxAttempts = 3;
        int attempt = 0;
        boolean lockAcquired = false;

        while (!lockAcquired && attempt < maxAttempts) {
            attempt++;

            LockService lockService = new LockService(client(), this.clusterService);
            final JobExecutionContext context = new JobExecutionContext(
                    Instant.now(),
                    new JobDocVersion(0, 0, 0),
                    lockService,
                    JOB_INDEX_NAME + uniqSuffix,
                    JOB_ID + uniqSuffix
            );

            CountDownLatch latch = new CountDownLatch(1);
            AtomicBoolean lockReleased = new AtomicBoolean(false);

            lockService.acquireLockWithId(context.getJobIndexName(), LOCK_DURATION_SECONDS, lockID, ActionListener.wrap(lock -> {
                assertNotNull("Expected to successfully grab lock", lock);
                Instant now = Instant.now();
                lockService.setTime(now);
                lockService.renewLock(lock, ActionListener.wrap(renewedLock -> {
                    assertNotNull("Expected to successfully renew lock", renewedLock);
                    assertEquals("lock_time is expected to be the renewal time.", now, renewedLock.getLockTime());
                    assertEquals("lock_duration is expected to be unchanged.", lock.getLockDurationSeconds(), renewedLock.getLockDurationSeconds());
                    lockService.release(lock, ActionListener.wrap(released -> {
                        assertTrue("Failed to release lock.", released);
                        lockReleased.set(true);
                        lockService.deleteLock(lock.getLockId(), ActionListener.wrap(deleted -> {
                            assertTrue("Failed to delete lock.", deleted);
                            latch.countDown();
                        }, exception -> {
                            fail(exception.getMessage());
                            latch.countDown();
                        }));
                    }, exception -> {
                        fail(exception.getMessage());
                        latch.countDown();
                    }));
                }, exception -> {
                    fail(exception.getMessage());
                    latch.countDown();
                }));
            }, exception -> {
                fail(exception.getMessage());
                latch.countDown();
            }));

            latch.await(5L, TimeUnit.SECONDS);

            if (lockReleased.get()) {
                lockAcquired = true;
            } else {
                // Wait before retrying
                Thread.sleep(1000);
            }
        }
        assertTrue("Failed to acquire lock after " + maxAttempts + " retries.", lockAcquired);
    }
```
 But @reta suggested to use `org.gradle.test-retry` that does the exact some thing for all tests.
 
### Issues Resolved
https://github.com/opensearch-project/job-scheduler/issues/56 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
