### PR TITLE
Remove gradle task dependencies to allow running single test at a time

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,9 +45,9 @@ plugins {
 
 apply plugin: 'opensearch.opensearchplugin'
 apply plugin: 'opensearch.testclusters'
-apply plugin: 'opensearch.java-rest-test'
 apply plugin: 'opensearch.pluginzip'
 apply plugin: 'opensearch.java-agent'
+apply plugin: 'opensearch.rest-test'
 apply from: 'build-tools/opensearchplugin-coverage.gradle'
 apply from: 'gradle/formatting.gradle'
 
@@ -90,15 +90,6 @@ opensearchplugin {
 
 configurations {
     opensearchPlugin
-}
-
-javaRestTest {
-    // add "-Dtests.security.manager=false" to VM options if you want to run integ tests in IntelliJ
-    systemProperty 'tests.security.manager', 'false'
-}
-
-testClusters.javaRestTest {
-    testDistribution = 'INTEG_TEST'
 }
 
 allprojects {
@@ -188,7 +179,6 @@ repositories {
 dependencies {
     implementation project(path: ":${rootProject.name}-spi", configuration: 'shadow')
     testImplementation group: 'org.mockito', name: 'mockito-core', version: "${versions.mockito}"
-    javaRestTestImplementation project.sourceSets.main.runtimeClasspath
 
     opensearchPlugin "org.opensearch.plugin:opensearch-security:${security_plugin_version}@zip"
 }
@@ -204,13 +194,6 @@ def _numNodes = findProperty('numNodes') as Integer ?: 1
 
 def opensearch_tmp_dir = rootProject.file('build/private/opensearch_tmp').absoluteFile
 opensearch_tmp_dir.mkdirs()
-
-task integTest(type: RestIntegTestTask) {
-    description = "Run tests against a cluster"
-    testClassesDirs = sourceSets.test.output.classesDirs
-    classpath = sourceSets.test.runtimeClasspath
-}
-tasks.named("check").configure { dependsOn(integTest) }
 
 tasks.generatePomFileForPluginZipPublication.dependsOn publishNebulaPublicationToMavenLocal
 
@@ -248,7 +231,6 @@ integTest {
     }
 }
 Zip bundle = (Zip) project.getTasks().getByName("bundlePlugin");
-integTest.dependsOn(bundle)
 integTest.getClusters().forEach{c -> {
     c.plugin(project.getObjects().fileProperty().value(bundle.getArchiveFile()))
 }}

--- a/sample-extension-plugin/build.gradle
+++ b/sample-extension-plugin/build.gradle
@@ -5,8 +5,8 @@
 
 apply plugin: 'opensearch.opensearchplugin'
 apply plugin: 'opensearch.testclusters'
-apply plugin: 'opensearch.java-rest-test'
 apply plugin: 'opensearch.java-agent'
+apply plugin: 'opensearch.rest-test'
 
 import org.opensearch.gradle.test.RestIntegTestTask
 import org.opensearch.gradle.testclusters.StandaloneRestIntegTestTask
@@ -50,21 +50,6 @@ validateNebulaPom.enabled = false
 testingConventions.enabled = false
 loggerUsageCheck.enabled = false
 
-javaRestTest.dependsOn(rootProject.assemble)
-javaRestTest {
-    systemProperty 'tests.security.manager', 'false'
-}
-testClusters.javaRestTest {
-    testDistribution = 'INTEG_TEST'
-}
-
-task integTest(type: RestIntegTestTask) {
-    description = "Run tests against a cluster"
-    testClassesDirs = sourceSets.test.output.classesDirs
-    classpath = sourceSets.test.runtimeClasspath
-}
-tasks.named("check").configure { dependsOn(integTest) }
-
 integTest {
     if (project.hasProperty('excludeTests')) {
         project.properties['excludeTests']?.replaceAll('\\s', '')?.split('[,;]')?.each {
@@ -103,10 +88,9 @@ integTest {
         }
     }
 }
-project.getTasks().getByName('bundlePlugin').dependsOn(rootProject.tasks.getByName('build'))
+
 Zip bundle = (Zip) project.getTasks().getByName("bundlePlugin");
 Zip rootBundle = (Zip) rootProject.getTasks().getByName("bundlePlugin");
-integTest.dependsOn(bundle)
 integTest.getClusters().forEach{c -> {
     c.plugin(rootProject.getObjects().fileProperty().value(rootBundle.getArchiveFile()))
     c.plugin(project.getObjects().fileProperty().value(bundle.getArchiveFile()))
@@ -295,20 +279,4 @@ run {
         }
     }
     useCluster testClusters.integTest
-}
-
-// As of ES 7.7 the sample-extension-plugin is being added to the list of plugins for the testCluster during build before
-// the job-scheduler plugin is causing build failures.
-// The job-scheduler zip is added explicitly above but the sample-extension-plugin is added implicitly at some time during evaluation.
-// Will need to do a deep dive to find out exactly what task adds the sample-extension-plugin and add job-scheduler there but a temporary hack is to
-// reorder the plugins list after evaluation but prior to task execution when the plugins are installed.
-afterEvaluate {
-    testClusters.javaRestTest.nodes.each { node ->
-        def nodePlugins = node.plugins
-        def firstPlugin = nodePlugins.get(0)
-        if (firstPlugin.provider == project.bundlePlugin.archiveFile) {
-            nodePlugins.remove(0)
-            nodePlugins.add(firstPlugin)
-        }
-    }
 }

--- a/spi/build.gradle
+++ b/spi/build.gradle
@@ -16,7 +16,6 @@ plugins {
 
 apply plugin: 'opensearch.java'
 apply plugin: 'opensearch.testclusters'
-apply plugin: 'opensearch.java-rest-test'
 
 repositories {
     mavenLocal()
@@ -91,12 +90,6 @@ task integTest(type: RestIntegTestTask) {
     description 'Run integ test with opensearch test framework'
     group 'verification'
     systemProperty 'tests.security.manager', 'false'
-    dependsOn test
-}
-check.dependsOn integTest
-
-testClusters.javaRestTest {
-    testDistribution = 'INTEG_TEST'
 }
 
 task sourcesJar(type: Jar) {


### PR DESCRIPTION
### Description

Currently, when I try to run a command like `./gradlew :opensearch-job-scheduler-sample-extension:integTest --tests SampleJobRunnerRestIT.testJobUpdateWithRescheduleJobThenListJobs -x :test -x :integTest` it will always run all top-level unit tests and integ tests even though I explicitly passed a skip flag.

JS has a fairly complex gradle configuration the sets a dependency from integTest -> bundle -> bundlePlugin which creates this chain of task dependencies. It also has a dependency on `java-rest-test` that appears to be unused.

I am raising this PR to break this chain of dependencies which allows a developer to now run a single unit test without having to specify to skip any tasks.

With the changes in this PR,  a command like `./gradlew :opensearch-job-scheduler-sample-extension:integTest --tests SampleJobRunnerRestIT.testJobUpdateWithRescheduleJobThenListJobs` will run a single test.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/job-scheduler/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
