### PR TITLE
Return instance of LockService from createComponents

### DIFF
--- a/src/main/java/org/opensearch/jobscheduler/JobSchedulerPlugin.java
+++ b/src/main/java/org/opensearch/jobscheduler/JobSchedulerPlugin.java
@@ -127,7 +127,7 @@ public class JobSchedulerPlugin extends Plugin implements ActionPlugin, Extensib
         clusterService.addListener(this.sweeper);
         clusterService.addLifecycleListener(this.sweeper);
 
-        return Collections.emptyList();
+        return List.of(this.lockService);
     }
 
     @Override


### PR DESCRIPTION
### Description

This is a small PR to return the LockService instance that's initialized with `JobSchedulerPlugin.createComponents` as one of the JobScheduler components so that it is injectable via Guice to plugins that rely on the JS SPI. 

Tested this by making GeoSpatial into a ClusterPlugin and verified that the LockService is injectable with Guice. See companion geospatial PR here: https://github.com/opensearch-project/geospatial/pull/677

This PR is part of an effort to remove usages of ThreadContext.stashContext across the plugins: https://github.com/opensearch-project/opensearch-plugins/issues/238

Currently, plugins like geospatial instantiate their own instance of the [LockService](https://github.com/opensearch-project/geospatial/blob/main/src/main/java/org/opensearch/geospatial/plugin/GeospatialPlugin.java#L166) by passing in the Client given to the plugin through `createComponents`.

As part of the effort to [Strengthen System Indices in the Plugin Ecosystem](https://github.com/opensearch-project/security/issues/4439), plugins will be restricted to only perform transport actions to their own system indices. This PR is to ensure that plugins like Geospatial can re-use the LockService instantiated by JS (which has permission to JS system indices) vs creating its own LockService. 

### Related Issues

Related to https://github.com/opensearch-project/security/issues/4439

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/job-scheduler/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
