### PR TITLE
Bump bwcOpenSearchVersion to 2.15.0 on main branch

### DIFF
--- a/sample-extension-plugin/build.gradle
+++ b/sample-extension-plugin/build.gradle
@@ -129,7 +129,7 @@ testClusters.integTest {
 }
 
 String baseName = "jobSchedulerBwcCluster"
-String bwcOpenSearchVersion = "2.14.0"
+String bwcOpenSearchVersion = "2.15.0"
 String bwcPluginVersion = bwcOpenSearchVersion + ".0"
 String bwcFilePath = "src/test/resources/bwc/job-scheduler/"
 bwcOpenSearchVersion += "-SNAPSHOT"


### PR DESCRIPTION
### Description

Bump bwcOpenSearchVersion to 2.15.0 on main branch
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
