### PR TITLE
Only download demo certs when integTest run with -Dsecurity.enabled=true

### DIFF
--- a/.github/workflows/test-with-security.yml
+++ b/.github/workflows/test-with-security.yml
@@ -29,4 +29,4 @@ jobs:
       - name: Run Job-scheduler Integ Tests with Security
         run: |
           echo "Running integ tests with security..."
-          ./gradlew :integTest --tests "*RestIT" -Dhttps=true -Dsecurity=true  -Dtests.opensearch.secure=true -Dtests.opensearch.username=admin -Dtests.opensearch.password=admin -Duser=admin -Dpassword=admin
+          ./gradlew :integTest --tests "*RestIT" -Dhttps=true -Dsecurity.enabled=true  -Dtests.opensearch.secure=true -Dtests.opensearch.username=admin -Dtests.opensearch.password=admin -Duser=admin -Dpassword=admin

--- a/build.gradle
+++ b/build.gradle
@@ -284,7 +284,7 @@ def securityPluginFile = resolvePluginFile("opensearch-security")
 
 // === Setup security test ===
 // This flag indicates the existence of security plugin
-def securityEnabled = System.getProperty("security", "false") == "true" || System.getProperty("https", "false") == "true"
+def securityEnabled = System.getProperty("security.enabled", "false") == "true" || System.getProperty("https", "false") == "true"
 afterEvaluate {
     testClusters.integTest.nodes.each { node ->
         def plugins = node.plugins
@@ -363,7 +363,7 @@ task integTestRemote(type: RestIntegTestTask) {
     systemProperty 'java.io.tmpdir', opensearch_tmp_dir.absolutePath
 
     systemProperty "https", System.getProperty("https")
-    systemProperty "security", System.getProperty("security")
+    systemProperty "security.enabled", System.getProperty("security.enabled")
     systemProperty "user", System.getProperty("user")
     systemProperty "password", System.getProperty("password")
     systemProperty 'tests.rest.cluster', 'localhost:9200'

--- a/build.gradle
+++ b/build.gradle
@@ -54,15 +54,18 @@ ext {
     licenseFile = rootProject.file('LICENSE.txt')
     noticeFile = rootProject.file('NOTICE')
 
-    ['esnode.pem', 'esnode-key.pem', 'kirk.pem', 'kirk-key.pem', 'root-ca.pem', 'sample.pem', 'test-kirk.jks'].forEach { file ->
-        File local = getLayout().getBuildDirectory().file(file).get().getAsFile()
-        download.run {
-            src "https://raw.githubusercontent.com/opensearch-project/security/refs/heads/main/bwc-test/src/test/resources/security/" + file
-            dest local
-            overwrite false
-        }
-        processResources {
-            from(local)
+    runIntegTestWithSecurityPlugin= System.getProperty("security.enabled")
+    if (runIntegTestWithSecurityPlugin == "true"){
+        ['esnode.pem', 'esnode-key.pem', 'kirk.pem', 'kirk-key.pem', 'root-ca.pem', 'sample.pem', 'test-kirk.jks'].forEach { file ->
+            File local = getLayout().getBuildDirectory().file(file).get().getAsFile()
+            download.run {
+                src "https://raw.githubusercontent.com/opensearch-project/security/refs/heads/main/bwc-test/src/test/resources/security/" + file
+                dest local
+                overwrite false
+            }
+            processResources {
+                from(local)
+            }
         }
     }
 }


### PR DESCRIPTION
### Description

This PR is a small change to only download the demo certs when run with `-Dsecurity.enabled=true`. If security is not enabled, downloading demo certs is not necessary.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/job-scheduler/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
