### PR TITLE
Support defining IntervalSchedule in seconds

### DIFF
--- a/sample-extension-plugin/build.gradle
+++ b/sample-extension-plugin/build.gradle
@@ -153,6 +153,7 @@ String bwcDownloadUrl = "https://aws.oss.sonatype.org/service/local/artifact/mav
             }))
             setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
             setting 'http.content_type.required', 'true'
+            setting 'plugins.jobscheduler.sweeper.period', '1s'
         }
     }
 }

--- a/sample-extension-plugin/build.gradle
+++ b/sample-extension-plugin/build.gradle
@@ -37,6 +37,9 @@ repositories {
 
 dependencies {
     compileOnly project(path: ":${rootProject.name}-spi", configuration: 'shadow')
+    testImplementation('org.awaitility:awaitility:4.3.0') {
+        exclude(group: 'org.hamcrest', module: 'hamcrest')
+    }
 }
 
 def es_tmp_dir = rootProject.file('build/private/es_tmp').absoluteFile
@@ -112,7 +115,7 @@ testClusters.integTest {
         }
     }
     setting 'path.repo', repo.absolutePath
-    setting 'plugins.jobscheduler.sweeper.period', '5s'
+    setting 'plugins.jobscheduler.sweeper.period', '1s'
 }
 
 String baseName = "jobSchedulerBwcCluster"

--- a/sample-extension-plugin/build.gradle
+++ b/sample-extension-plugin/build.gradle
@@ -112,6 +112,7 @@ testClusters.integTest {
         }
     }
     setting 'path.repo', repo.absolutePath
+    setting 'plugins.jobscheduler.sweeper.period', '5s'
 }
 
 String baseName = "jobSchedulerBwcCluster"

--- a/sample-extension-plugin/src/main/java/org/opensearch/jobscheduler/sampleextension/SampleExtensionRestHandler.java
+++ b/sample-extension-plugin/src/main/java/org/opensearch/jobscheduler/sampleextension/SampleExtensionRestHandler.java
@@ -90,7 +90,7 @@ public class SampleExtensionRestHandler extends BaseRestHandler {
 
             Schedule schedule;
             if (interval != null) {
-                schedule = new IntervalSchedule(Instant.now(), Integer.parseInt(interval), ChronoUnit.MINUTES);
+                schedule = new IntervalSchedule(Instant.now(), Integer.parseInt(interval), ChronoUnit.SECONDS);
             } else {
                 schedule = new CronSchedule(cron, ZoneId.systemDefault());
             }

--- a/sample-extension-plugin/src/main/java/org/opensearch/jobscheduler/sampleextension/SampleJobRunner.java
+++ b/sample-extension-plugin/src/main/java/org/opensearch/jobscheduler/sampleextension/SampleJobRunner.java
@@ -107,7 +107,6 @@ public class SampleJobRunner implements ScheduledJobRunner {
                     SampleJobParameter parameter = (SampleJobParameter) jobParameter;
                     StringBuilder msg = new StringBuilder();
                     msg.append("Watching index ").append(parameter.getIndexToWatch()).append("\n");
-                    System.out.println("msg.toString(): " + msg.toString());
 
                     List<ShardRouting> shardRoutingList = this.clusterService.state().routingTable().allShards(parameter.getIndexToWatch());
                     for (ShardRouting shardRouting : shardRoutingList) {
@@ -144,7 +143,7 @@ public class SampleJobRunner implements ScheduledJobRunner {
 
     private void runTaskForLockIntegrationTests(SampleJobParameter jobParameter) throws InterruptedException {
         if (jobParameter.getName().equals("sample-job-lock-test-it")) {
-            Thread.sleep(180000);
+            Thread.sleep(10000);
         }
     }
 }

--- a/sample-extension-plugin/src/main/java/org/opensearch/jobscheduler/sampleextension/SampleJobRunner.java
+++ b/sample-extension-plugin/src/main/java/org/opensearch/jobscheduler/sampleextension/SampleJobRunner.java
@@ -107,6 +107,7 @@ public class SampleJobRunner implements ScheduledJobRunner {
                     SampleJobParameter parameter = (SampleJobParameter) jobParameter;
                     StringBuilder msg = new StringBuilder();
                     msg.append("Watching index ").append(parameter.getIndexToWatch()).append("\n");
+                    System.out.println("msg.toString(): " + msg.toString());
 
                     List<ShardRouting> shardRoutingList = this.clusterService.state().routingTable().allShards(parameter.getIndexToWatch());
                     for (ShardRouting shardRouting : shardRoutingList) {

--- a/sample-extension-plugin/src/test/java/org/opensearch/jobscheduler/sampleextension/SampleExtensionIntegTestCase.java
+++ b/sample-extension-plugin/src/test/java/org/opensearch/jobscheduler/sampleextension/SampleExtensionIntegTestCase.java
@@ -183,10 +183,6 @@ public class SampleExtensionIntegTestCase extends OpenSearchRestTestCase {
         return createWatcherJobWithClient(client(), jobId, jobParameter);
     }
 
-    protected String createWatcherJobJson(String jobId, String jobParameter) throws IOException {
-        return createWatcherJobJsonWithClient(client(), jobId, jobParameter);
-    }
-
     protected SampleJobParameter createWatcherJobWithClient(RestClient client, String jobId, SampleJobParameter jobParameter)
         throws IOException {
         Map<String, String> params = getJobParameterAsMap(jobId, jobParameter);
@@ -367,6 +363,10 @@ public class SampleExtensionIntegTestCase extends OpenSearchRestTestCase {
     }
 
     protected void waitUntilLockIsAcquiredAndReleased(String jobId) {
+        waitUntilLockIsAcquiredAndReleased(jobId, 20);
+    }
+
+    protected void waitUntilLockIsAcquiredAndReleased(String jobId, int maxTimeInSec) {
         AtomicLong prevLockAcquiredTime = new AtomicLong(0L);
         AtomicReference<LockModel> lock = new AtomicReference<>();
         try {
@@ -377,7 +377,7 @@ public class SampleExtensionIntegTestCase extends OpenSearchRestTestCase {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-        await().atMost(20, TimeUnit.SECONDS).pollInterval(1, TimeUnit.SECONDS).ignoreExceptions().until(() -> {
+        await().atMost(maxTimeInSec, TimeUnit.SECONDS).pollInterval(1, TimeUnit.SECONDS).ignoreExceptions().until(() -> {
             lock.set(getLockByJobId(jobId));
             return lock.get() != null && lock.get().getLockTime().toEpochMilli() != prevLockAcquiredTime.get() && lock.get().isReleased();
         });

--- a/sample-extension-plugin/src/test/java/org/opensearch/jobscheduler/sampleextension/SampleJobRunnerRestIT.java
+++ b/sample-extension-plugin/src/test/java/org/opensearch/jobscheduler/sampleextension/SampleJobRunnerRestIT.java
@@ -111,7 +111,7 @@ public class SampleJobRunnerRestIT extends SampleExtensionIntegTestCase {
         Assert.assertEquals(1, countRecordsInTestIndex(index));
     }
 
-    public void testJobUpdateWithRescheduleJobThenListJobs() throws Exception {
+    public void testRunThenListJobs() throws Exception {
 
         String SCHEDULER_INFO_URI = "/_plugins/_job_scheduler/api/jobs?by_node";
 
@@ -119,8 +119,8 @@ public class SampleJobRunnerRestIT extends SampleExtensionIntegTestCase {
         SampleJobParameter jobParameter = new SampleJobParameter();
         jobParameter.setJobName("sample-job-it");
         jobParameter.setIndexToWatch(index);
-        jobParameter.setSchedule(new IntervalSchedule(Instant.now(), 1, ChronoUnit.MINUTES));
-        jobParameter.setLockDurationSeconds(120L);
+        jobParameter.setSchedule(new IntervalSchedule(Instant.now(), 5, ChronoUnit.SECONDS));
+        jobParameter.setLockDurationSeconds(5L);
 
         for (int i = 0; i < 10; i++) {
             // Creates a new watcher job.
@@ -139,8 +139,8 @@ public class SampleJobRunnerRestIT extends SampleExtensionIntegTestCase {
         String jobId = OpenSearchRestTestCase.randomAlphaOfLength(10);
         createWatcherJob(jobId, jobParameter);
 
-        long actualCount = waitAndCountRecords(index, 65000);
-        Assert.assertEquals(1, actualCount);
+        waitUntilLockIsAcquiredAndReleased(jobId);
+        Assert.assertEquals(1, countRecordsInTestIndex(index));
 
         Response response = makeRequest(client(), "GET", SCHEDULER_INFO_URI, Map.of(), null);
         Map<String, Object> responseJson = JsonXContent.jsonXContent.createParser(

--- a/sample-extension-plugin/src/test/java/org/opensearch/jobscheduler/sampleextension/SampleJobRunnerRestIT.java
+++ b/sample-extension-plugin/src/test/java/org/opensearch/jobscheduler/sampleextension/SampleJobRunnerRestIT.java
@@ -9,12 +9,19 @@
 package org.opensearch.jobscheduler.sampleextension;
 
 import org.junit.Assert;
+import org.opensearch.client.Response;
+import org.opensearch.common.xcontent.LoggingDeprecationHandler;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.jobscheduler.spi.LockModel;
 import org.opensearch.jobscheduler.spi.schedule.IntervalSchedule;
 import org.opensearch.test.rest.OpenSearchRestTestCase;
 
 import java.io.IOException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.Map;
 
 public class SampleJobRunnerRestIT extends SampleExtensionIntegTestCase {
 
@@ -22,8 +29,8 @@ public class SampleJobRunnerRestIT extends SampleExtensionIntegTestCase {
         SampleJobParameter jobParameter = new SampleJobParameter();
         jobParameter.setJobName("sample-job-it");
         jobParameter.setIndexToWatch("http-logs");
-        jobParameter.setSchedule(new IntervalSchedule(Instant.now(), 1, ChronoUnit.MINUTES));
-        jobParameter.setLockDurationSeconds(120L);
+        jobParameter.setSchedule(new IntervalSchedule(Instant.now(), 5, ChronoUnit.SECONDS));
+        jobParameter.setLockDurationSeconds(7L);
 
         // Creates a new watcher job.
         String jobId = OpenSearchRestTestCase.randomAlphaOfLength(10);
@@ -40,16 +47,22 @@ public class SampleJobRunnerRestIT extends SampleExtensionIntegTestCase {
         SampleJobParameter jobParameter = new SampleJobParameter();
         jobParameter.setJobName("sample-job-it");
         jobParameter.setIndexToWatch(index);
-        jobParameter.setSchedule(new IntervalSchedule(Instant.now(), 1, ChronoUnit.MINUTES));
-        jobParameter.setLockDurationSeconds(120L);
+        jobParameter.setSchedule(new IntervalSchedule(Instant.now(), 5, ChronoUnit.SECONDS));
+        jobParameter.setLockDurationSeconds(7L);
 
         // Creates a new watcher job.
         String jobId = OpenSearchRestTestCase.randomAlphaOfLength(10);
         SampleJobParameter schedJobParameter = createWatcherJob(jobId, jobParameter);
 
+        System.out.println("schedJobParameter: " + schedJobParameter);
+
         // wait till the job runner runs for the first time after 1 min & inserts a record into the watched index & then delete the job.
         waitAndDeleteWatcherJob(schedJobParameter.getIndexToWatch(), jobId);
-        long actualCount = waitAndCountRecords(index, 130000);
+
+        LockModel lock = getLockByJobId(jobId);
+        System.out.println("lock: " + lock);
+
+        long actualCount = waitAndCountRecords(index, 15000);
 
         // Asserts that in the last 3 mins, no new job ran to insert a record into the watched index & all locks are deleted for the job.
         Assert.assertEquals(1, actualCount);
@@ -61,8 +74,8 @@ public class SampleJobRunnerRestIT extends SampleExtensionIntegTestCase {
         SampleJobParameter jobParameter = new SampleJobParameter();
         jobParameter.setJobName("sample-job-it");
         jobParameter.setIndexToWatch(index);
-        jobParameter.setSchedule(new IntervalSchedule(Instant.now(), 1, ChronoUnit.MINUTES));
-        jobParameter.setLockDurationSeconds(120L);
+        jobParameter.setSchedule(new IntervalSchedule(Instant.now(), 5, ChronoUnit.SECONDS));
+        jobParameter.setLockDurationSeconds(10L);
 
         // Creates a new watcher job.
         String jobId = OpenSearchRestTestCase.randomAlphaOfLength(10);
@@ -75,7 +88,7 @@ public class SampleJobRunnerRestIT extends SampleExtensionIntegTestCase {
         // wait till the job runner runs for the first time after 1 min & inserts a record into the watched index & then update the job with
         // new params.
         waitAndCreateWatcherJob(schedJobParameter.getIndexToWatch(), jobId, jobParameter);
-        long actualCount = waitAndCountRecords(newIndex, 130000);
+        long actualCount = waitAndCountRecords(newIndex, 7000);
 
         // Asserts that the job runner has the updated params & it inserted the record in the new watched index.
         Assert.assertEquals(1, actualCount);
@@ -92,15 +105,15 @@ public class SampleJobRunnerRestIT extends SampleExtensionIntegTestCase {
         jobParameter.setIndexToWatch(index);
         // ensures that the next job tries to run even before the previous job finished & released its lock. Also look at
         // SampleJobRunner.runTaskForLockIntegrationTests
-        jobParameter.setSchedule(new IntervalSchedule(Instant.now(), 1, ChronoUnit.MINUTES));
-        jobParameter.setLockDurationSeconds(120L);
+        jobParameter.setSchedule(new IntervalSchedule(Instant.now(), 5, ChronoUnit.SECONDS));
+        jobParameter.setLockDurationSeconds(10L);
 
         // Creates a new watcher job.
         String jobId = OpenSearchRestTestCase.randomAlphaOfLength(10);
         createWatcherJob(jobId, jobParameter);
 
         // Asserts that the job runner is running for the first time & it has inserted a new record into the watched index.
-        long actualCount = waitAndCountRecords(index, 80000);
+        long actualCount = waitAndCountRecords(index, 7000);
         Assert.assertEquals(1, actualCount);
 
         // gets the lock time for the lock acquired for running first job.
@@ -108,15 +121,21 @@ public class SampleJobRunnerRestIT extends SampleExtensionIntegTestCase {
 
         // Asserts that the second job could not run & hence no new record is inserted into the watched index.
         // Also asserts that the old lock acquired for running first job is still not released.
-        actualCount = waitAndCountRecords(index, 80000);
+        actualCount = waitAndCountRecords(index, 7000);
         Assert.assertEquals(1, actualCount);
         Assert.assertTrue(doesLockExistByLockTime(lockTime));
 
         // Asserts that the new job ran after 2 mins after the first job lock is released. Hence new record is inserted into the watched
         // index.
         // Also asserts that the old lock is released.
-        actualCount = waitAndCountRecords(index, 130000);
+        actualCount = waitAndCountRecords(index, 7000);
         Assert.assertEquals(2, actualCount);
         Assert.assertFalse(doesLockExistByLockTime(lockTime));
+    }
+
+    private Map<String, Object> parseResponseAsMap(Response response) throws IOException {
+        XContentParser parser = XContentType.JSON.xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, response.getEntity().getContent());
+        return parser.map();
     }
 }

--- a/sample-extension-plugin/src/test/java/org/opensearch/jobscheduler/sampleextension/bwc/JobSchedulerBackwardsCompatibilityIT.java
+++ b/sample-extension-plugin/src/test/java/org/opensearch/jobscheduler/sampleextension/bwc/JobSchedulerBackwardsCompatibilityIT.java
@@ -112,35 +112,29 @@ public class JobSchedulerBackwardsCompatibilityIT extends SampleExtensionIntegTe
         * Thus, failure to schedule the job would mean, backward incompatible changes were made in the serde logic.
         * & the assert would fail.
          */
-        String jobParameter = "{"
-            + "\"name\":\"sample-job-it\","
-            + "\"enabled\":true,"
-            + "\"enabled_time\":"
-            + now.toEpochMilli()
-            + ", "
-            + "\"last_update_time\":"
-            + now.toEpochMilli()
-            + ", "
-            + "\"schedule\":{"
-            + "\"interval\":{"
-            + "\"start_time\":"
-            + now.toEpochMilli()
-            + ","
-            + "\"period\":1,"
-            + "\"unit\":\"Minutes\""
-            + "}"
-            + "},"
-            + "\"index_name_to_watch\":\""
-            + index
-            + "\","
-            + "\"lock_duration_seconds\":120"
-            + "}";
+        String jobParameter = """
+            {
+                "name": "sample-job-it",
+                "enabled": true,
+                "enabled_time": %d,
+                "last_update_time": %d,
+                "schedule": {
+                    "interval": {
+                        "start_time": %d,
+                        "period": 1,
+                        "unit": "Minutes"
+                    }
+                },
+                "index_name_to_watch": "%s",
+                "lock_duration_seconds": 120
+            }
+            """.formatted(now.toEpochMilli(), now.toEpochMilli(), now.toEpochMilli(), index);
 
         // Creates a new watcher job.
         String jobId = OpenSearchRestTestCase.randomAlphaOfLength(10);
         createWatcherJobJson(jobId, jobParameter);
+        waitUntilLockIsAcquiredAndReleased(jobId);
 
-        long actualCount = waitAndCountRecords(index, 100000);
-        Assert.assertEquals(1, actualCount);
+        Assert.assertEquals(1, countRecordsInTestIndex(index));
     }
 }

--- a/sample-extension-plugin/src/test/java/org/opensearch/jobscheduler/sampleextension/bwc/JobSchedulerBackwardsCompatibilityIT.java
+++ b/sample-extension-plugin/src/test/java/org/opensearch/jobscheduler/sampleextension/bwc/JobSchedulerBackwardsCompatibilityIT.java
@@ -121,12 +121,12 @@ public class JobSchedulerBackwardsCompatibilityIT extends SampleExtensionIntegTe
                 "schedule": {
                     "interval": {
                         "start_time": %d,
-                        "period": 1,
-                        "unit": "Minutes"
+                        "period": 5,
+                        "unit": "Seconds"
                     }
                 },
                 "index_name_to_watch": "%s",
-                "lock_duration_seconds": 120
+                "lock_duration_seconds": 5
             }
             """.formatted(now.toEpochMilli(), now.toEpochMilli(), now.toEpochMilli(), index);
 

--- a/spi/src/main/java/org/opensearch/jobscheduler/spi/schedule/IntervalSchedule.java
+++ b/spi/src/main/java/org/opensearch/jobscheduler/spi/schedule/IntervalSchedule.java
@@ -43,6 +43,7 @@ public class IntervalSchedule implements Schedule {
 
     static {
         HashSet<ChronoUnit> set = new HashSet<>();
+        set.add(ChronoUnit.SECONDS);
         set.add(ChronoUnit.MINUTES);
         set.add(ChronoUnit.HOURS);
         set.add(ChronoUnit.DAYS);
@@ -66,6 +67,7 @@ public class IntervalSchedule implements Schedule {
         this.initialStartTime = startTime;
         this.startTimeWithDelay = startTime;
         this.interval = interval;
+        System.out.println("unit in constructor: " + unit);
         this.unit = unit;
         this.intervalInMillis = Duration.of(interval, this.unit).toMillis();
         this.clock = Clock.system(ZoneId.systemDefault());
@@ -105,10 +107,17 @@ public class IntervalSchedule implements Schedule {
 
     @Override
     public Instant getNextExecutionTime(Instant time) {
+        System.out.println("time: " + time);
         Instant baseTime = time == null ? this.clock.instant() : time;
+        System.out.println("baseTime: " + baseTime);
+        System.out.println("this.startTimeWithDelay: " + this.startTimeWithDelay);
         long delta = (baseTime.toEpochMilli() - this.startTimeWithDelay.toEpochMilli());
+        System.out.println("delta: " + delta);
+        System.out.println("interval: " + interval);
+        System.out.println("unit: " + unit);
         if (delta >= 0) {
             long remaining = this.intervalInMillis - (delta % this.intervalInMillis);
+            System.out.println("remaining: " + remaining);
             return baseTime.plus(remaining, ChronoUnit.MILLIS);
         } else {
             return this.startTimeWithDelay;

--- a/spi/src/main/java/org/opensearch/jobscheduler/spi/schedule/IntervalSchedule.java
+++ b/spi/src/main/java/org/opensearch/jobscheduler/spi/schedule/IntervalSchedule.java
@@ -67,7 +67,6 @@ public class IntervalSchedule implements Schedule {
         this.initialStartTime = startTime;
         this.startTimeWithDelay = startTime;
         this.interval = interval;
-        System.out.println("unit in constructor: " + unit);
         this.unit = unit;
         this.intervalInMillis = Duration.of(interval, this.unit).toMillis();
         this.clock = Clock.system(ZoneId.systemDefault());
@@ -107,17 +106,10 @@ public class IntervalSchedule implements Schedule {
 
     @Override
     public Instant getNextExecutionTime(Instant time) {
-        System.out.println("time: " + time);
         Instant baseTime = time == null ? this.clock.instant() : time;
-        System.out.println("baseTime: " + baseTime);
-        System.out.println("this.startTimeWithDelay: " + this.startTimeWithDelay);
         long delta = (baseTime.toEpochMilli() - this.startTimeWithDelay.toEpochMilli());
-        System.out.println("delta: " + delta);
-        System.out.println("interval: " + interval);
-        System.out.println("unit: " + unit);
         if (delta >= 0) {
             long remaining = this.intervalInMillis - (delta % this.intervalInMillis);
-            System.out.println("remaining: " + remaining);
             return baseTime.plus(remaining, ChronoUnit.MILLIS);
         } else {
             return this.startTimeWithDelay;

--- a/src/main/java/org/opensearch/jobscheduler/scheduler/JobScheduler.java
+++ b/src/main/java/org/opensearch/jobscheduler/scheduler/JobScheduler.java
@@ -135,15 +135,12 @@ public class JobScheduler {
         JobDocVersion version,
         Double jitterLimit
     ) {
-        System.out.println("reschedule called with: " + jobInfo.getExpectedExecutionTime());
         if (jobParameter.getEnabledTime() == null) {
             log.info("There is no enable time of job {}, this job should never be scheduled.", jobParameter.getName());
             return false;
         }
 
         Instant nextExecutionTime = jobParameter.getSchedule().getNextExecutionTime(jobInfo.getExpectedExecutionTime());
-        System.out.println("jobParameter: " + jobParameter);
-        System.out.println("nextExecutionTime: " + nextExecutionTime);
         if (nextExecutionTime == null) {
             log.info("No next execution time for job {}", jobParameter.getName());
             return true;
@@ -160,8 +157,6 @@ public class JobScheduler {
             nextExecutionTime = now;
             duration = Duration.ZERO;
         }
-
-        System.out.println("duration before: " + duration.toMillis());
 
         // Too many jobs start at the same time point will bring burst. Add random jitter delay to spread out load.
         // Example, if interval is 10 minutes, jitter is 0.6, next job run will be randomly delayed by 0 to 10*0.6 minutes.
@@ -185,11 +180,8 @@ public class JobScheduler {
 
         jobInfo.setExpectedExecutionTime(nextExecutionTime);
 
-        System.out.println("should call runJob");
-
         Runnable runnable = () -> {
             if (jobInfo.isDescheduled()) {
-                System.out.println("descheduled");
                 return;
             }
 
@@ -207,16 +199,13 @@ public class JobScheduler {
                 jobInfo.getJobId()
             );
 
-            System.out.println("runJob called");
             jobRunner.runJob(jobParameter, context);
         };
 
         if (jobInfo.isDescheduled()) {
-            System.out.println("descheduled2");
             return false;
         }
 
-        System.out.println("setScheduledCancellable, duration: " + duration.toMillis());
         jobInfo.setScheduledCancellable(
             this.threadPool.schedule(
                 runnable,

--- a/src/main/java/org/opensearch/jobscheduler/scheduler/JobScheduler.java
+++ b/src/main/java/org/opensearch/jobscheduler/scheduler/JobScheduler.java
@@ -135,12 +135,15 @@ public class JobScheduler {
         JobDocVersion version,
         Double jitterLimit
     ) {
+        System.out.println("reschedule called with: " + jobInfo.getExpectedExecutionTime());
         if (jobParameter.getEnabledTime() == null) {
             log.info("There is no enable time of job {}, this job should never be scheduled.", jobParameter.getName());
             return false;
         }
 
         Instant nextExecutionTime = jobParameter.getSchedule().getNextExecutionTime(jobInfo.getExpectedExecutionTime());
+        System.out.println("jobParameter: " + jobParameter);
+        System.out.println("nextExecutionTime: " + nextExecutionTime);
         if (nextExecutionTime == null) {
             log.info("No next execution time for job {}", jobParameter.getName());
             return true;
@@ -157,6 +160,8 @@ public class JobScheduler {
             nextExecutionTime = now;
             duration = Duration.ZERO;
         }
+
+        System.out.println("duration before: " + duration.toMillis());
 
         // Too many jobs start at the same time point will bring burst. Add random jitter delay to spread out load.
         // Example, if interval is 10 minutes, jitter is 0.6, next job run will be randomly delayed by 0 to 10*0.6 minutes.
@@ -180,8 +185,11 @@ public class JobScheduler {
 
         jobInfo.setExpectedExecutionTime(nextExecutionTime);
 
+        System.out.println("should call runJob");
+
         Runnable runnable = () -> {
             if (jobInfo.isDescheduled()) {
+                System.out.println("descheduled");
                 return;
             }
 
@@ -199,13 +207,16 @@ public class JobScheduler {
                 jobInfo.getJobId()
             );
 
+            System.out.println("runJob called");
             jobRunner.runJob(jobParameter, context);
         };
 
         if (jobInfo.isDescheduled()) {
+            System.out.println("descheduled2");
             return false;
         }
 
+        System.out.println("setScheduledCancellable, duration: " + duration.toMillis());
         jobInfo.setScheduledCancellable(
             this.threadPool.schedule(
                 runnable,

--- a/src/main/java/org/opensearch/jobscheduler/sweeper/JobSweeper.java
+++ b/src/main/java/org/opensearch/jobscheduler/sweeper/JobSweeper.java
@@ -265,8 +265,6 @@ public class JobSweeper extends LifecycleListener implements IndexingOperationLi
                         return null;
                     }
                     ScheduledJobRunner jobRunner = this.indexToProviders.get(shardId.getIndexName()).getJobRunner();
-                    System.out.println("jobRunner: " + jobRunner);
-                    System.out.println("jobParameter: " + jobParameter);
                     if (jobParameter.isEnabled()) {
                         this.scheduler.schedule(shardId.getIndexName(), docId, jobParameter, jobRunner, jobDocVersion, jitterLimit);
                     }
@@ -300,7 +298,6 @@ public class JobSweeper extends LifecycleListener implements IndexingOperationLi
             log.info("Running full sweep");
             TimeValue elapsedTime = getFullSweepElapsedTime();
             long delta = this.sweepPeriod.millis() - elapsedTime.millis();
-            System.out.println("delta: " + delta);
             if (delta < 20L) {
                 this.fullSweepExecutor.submit(this::sweepAllJobIndices);
             }
@@ -329,7 +326,6 @@ public class JobSweeper extends LifecycleListener implements IndexingOperationLi
 
     private void sweepAllJobIndices() {
         for (String indexName : this.indexToProviders.keySet()) {
-            System.out.println("sweeping index: " + indexName);
             this.sweepIndex(indexName);
         }
         this.lastFullSweepTimeNano = System.nanoTime();
@@ -383,8 +379,6 @@ public class JobSweeper extends LifecycleListener implements IndexingOperationLi
             ? this.sweptJobs.get(shardId)
             : new ConcurrentHashMap<>();
 
-        System.out.println("currentJobs: " + currentJobs);
-
         for (String jobId : currentJobs.keySet()) {
 
             if (!shardNodes.isOwningNode(jobId)) {
@@ -417,7 +411,6 @@ public class JobSweeper extends LifecycleListener implements IndexingOperationLi
             }
             for (SearchHit hit : response.getHits()) {
                 String jobId = hit.getId();
-                System.out.println("Sweeping jobId: " + jobId);
                 if (shardNodes.isOwningNode(jobId)) {
                     this.sweep(
                         shardId,


### PR DESCRIPTION
### Description

This PR contains an enhancement that allows user's to define an interval schedule in seconds. In order to adequately have jobs running in seconds, a cluster admin must set `plugins.jobscheduler.sweeper.period` also to a value in seconds as this is the frequency at which the jobs are swept.

One of the primary benefits of this PR is it drastically reduces the time for integ tests in the sample plugin bc we can now wait seconds instead of minutes to verify behavior.

This PR also refactors the integ tests in the sample plugin for readability.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/job-scheduler/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
