### PR TITLE
Fix system index compatibility with v1 templates

### DIFF
--- a/spi/src/main/java/org/opensearch/jobscheduler/spi/utils/LockService.java
+++ b/spi/src/main/java/org/opensearch/jobscheduler/spi/utils/LockService.java
@@ -26,6 +26,7 @@ import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
+import org.opensearch.core.xcontent.MediaType;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.common.xcontent.XContentFactory;
@@ -82,7 +83,10 @@ public final class LockService {
             if (lockIndexExist()) {
                 listener.onResponse(true);
             } else {
-                final CreateIndexRequest request = new CreateIndexRequest(LOCK_INDEX_NAME).mapping(lockMapping());
+                final CreateIndexRequest request = new CreateIndexRequest(LOCK_INDEX_NAME).mapping(
+                    lockMapping(),
+                    (MediaType) XContentType.JSON
+                );
                 client.admin()
                     .indices()
                     .create(request, ActionListener.wrap(response -> listener.onResponse(response.isAcknowledged()), exception -> {

--- a/src/main/java/org/opensearch/jobscheduler/utils/JobDetailsService.java
+++ b/src/main/java/org/opensearch/jobscheduler/utils/JobDetailsService.java
@@ -30,6 +30,7 @@ import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.extensions.action.ExtensionProxyAction;
+import org.opensearch.core.xcontent.MediaType;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.index.IndexNotFoundException;
@@ -293,7 +294,10 @@ public class JobDetailsService implements IndexingOperationListener {
         if (jobDetailsIndexExist()) {
             listener.onResponse(true);
         } else {
-            CreateIndexRequest request = new CreateIndexRequest(JOB_DETAILS_INDEX_NAME).mapping(jobDetailsMapping());
+            CreateIndexRequest request = new CreateIndexRequest(JOB_DETAILS_INDEX_NAME).mapping(
+                jobDetailsMapping(),
+                (MediaType) XContentType.JSON
+            );
             client.admin()
                 .indices()
                 .create(request, ActionListener.wrap(response -> listener.onResponse(response.isAcknowledged()), exception -> {


### PR DESCRIPTION
### Description

Adds back the content type argument to `CreateIndexRequest.mapping()`, which is required by the single-arg String method.

It was removed in #155 on `LockService` in 2.0.0, and introduced in #289 in `JobDetailsService` in 2.8.0, using the `LockService` code as an example.

### Related Issues

See details in https://github.com/opensearch-project/OpenSearch/issues/14984

### Check List
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/job-scheduler/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
