### PR TITLE
Make Lock service not final

### DIFF
--- a/spi/src/main/java/org/opensearch/jobscheduler/spi/utils/LockService.java
+++ b/spi/src/main/java/org/opensearch/jobscheduler/spi/utils/LockService.java
@@ -44,7 +44,7 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 
-public final class LockService {
+public class LockService {
     private static final Logger logger = LogManager.getLogger(LockService.class);
     public static final String LOCK_INDEX_NAME = ".opendistro-job-scheduler-lock";
 


### PR DESCRIPTION
### Description

This PR is a non-breaking change that is a precursor for https://github.com/opensearch-project/job-scheduler/pull/714

Essentially, there are plugins in the OpenSearch ecosystem that are directly instantiating the LockService class from JS SPI and I am seeking to forbid this in future versions of OpenSearch in favor of using dependency injection and only instantiating within the Job Scheduler.

Ultimately, I plan to convert the LockService to an interface.

The problem with having this class marked as final, is that I cannot replace usages like https://github.com/opensearch-project/geospatial/blob/506b38356e9ff79ce5dd3ac6871f4e871af6b2aa/src/test/java/org/opensearch/geospatial/ip2geo/common/Ip2GeoLockServiceTests.java#L35 because it requires mocking.

I would like to remove `final` as a modifier (only in the interim) to be able to replace existing places where the LockService is instantiated and then fully replace it with an interface.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/job-scheduler/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
