### PR TITLE
[Backport 2.12] Include task publishPluginZipPublicationToMavenLocal

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -188,6 +188,8 @@ task integTest(type: RestIntegTestTask) {
 }
 tasks.named("check").configure { dependsOn(integTest) }
 
+tasks.generatePomFileForPluginZipPublication.dependsOn publishNebulaPublicationToMavenLocal
+
 integTest {
     if (project.hasProperty('excludeTests')) {
         project.properties['excludeTests']?.replaceAll('\\s', '')?.split('[,;]')?.each {

--- a/release-notes/opensearch.job-scheduler.release-notes-2.12.0.0.md
+++ b/release-notes/opensearch.job-scheduler.release-notes-2.12.0.0.md
@@ -15,3 +15,4 @@ Compatible with OpenSearch 2.12.0
 * Update `com.netflix.nebula.ospackage` from 11.5.0 to 11.6.0 ([#551](https://github.com/opensearch-project/job-scheduler/pull/551)).
 * Update `com.diffplug.spotless` from 6.22.0 to 6.25.0 ([#558](https://github.com/opensearch-project/job-scheduler/pull/558)).
 * Fix backport workflow ([#533](https://github.com/opensearch-project/job-scheduler/pull/533)).
+* Enable `publishPluginZipPublicationToMavenLocal` gradle task to publish job-scheduler plugin zip to maven local ([#584](https://github.com/opensearch-project/job-scheduler/pull/584)).

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,4 +10,4 @@ project(":spi").name = rootProject.name + "-spi"
 
 include "sample-extension-plugin"
 project(":sample-extension-plugin").name = rootProject.name + "-sample-extension"
-startParameter.excludedTaskNames=["publishPluginZipPublicationToMavenLocal", "publishPluginZipPublicationToStagingRepository", "bwcTestSuite"]
+startParameter.excludedTaskNames=["publishPluginZipPublicationToStagingRepository", "bwcTestSuite"]


### PR DESCRIPTION
### Description
Backport PR of https://github.com/opensearch-project/job-scheduler/pull/584/files.
Include task publishPluginZipPublicationToMavenLocal.
 
### Issues Resolved
https://github.com/opensearch-project/job-scheduler/issues/583
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
