### PR TITLE
Change spotbugs from 6.25.0 to 6.16.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ buildscript {
 plugins {
     id 'com.netflix.nebula.ospackage' version "11.8.0"
     id 'java-library'
-    id "com.diffplug.spotless" version "6.25.0"
+    id "com.diffplug.spotless" version "6.16.0"
 }
 
 apply plugin: 'opensearch.opensearchplugin'


### PR DESCRIPTION
### Description
The spot bugs 6.25.0 gradle plugin making internet calls https://download.eclipse.org/ and fails to fetch the right JDT jars making the builds fail for internet restricted environments.

Here is an open issue from plugin: https://github.com/diffplug/spotless/issues/1996 where it does not honor local JDT jars .

 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
