### PR TITLE
Add maven-publish workflow to 1.3 branch

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -1,0 +1,44 @@
+name: Publish snapshots to maven
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - '[0-9]+.[0-9]+'
+      - '[0-9]+.x'
+
+jobs:
+  build-and-publish-snapshots:
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin # Temurin is a distribution of adoptium
+          java-version: 11
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.PUBLISH_SNAPSHOTS_ROLE }}
+          aws-region: us-east-1
+
+      - name: Publish snapshots to maven
+        run: |
+          export SONATYPE_USERNAME=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-username --query SecretString --output text)
+          export SONATYPE_PASSWORD=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-password --query SecretString --output text)
+          echo "::add-mask::$SONATYPE_USERNAME"
+          echo "::add-mask::$SONATYPE_PASSWORD"
+          # For JS-SPI jar
+          ./gradlew publishShadowPublicationToSnapshotsRepository
+          # For JS jar
+          ./gradlew publishNebulaPublicationToSnapshotsRepository
+          # For JS plugin zip
+          ./gradlew publishPluginZipPublicationToSnapshotsRepository

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -4,9 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
-      - '[0-9]+.[0-9]+'
-      - '[0-9]+.x'
+      - '1.3'
 
 jobs:
   build-and-publish-snapshots:

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ import com.github.jengelman.gradle.plugins.shadow.ShadowPlugin
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "1.3.20-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "1.3.21-SNAPSHOT")
     }
 
     repositories {


### PR DESCRIPTION
### Description

Add maven-publish workflow to 1.3 branch

This helps AD solve bwc test failures on a backport to 2.x: https://github.com/opensearch-project/anomaly-detection/pull/1442

Many snapshots were deleted from sonatype that plugins depend on for CI checks: https://aws.oss.sonatype.org/content/repositories/snapshots/org/opensearch/plugin/opensearch-job-scheduler/

Plugins can switch to using released artifacts, but many rely on SNAPSHOT for testing

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/job-scheduler/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
