### PR TITLE
Improve Health Status of lock Index in Single Node Clusters

### DIFF
--- a/sample-extension-plugin/src/test/java/org/opensearch/jobscheduler/sampleextension/SampleJobRunnerRestIT.java
+++ b/sample-extension-plugin/src/test/java/org/opensearch/jobscheduler/sampleextension/SampleJobRunnerRestIT.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 
 public class SampleJobRunnerRestIT extends SampleExtensionIntegTestCase {
 
@@ -281,6 +282,17 @@ public class SampleJobRunnerRestIT extends SampleExtensionIntegTestCase {
 
         // Asserts that "released" is true
         assertTrue(isLockReleased.apply(responseJson));
+
+        // Check that .opendistro-job-scheduler-lock index is green
+        Response catResponse = makeRequest(
+            client(),
+            "GET",
+            "/_cat/indices/.opendistro-job-scheduler-lock?v&h=index,health",
+            Map.of(),
+            null
+        );
+        String catResponseBody = EntityUtils.toString(catResponse.getEntity());
+        assertTrue("Lock index should be green", catResponseBody.contains("green"));
 
         // Cleanup
         deleteWatcherJob(jobId);

--- a/spi/src/main/java/org/opensearch/jobscheduler/spi/utils/LockService.java
+++ b/spi/src/main/java/org/opensearch/jobscheduler/spi/utils/LockService.java
@@ -44,6 +44,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.Map;
 
 public class LockService {
     private static final Logger logger = LogManager.getLogger(LockService.class);
@@ -51,6 +52,7 @@ public class LockService {
 
     private final Client client;
     private final ClusterService clusterService;
+    final static Map<String, Object> INDEX_SETTINGS = Map.of("index.number_of_shards", 1, "index.auto_expand_replicas", "0-1");
 
     // This is used in tests to control time.
     private Instant testInstant = null;
@@ -87,7 +89,7 @@ public class LockService {
                 final CreateIndexRequest request = new CreateIndexRequest(LOCK_INDEX_NAME).mapping(
                     lockMapping(),
                     (MediaType) XContentType.JSON
-                );
+                ).settings(INDEX_SETTINGS);
                 client.admin()
                     .indices()
                     .create(request, ActionListener.wrap(response -> listener.onResponse(response.isAcknowledged()), exception -> {


### PR DESCRIPTION
### Description

#### Bug Fix: Improve Health Status of .opendistro-job-scheduler-lock Index in Single Node Clusters

This pull request addresses an issue where the `.opendistro-job-scheduler-lock` index was showing a yellow health status in single node clusters. The problem was caused by the use of `indexrequest` default settings, which were not optimal for single node environments.

#### Changes:

* Modified the replica settings for the `.opendistro-job-scheduler-lock` index to:
  ```json
  {
    "index.number_of_shards": 1,
    "index.auto_expand_replicas": "0-1"
  }


### Issues Resolved
* https://github.com/opensearch-project/job-scheduler/issues/784

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/job-scheduler/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
