### PR TITLE
Spotless plugin remove apply false

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ buildscript {
 plugins {
     id 'com.netflix.nebula.ospackage' version "11.8.0"
     id 'java-library'
-    id "com.diffplug.spotless" version "6.25.0" apply false
+    id "com.diffplug.spotless" version "6.25.0"
 }
 
 apply plugin: 'opensearch.opensearchplugin'


### PR DESCRIPTION
### Description
Spotless plugin remove apply false. With false Gradle will not automatically download and configure the plugin and its dependencies from remote repositories during the build process.
Using apply false in an internet-restricted environment can potentially lead to issues if the plugin's dependencies are not already available locally. 

### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
