### PR TITLE
Add security permission for job-scheduler 

### DIFF
--- a/src/main/plugin-metadata/plugin-security.policy
+++ b/src/main/plugin-metadata/plugin-security.policy
@@ -4,28 +4,7 @@
  */
 
 grant {
-  // For Spring IOC
-  permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
-  permission java.lang.RuntimePermission "accessDeclaredMembers";
-  permission java.lang.RuntimePermission "defineClass";
-  permission java.lang.RuntimePermission "getClassLoader";
-  permission java.lang.RuntimePermission "accessUserInformation";
-  permission java.net.NetPermission "getProxySelector";
-  permission java.net.SocketPermission "*", "accept,connect,resolve";
-
-  // ml-commons client
-  permission java.lang.RuntimePermission "setContextClassLoader";
-
-  // aws credentials
-  permission java.io.FilePermission "${user.home}${/}.aws${/}*", "read";
-
-  // Permissions for aws emr servless sdk
-  permission javax.management.MBeanServerPermission "createMBeanServer";
-  permission javax.management.MBeanServerPermission "findMBeanServer";
-  permission javax.management.MBeanPermission "com.amazonaws.metrics.*", "*";
-  permission javax.management.MBeanTrustPermission "register";
-
   // Calcite
-  permission java.util.PropertyPermission "*", "read,write";
-  permission java.lang.RuntimePermission "*";
+    permission java.lang.RuntimePermission "getClassLoader";
+    permission java.lang.RuntimePermission "accessDeclaredMembers";
 };

--- a/src/main/plugin-metadata/plugin-security.policy
+++ b/src/main/plugin-metadata/plugin-security.policy
@@ -1,0 +1,31 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+grant {
+  // For Spring IOC
+  permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
+  permission java.lang.RuntimePermission "accessDeclaredMembers";
+  permission java.lang.RuntimePermission "defineClass";
+  permission java.lang.RuntimePermission "getClassLoader";
+  permission java.lang.RuntimePermission "accessUserInformation";
+  permission java.net.NetPermission "getProxySelector";
+  permission java.net.SocketPermission "*", "accept,connect,resolve";
+
+  // ml-commons client
+  permission java.lang.RuntimePermission "setContextClassLoader";
+
+  // aws credentials
+  permission java.io.FilePermission "${user.home}${/}.aws${/}*", "read";
+
+  // Permissions for aws emr servless sdk
+  permission javax.management.MBeanServerPermission "createMBeanServer";
+  permission javax.management.MBeanServerPermission "findMBeanServer";
+  permission javax.management.MBeanPermission "com.amazonaws.metrics.*", "*";
+  permission javax.management.MBeanTrustPermission "register";
+
+  // Calcite
+  permission java.util.PropertyPermission "*", "read,write";
+  permission java.lang.RuntimePermission "*";
+};


### PR DESCRIPTION
### Description
This pr is to add security permission for job-scheduler since sql plugin is the extended plugin of job scheduler. And now sql is trying to implement [calcite engine ](https://github.com/opensearch-project/sql/issues/3229). And during the implementation, we find we need security permissions to run the calcite engine.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/job-scheduler/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
