### PR TITLE
Set job-scheduler plugin 3.0.0 baseline JDK version to JDK-21

### DIFF
--- a/.github/workflows/bwc-test-workflow.yml
+++ b/.github/workflows/bwc-test-workflow.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [ 11 ]
+        java: [ 21 ]
     # Job name
     name: Build and test Job-scheduler
     # This job runs on Linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [11, 17, 21]
+        java: [21]
 
     name: Build job-scheduler Plugin on Linux using Container Image
     runs-on: ubuntu-latest
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [11, 17, 21]
+        java: [21]
 
     name: Build job-scheduler Plugin on MacOS
     needs: Get-CI-Image-Tag
@@ -104,7 +104,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 11, 17 ]
+        java: [ 21 ]
 
     name: Build job-scheduler Plugin on Windows
     needs: Get-CI-Image-Tag

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -18,11 +18,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 11
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
           distribution: temurin # Temurin is a distribution of adoptium
-          java-version: 11
+          java-version: 21
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [11]
+        java: [21]
     # Job name
     name: Build Job-scheduler with JDK ${{ matrix.java }}
     # This job runs on Linux

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -1,7 +1,7 @@
 - [Developer Guide](#developer-guide)
     - [Forking and Cloning](#forking-and-cloning)
     - [Install Prerequisites](#install-prerequisites)
-        - [JDK 11](#jdk-11)
+        - [JDK 21](#jdk-21)
     - [Setup](#setup)
     - [Build](#build)
         - [Building from the command line](#building-from-the-command-line)
@@ -19,15 +19,15 @@ Fork this repository on GitHub, and clone locally with `git clone`.
 
 ### Install Prerequisites
 
-#### JDK 11
+#### JDK 21
 
-OpenSearch components build using Java 11 at a minimum. This means you must have a JDK 11 installed with the environment variable `JAVA_HOME` referencing the path to Java home for your JDK 11 installation, e.g. `JAVA_HOME=/usr/lib/jvm/jdk-11`.
+OpenSearch components build using Java 21 at a minimum. This means you must have a JDK 21 installed with the environment variable `JAVA_HOME` referencing the path to Java home for your JDK 21 installation, e.g. `JAVA_HOME=/usr/lib/jvm/jdk-21`.
 
 ## Setup
 
 1. Check out this package from version control.
 2. Launch Intellij IDEA, choose **Import Project**, and select the `settings.gradle` file in the root of this package.
-3. To build from the command line, set `JAVA_HOME` to point to a JDK >= 11 before running `./gradlew`.
+3. To build from the command line, set `JAVA_HOME` to point to a JDK >= 21 before running `./gradlew`.
 - Unix System
     1. `export JAVA_HOME=jdk-install-dir`: Replace `jdk-install-dir` with the JAVA_HOME directory of your system.
     2. `export PATH=$JAVA_HOME/bin:$PATH`
@@ -41,7 +41,7 @@ OpenSearch components build using Java 11 at a minimum. This means you must have
 The JobScheduler plugin uses the [Gradle](https://docs.gradle.org/4.10.2/userguide/userguide.html)
 build system.
 1. Checkout this package from version control.
-1. To build from command line set `JAVA_HOME` to point to a JDK >=11
+1. To build from command line set `JAVA_HOME` to point to a JDK >=21
 1. Run `./gradlew build`
 
 Then you will find the built artifact located at `build/distributions` directory

--- a/build.gradle
+++ b/build.gradle
@@ -80,8 +80,8 @@ allprojects {
     apply from: "$rootDir/build-tools/repositories.gradle"
 
     plugins.withId('java') {
-        targetCompatibility = JavaVersion.VERSION_11
-        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_21
+        sourceCompatibility = JavaVersion.VERSION_21
     }
 }
 


### PR DESCRIPTION
### Description
Set job-scheduler plugin 3.0.0 baseline JDK version to JDK-21

### Related Issues
Closes https://github.com/opensearch-project/job-scheduler/issues/636

<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/job-scheduler/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
