### PR TITLE
Refer to the version of Mockito from core's buildSrc/version.properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -162,7 +162,7 @@ dependencies {
     implementation project(path: ":${rootProject.name}-spi", configuration: 'shadow')
     implementation group: 'com.google.guava', name: 'guava', version:'32.1.3-jre'
     implementation group: 'com.google.guava', name: 'failureaccess', version:'1.0.2'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.11.0'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: "${versions.mockito}"
     javaRestTestImplementation project.sourceSets.main.runtimeClasspath
     //spotless
     implementation('com.google.googlejavaformat:google-java-format:1.22.0') {


### PR DESCRIPTION
### Description

Refer to the version of Mockito from core's buildSrc/version.properties
 
Resolves build issue seen on https://github.com/opensearch-project/OpenSearch/pull/13665 where there could be a version mismatch between core and job-scheduler for Mockito.
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
