### PR TITLE
Ensure that dates are serialized in TransportGetScheduledInfoAction.nodeOperation

### DIFF
--- a/sample-extension-plugin/src/test/java/org/opensearch/jobscheduler/sampleextension/SampleJobRunnerRestIT.java
+++ b/sample-extension-plugin/src/test/java/org/opensearch/jobscheduler/sampleextension/SampleJobRunnerRestIT.java
@@ -19,11 +19,10 @@ import org.opensearch.test.rest.OpenSearchRestTestCase;
 import java.io.IOException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.Map;
 
 public class SampleJobRunnerRestIT extends SampleExtensionIntegTestCase {
-
-    private static final String SCHEDULER_INFO_URI = "/_plugins/_job_scheduler/api/jobs";
 
     public void testJobCreateWithCorrectParams() throws IOException {
         SampleJobParameter jobParameter = new SampleJobParameter();
@@ -93,12 +92,28 @@ public class SampleJobRunnerRestIT extends SampleExtensionIntegTestCase {
     }
 
     public void testJobUpdateWithRescheduleJobThenListJobs() throws Exception {
+
+        String SCHEDULER_INFO_URI = "/_plugins/_job_scheduler/api/jobs?by_node";
+
         String index = createTestIndex();
         SampleJobParameter jobParameter = new SampleJobParameter();
         jobParameter.setJobName("sample-job-it");
         jobParameter.setIndexToWatch(index);
         jobParameter.setSchedule(new IntervalSchedule(Instant.now(), 1, ChronoUnit.MINUTES));
         jobParameter.setLockDurationSeconds(120L);
+
+        for (int i = 0; i < 10; i++) {
+            // Creates a new watcher job.
+            String indexN = createTestIndex();
+            SampleJobParameter jobParameterN = new SampleJobParameter();
+            jobParameterN.setJobName("sample-job-it" + i);
+            jobParameterN.setIndexToWatch(indexN);
+            jobParameterN.setSchedule(new IntervalSchedule(Instant.now(), 1, ChronoUnit.MINUTES));
+            jobParameterN.setLockDurationSeconds(120L);
+
+            String jobIdN = OpenSearchRestTestCase.randomAlphaOfLength(10);
+            createWatcherJob(jobIdN, jobParameterN);
+        }
 
         // Creates a new watcher job.
         String jobId = OpenSearchRestTestCase.randomAlphaOfLength(10);
@@ -126,7 +141,47 @@ public class SampleJobRunnerRestIT extends SampleExtensionIntegTestCase {
             LoggingDeprecationHandler.INSTANCE,
             response.getEntity().getContent()
         ).map();
-        System.out.println("Response from list jobs: " + responseJson);
+
+        List<Map<String, Object>> nodes = (List<Map<String, Object>>) responseJson.get("nodes");
+        assertNotNull("Nodes list should not be null", nodes);
+        assertEquals(11, responseJson.get("total_jobs"));
+        assertEquals(0, ((List<?>) responseJson.get("failures")).size());
+        assertFalse("Should have at least one node", nodes.isEmpty());
+
+        for (Map<String, Object> node : nodes) {
+
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> nodeJobs = (List<Map<String, Object>>) ((Map<String, Object>) node.get("scheduled_job_info")).get(
+                "jobs"
+            );
+            if (nodeJobs != null) {
+                for (Map<String, Object> job : nodeJobs) {
+                    assertEquals("job_type should be scheduler_sample_extension", "scheduler_sample_extension", job.get("job_type"));
+                    assertNotNull("job_id should not be null", job.get("job_id"));
+                    assertEquals(
+                        "index_name should not be .scheduler_sample_extension",
+                        ".scheduler_sample_extension",
+                        job.get("index_name")
+                    );
+                    assertNotNull("name should not be null", job.get("name"));
+                    assertFalse("descheduled should be False", (Boolean) job.get("descheduled"));
+                    assertTrue("enabled should be True", (Boolean) job.get("enabled"));
+                    assertNotNull("enabled_time should not be null", job.get("enabled_time"));
+                    assertNotNull("last_update_time should not be null", job.get("last_update_time"));
+                    assertNotNull("schedule should not be null", job.get("schedule"));
+                    assertTrue(job.get("lock_duration") instanceof Integer);
+                    assertEquals("none", job.get("jitter"));
+                    assertEquals("none", job.get("delay"));
+                    // Validate schedule object
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> schedule = (Map<String, Object>) job.get("schedule");
+                    assertTrue(
+                        "schedule should be interval or Cron",
+                        ((schedule.get("type").equals("interval")) || (schedule.get("type").equals("cron")))
+                    );
+                }
+            }
+        }
     }
 
     public void testAcquiredLockPreventExecOfTasks() throws Exception {

--- a/src/main/java/org/opensearch/jobscheduler/transport/action/TransportGetScheduledInfoAction.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/action/TransportGetScheduledInfoAction.java
@@ -138,12 +138,12 @@ public class TransportGetScheduledInfoAction extends TransportNodesAction<
                                 // Add execution information
 
                                 if (jobInfo.getActualPreviousExecutionTime() != null) {
-                                    jobDetails.put("last_execution_time", jobInfo.getActualPreviousExecutionTime());
+                                    jobDetails.put("last_execution_time", jobInfo.getActualPreviousExecutionTime().toString());
                                 } else {
                                     jobDetails.put("last_execution_time", "none");
                                 }
                                 if (jobInfo.getExpectedPreviousExecutionTime() != null) {
-                                    jobDetails.put("last_expected_execution_time", jobInfo.getExpectedPreviousExecutionTime());
+                                    jobDetails.put("last_expected_execution_time", jobInfo.getExpectedPreviousExecutionTime().toString());
                                 } else {
                                     jobDetails.put("last_expected_execution_time", "none");
                                 }

--- a/src/main/java/org/opensearch/jobscheduler/transport/action/TransportGetScheduledInfoAction.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/action/TransportGetScheduledInfoAction.java
@@ -15,6 +15,7 @@ import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.nodes.TransportNodesAction;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
+import org.opensearch.common.time.DateFormatter;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.jobscheduler.ScheduledJobProvider;
 import org.opensearch.jobscheduler.scheduler.JobScheduler;
@@ -31,6 +32,7 @@ import org.opensearch.jobscheduler.transport.request.GetScheduledInfoNodeRequest
 import org.opensearch.jobscheduler.transport.response.GetScheduledInfoNodeResponse;
 
 import java.io.IOException;
+import java.time.ZoneOffset;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -46,6 +48,7 @@ public class TransportGetScheduledInfoAction extends TransportNodesAction<
     private static final Logger log = LogManager.getLogger(JobScheduler.class);
     private final JobScheduler jobScheduler;
     private final JobDetailsService jobDetailsService;
+    private static final DateFormatter STRICT_DATE_TIME_FORMATTER = DateFormatter.forPattern("strict_date_time");
 
     @Inject
     public TransportGetScheduledInfoAction(
@@ -133,24 +136,43 @@ public class TransportGetScheduledInfoAction extends TransportNodesAction<
                                 jobDetails.put("name", jobInfo.getJobParameter().getName());
                                 jobDetails.put("descheduled", jobInfo.isDescheduled());
                                 jobDetails.put("enabled", jobInfo.getJobParameter().isEnabled());
-                                jobDetails.put("enabled_time", jobInfo.getJobParameter().getEnabledTime().toString());
-                                jobDetails.put("last_update_time", jobInfo.getJobParameter().getLastUpdateTime().toString());
+                                jobDetails.put(
+                                    "enabled_time",
+                                    STRICT_DATE_TIME_FORMATTER.format(jobInfo.getJobParameter().getEnabledTime().atOffset(ZoneOffset.UTC))
+                                );
+                                jobDetails.put(
+                                    "last_update_time",
+                                    STRICT_DATE_TIME_FORMATTER.format(
+                                        jobInfo.getJobParameter().getLastUpdateTime().atOffset(ZoneOffset.UTC)
+                                    )
+                                );
                                 // Add execution information
 
                                 if (jobInfo.getActualPreviousExecutionTime() != null) {
-                                    jobDetails.put("last_execution_time", jobInfo.getActualPreviousExecutionTime().toString());
+                                    jobDetails.put(
+                                        "last_execution_time",
+                                        STRICT_DATE_TIME_FORMATTER.format(jobInfo.getActualPreviousExecutionTime().atOffset(ZoneOffset.UTC))
+                                    );
                                 } else {
                                     jobDetails.put("last_execution_time", "none");
                                 }
                                 if (jobInfo.getExpectedPreviousExecutionTime() != null) {
-                                    jobDetails.put("last_expected_execution_time", jobInfo.getExpectedPreviousExecutionTime().toString());
+                                    jobDetails.put(
+                                        "last_expected_execution_time",
+                                        STRICT_DATE_TIME_FORMATTER.format(
+                                            jobInfo.getExpectedPreviousExecutionTime().atOffset(ZoneOffset.UTC)
+                                        )
+                                    );
                                 } else {
                                     jobDetails.put("last_expected_execution_time", "none");
                                 }
 
                                 // Add next execution time
                                 if (jobInfo.getExpectedExecutionTime() != null) {
-                                    jobDetails.put("next_expected_execution_time", jobInfo.getExpectedExecutionTime().toString());
+                                    jobDetails.put(
+                                        "next_expected_execution_time",
+                                        STRICT_DATE_TIME_FORMATTER.format(jobInfo.getExpectedExecutionTime().atOffset(ZoneOffset.UTC))
+                                    );
                                 } else {
                                     jobDetails.put("next_expected_execution_time", "none");
                                 }
@@ -164,7 +186,10 @@ public class TransportGetScheduledInfoAction extends TransportNodesAction<
                                     // Set schedule type
                                     if (jobInfo.getJobParameter().getSchedule() instanceof IntervalSchedule intervalSchedule) {
                                         scheduleMap.put("type", IntervalSchedule.INTERVAL_FIELD);
-                                        scheduleMap.put("start_time", intervalSchedule.getStartTime().toString());
+                                        scheduleMap.put(
+                                            "start_time",
+                                            STRICT_DATE_TIME_FORMATTER.format(intervalSchedule.getStartTime().atOffset(ZoneOffset.UTC))
+                                        );
                                         scheduleMap.put("interval", intervalSchedule.getInterval());
                                         scheduleMap.put("unit", intervalSchedule.getUnit().toString());
                                     } else if (jobInfo.getJobParameter().getSchedule() instanceof CronSchedule cronSchedule) {


### PR DESCRIPTION
### Description
Converts the Instant instance into a type that can be placed into an Object class. Adds a test to verify that the TransportGetScheduledInfoAction no longer crashes when transport action is called.

### Related Issues
Fixes the issue of a node crashing when there is a non null value in last_execution_time and last_expected_execution_time. 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/job-scheduler/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
