### PR TITLE
Active jobs

### DIFF
--- a/sample-extension-plugin/src/test/java/org/opensearch/jobscheduler/sampleextension/GetScheduledJobInfoIT.java
+++ b/sample-extension-plugin/src/test/java/org/opensearch/jobscheduler/sampleextension/GetScheduledJobInfoIT.java
@@ -114,9 +114,7 @@ public class GetScheduledJobInfoIT extends SampleExtensionIntegTestCase {
             assertNotNull("enabled_time should not be null", job.get("enabled_time"));
             assertNotNull("last_update_time should not be null", job.get("last_update_time"));
             assertNotNull("schedule should not be null", job.get("schedule"));
-            assertTrue(job.get("lock_duration") instanceof Integer);
             assertEquals("none", job.get("jitter"));
-            assertEquals("none", job.get("delay"));
 
             // Validate schedule object
             @SuppressWarnings("unchecked")
@@ -125,6 +123,7 @@ public class GetScheduledJobInfoIT extends SampleExtensionIntegTestCase {
                 "schedule should be interval or Cron",
                 ((schedule.get("type").equals("interval")) || (schedule.get("type").equals("cron")))
             );
+            assertNotNull("none", ((Map<String, Object>) job.get("schedule")).get("delay"));
         }
         assertEquals("All expected job IDs should be present", expectedJobIds, actualJobIds);
     }
@@ -175,9 +174,7 @@ public class GetScheduledJobInfoIT extends SampleExtensionIntegTestCase {
                     assertNotNull("enabled_time should not be null", job.get("enabled_time"));
                     assertNotNull("last_update_time should not be null", job.get("last_update_time"));
                     assertNotNull("schedule should not be null", job.get("schedule"));
-                    assertTrue(job.get("lock_duration") instanceof Integer);
                     assertEquals("none", job.get("jitter"));
-                    assertEquals("none", job.get("delay"));
                     // Validate schedule object
                     @SuppressWarnings("unchecked")
                     Map<String, Object> schedule = (Map<String, Object>) job.get("schedule");
@@ -185,6 +182,7 @@ public class GetScheduledJobInfoIT extends SampleExtensionIntegTestCase {
                         "schedule should be interval or Cron",
                         ((schedule.get("type").equals("interval")) || (schedule.get("type").equals("cron")))
                     );
+                    assertNotNull("none", ((Map<String, Object>) job.get("schedule")).get("delay"));
                 }
             }
         }

--- a/sample-extension-plugin/src/test/java/org/opensearch/jobscheduler/sampleextension/SampleJobRunnerRestIT.java
+++ b/sample-extension-plugin/src/test/java/org/opensearch/jobscheduler/sampleextension/SampleJobRunnerRestIT.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 
 public class SampleJobRunnerRestIT extends SampleExtensionIntegTestCase {
 
@@ -188,7 +189,7 @@ public class SampleJobRunnerRestIT extends SampleExtensionIntegTestCase {
         Assert.assertEquals(2, countRecordsInTestIndex(index));
     }
 
-    public void testActiveLockResponseInScheduledInfo() throws Exception {
+    public void testActiveLockResponseInScheduledInfoByNode() throws Exception {
         String SCHEDULER_INFO_URI = "/_plugins/_job_scheduler/api/jobs?by_node";
 
         String index = createTestIndex();
@@ -202,7 +203,7 @@ public class SampleJobRunnerRestIT extends SampleExtensionIntegTestCase {
         createWatcherJob(jobId, jobParameter);
 
         // Run job and check for release = false
-        waitUntilLockIsAcquiredAndReleasedTransportCall(jobId, 20);
+        waitUntilLockIsAcquiredAndReleasedTransportCall(jobId, 20, SCHEDULER_INFO_URI, navigationFunctionByNode);
 
         // Call the scheduled info API
         // Checks lock is released
@@ -213,22 +214,50 @@ public class SampleJobRunnerRestIT extends SampleExtensionIntegTestCase {
             response.getEntity().getContent()
         ).map();
 
-        List<Map<String, Object>> nodes = (List<Map<String, Object>>) responseJson.get("nodes");
-        Map<String, Object> node = nodes.get(0);
-        Map<String, Object> scheduled_job_info = (Map<String, Object>) node.get("scheduled_job_info");
-        List<Map<String, Object>> jobs = (List<Map<String, Object>>) scheduled_job_info.get("jobs");
-        Map<String, Object> job = jobs.get(0);
-        List<Object> lockProperties = (List<Object>) job.get("locks");
-        Map<String, Object> lockMap = (Map<String, Object>) lockProperties.get(0);
-        assertTrue((boolean) lockMap.get("released"));
+        // Asserts that "released" is true
+        assertTrue(navigationFunctionByNode.apply(responseJson));
 
     }
 
-    protected void waitUntilLockIsAcquiredAndReleasedTransportCall(String jobId, int maxTimeInSec) throws IOException,
-        InterruptedException {
+    public void testActiveLockResponseInScheduledEntireCluster() throws Exception {
+        String SCHEDULER_INFO_URI = "/_plugins/_job_scheduler/api/jobs";
+
+        String index = createTestIndex();
+        SampleJobParameter jobParameter = new SampleJobParameter();
+        jobParameter.setJobName("sample-job-lock-test-it");
+        jobParameter.setIndexToWatch(index);
+        jobParameter.setSchedule(new IntervalSchedule(Instant.now(), 5, ChronoUnit.SECONDS));
+        jobParameter.setLockDurationSeconds(10L);
+
+        String jobId = OpenSearchRestTestCase.randomAlphaOfLength(10);
+        createWatcherJob(jobId, jobParameter);
+
+        // Run job and check for release = false
+        waitUntilLockIsAcquiredAndReleasedTransportCall(jobId, 20, SCHEDULER_INFO_URI, navigationFunctionEntireCuster);
+
+        // Call the scheduled info API
+        // Checks lock is released
+        Response response = makeRequest(client(), "GET", SCHEDULER_INFO_URI, Map.of(), null);
+        Map<String, Object> responseJson = JsonXContent.jsonXContent.createParser(
+            NamedXContentRegistry.EMPTY,
+            LoggingDeprecationHandler.INSTANCE,
+            response.getEntity().getContent()
+        ).map();
+
+        // Asserts that "released" is true
+        assertTrue(navigationFunctionEntireCuster.apply(responseJson));
+
+    }
+
+    protected void waitUntilLockIsAcquiredAndReleasedTransportCall(
+        String jobId,
+        int maxTimeInSec,
+        String SCHEDULER_INFO_URI,
+        Function<Map<String, Object>, Boolean> navigationFunction
+    ) throws IOException, InterruptedException {
         AtomicLong prevLockAcquiredTime = new AtomicLong(0L);
         AtomicReference<LockModel> lock = new AtomicReference<>();
-        String SCHEDULER_INFO_URI = "/_plugins/_job_scheduler/api/jobs?by_node";
+
         try {
             lock.set(getLockByJobId(jobId));
             if (lock.get() != null && prevLockAcquiredTime.get() == 0L && lock.get().isReleased()) {
@@ -238,6 +267,7 @@ public class SampleJobRunnerRestIT extends SampleExtensionIntegTestCase {
             throw new RuntimeException(e);
         }
 
+        // Ensure the job is running then calls API
         Thread.sleep(7000);
 
         Response response = makeRequest(client(), "GET", SCHEDULER_INFO_URI, Map.of(), null);
@@ -247,19 +277,34 @@ public class SampleJobRunnerRestIT extends SampleExtensionIntegTestCase {
             response.getEntity().getContent()
         ).map();
 
-        List<Map<String, Object>> nodes = (List<Map<String, Object>>) responseJson.get("nodes");
-        Map<String, Object> node = nodes.get(0);
-        Map<String, Object> scheduled_job_info = (Map<String, Object>) node.get("scheduled_job_info");
-        List<Map<String, Object>> jobs = (List<Map<String, Object>>) scheduled_job_info.get("jobs");
-        Map<String, Object> job = jobs.get(0);
-        List<Object> lockProperties = (List<Object>) job.get("locks");
-        Map<String, Object> lockMap = (Map<String, Object>) lockProperties.get(0);
-        assertFalse((boolean) lockMap.get("released"));
+        // Asserts that "released" is false
+        assertFalse(navigationFunction.apply(responseJson));
 
         await().atMost(maxTimeInSec, TimeUnit.SECONDS).pollInterval(1, TimeUnit.SECONDS).ignoreExceptions().until(() -> {
             lock.set(getLockByJobId(jobId));
             return lock.get() != null && lock.get().getLockTime().toEpochMilli() != prevLockAcquiredTime.get() && lock.get().isReleased();
         });
     }
+
+    // navigates to released property in lock
+    Function<Map<String, Object>, Boolean> navigationFunctionByNode = (responseJson) -> {
+        List<Map<String, Object>> nodes = (List<Map<String, Object>>) responseJson.get("nodes");
+        Map<String, Object> node = nodes.get(0);
+        Map<String, Object> scheduled_job_info = (Map<String, Object>) node.get("scheduled_job_info");
+        List<Map<String, Object>> jobs = (List<Map<String, Object>>) scheduled_job_info.get("jobs");
+        Map<String, Object> job = jobs.get(0);
+        List<Object> lockProperties = (List<Object>) job.get("lock");
+        Map<String, Object> lockMap = (Map<String, Object>) lockProperties.get(0);
+        return (boolean) lockMap.get("released");
+    };
+
+    // navigates to released property in lock
+    Function<Map<String, Object>, Boolean> navigationFunctionEntireCuster = (responseJson) -> {
+        List<Map<String, Object>> jobs = (List<Map<String, Object>>) responseJson.get("jobs");
+        Map<String, Object> job = jobs.get(0);
+        List<Object> lockProperties = (List<Object>) job.get("lock");
+        Map<String, Object> lockMap = (Map<String, Object>) lockProperties.get(0);
+        return (boolean) lockMap.get("released");
+    };
 
 }


### PR DESCRIPTION
### Description
Adds lock information to the Existing Job information API. Lock information includes. Index name, lock time, job ID, lock duration, and released status. See an example output below.

### Related Issues
This will be used as a method to get the currently executing jobs.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/job-scheduler/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

{
  "nodes": [
    {
      "node_id": "Oiw0UMt6R6G1IPb4MAyenQ",
      "node_name": "opensearch-node1",
      "scheduled_job_info": {
        "total_jobs": 0,
        "jobs": []
      }
    },
    {
      "node_id": "GBzll_s3QcyEzyAcTB9COQ",
      "node_name": "opensearch-node2",
      "scheduled_job_info": {
        "total_jobs": 1,
        "jobs": [
          {
            "job_type": "scheduler_sample_extension",
            "job_id": "jobid1",
            "index_name": ".scheduler_sample_extension",
            "name": "saple-job-it",
            "descheduled": false,
            "enabled": true,
            "enabled_time": "1970-07-22T20:08:46.833Z",
            "last_update_time": "1970-07-22T20:08:46.833Z",
            "last_execution_time": "2025-07-14T22:38:46.835317291Z",
            "last_expected_execution_time": "2025-07-14T22:38:46.833192593Z",
            "next_expected_execution_time": "2025-07-14T22:39:46.833192593Z",
            "schedule": {
              "type": "interval",
              "start_time": "1970-07-22T20:08:46.833Z",
              "interval": 1,
              "unit": "Minutes",
              "delay": "none"
            },
            "lock": [
              {
                "job_index_name": ".scheduler_sample_extension",
                "lock_time": "2025-07-14T22:38:46.000Z",
                "job_id": "jobid1",
                "lock_duration_seconds": 120,
                "released": true
              }
            ],
            "jitter": "none"
          }
        ]
      }
    }
  ],
  "failures": [],
  "total_jobs": 1
}
