### PR TITLE
Add @prudhvigodithi as a Maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @joshpalis @saratvemulapalli @dbwiddis @kaituo @vibrantvarun @cwperks
+*   @joshpalis @saratvemulapalli @dbwiddis @kaituo @vibrantvarun @cwperks @prudhvigodithi

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -12,6 +12,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Kaituo Li         | [kaituo](https://github.com/kaituo)                     | Amazon      |
 | Varun Jain        | [vibrantvarun](https://github.com/vibrantvarun)         | Amazon      |
 | Craig Perkins     | [cwperks](https://github.com/cwperks)                   | Amazon      |
+| Prudhvi Godithi   | [prudhvigodithi](https://github.com/prudhvigodithi)     | Amazon      |
 
 ## Emeritus Maintainers
 


### PR DESCRIPTION
### Description

@prudhvigodithi currently has the 4th most contributions on the repo with 15 PRs merged to date.
 
Notable contributions include:
 
- Improve code coverage (https://github.com/opensearch-project/job-scheduler/pull/616)
- Include task publishPluginZipPublicationToMavenLocal (https://github.com/opensearch-project/job-scheduler/pull/584)
- Use to use the build CI image in ci.yml (https://github.com/opensearch-project/job-scheduler/pull/534)
- Fix SPI flakey Integ Test (https://github.com/opensearch-project/job-scheduler/pull/556)
- Update to Gradle 8.5 (https://github.com/opensearch-project/job-scheduler/pull/545)
- Create the release notes PRs for last 3 releases

Nomination process has been concluded and approved by the current maintainers, nominee has accepted.
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
