### PR TITLE
Add a CHANGELOG and changelog_verifier workflow

### DIFF
--- a/.github/workflows/changelog_verifier.yml
+++ b/.github/workflows/changelog_verifier.yml
@@ -1,0 +1,18 @@
+name: "Changelog Verifier"
+on:
+  pull_request:
+    types: [opened, edited, reopened]
+
+jobs:
+  # Enforces the update of a changelog file on every pull request
+  verify-changelog:
+    if: github.repository == 'opensearch-project/security-dashboards-plugin'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: dangoslen/changelog-enforcer@v3
+        with:
+          skipLabels: "autocut, skip-changelog"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,22 @@
+# CHANGELOG
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to the [Semantic Versioning](https://semver.org/spec/v2.0.0.html). See the [CONTRIBUTING guide](./CONTRIBUTING.md#Changelog) for instructions on how to add changelog entries.
+
+## [Unreleased 3.x]
+### Added
+
+### Changed
+
+### Dependencies
+
+### Deprecated
+
+### Removed
+- remove guava dependency ([#773](https://github.com/opensearch-project/security-dashboards-plugin/pull/773))
+
+### Fixed
+
+### Security
+
+[Unreleased 3.x]: https://github.com/opensearch-project/job-scheduler/compare/3.0...main


### PR DESCRIPTION
### Description

This PR adds a CHANGELOG and changelog_verifier workflow

### Related Issues
Resolves https://github.com/opensearch-project/job-scheduler/issues/777

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/job-scheduler/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
