### PR TITLE
Changing logger and threadpool in TransportGetScheduledInfo Action

### DIFF
--- a/src/main/java/org/opensearch/jobscheduler/transport/action/TransportGetScheduledInfoAction.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/action/TransportGetScheduledInfoAction.java
@@ -45,7 +45,7 @@ public class TransportGetScheduledInfoAction extends TransportNodesAction<
     GetScheduledInfoNodeRequest,
     GetScheduledInfoNodeResponse> {
 
-    private static final Logger log = LogManager.getLogger(JobScheduler.class);
+    private static final Logger log = LogManager.getLogger(TransportGetScheduledInfoAction.class);
     private final JobScheduler jobScheduler;
     private final JobDetailsService jobDetailsService;
     private static final DateFormatter STRICT_DATE_TIME_FORMATTER = DateFormatter.forPattern("strict_date_time");
@@ -67,7 +67,7 @@ public class TransportGetScheduledInfoAction extends TransportNodesAction<
             actionFilters,
             GetScheduledInfoRequest::new,
             GetScheduledInfoNodeRequest::new,
-            ThreadPool.Names.MANAGEMENT,
+            ThreadPool.Names.GENERIC,
             GetScheduledInfoNodeResponse.class
         );
         this.jobScheduler = jobScheduler;


### PR DESCRIPTION
### Description
Changes to the correct class in in logger. Threadpool is changed to a pool with a greater number of threads.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/job-scheduler/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
