### PR TITLE
Remove manual tracking of seqNo and priTerm for the LockModel

### DIFF
--- a/spi/src/main/java/org/opensearch/jobscheduler/spi/StatusHistoryModel.java
+++ b/spi/src/main/java/org/opensearch/jobscheduler/spi/StatusHistoryModel.java
@@ -47,7 +47,7 @@ public final class StatusHistoryModel implements ToXContentObject, Writeable {
         this(in.readString(), in.readString(), in.readInstant(), in.readOptionalInstant(), in.readInt());
     }
 
-    public static StatusHistoryModel parse(final XContentParser parser, long seqNo, long primaryTerm) throws IOException {
+    public static StatusHistoryModel parse(final XContentParser parser) throws IOException {
         String jobIndexName = null;
         String jobId = null;
         Instant startTime = null;

--- a/spi/src/main/java/org/opensearch/jobscheduler/spi/StatusHistoryModel.java
+++ b/spi/src/main/java/org/opensearch/jobscheduler/spi/StatusHistoryModel.java
@@ -15,7 +15,6 @@ import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.core.xcontent.XContentParserUtils;
-import org.opensearch.index.seqno.SequenceNumbers;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -35,33 +34,17 @@ public final class StatusHistoryModel implements ToXContentObject, Writeable {
     private final Instant startTime;
     private final Instant endTime;
     private final int status;
-    private final long seqNo;
-    private final long primaryTerm;
 
     public StatusHistoryModel(String jobIndexName, String jobId, Instant startTime, Instant endTime, int status) {
-        this(jobIndexName, jobId, startTime, endTime, status, SequenceNumbers.UNASSIGNED_SEQ_NO, SequenceNumbers.UNASSIGNED_PRIMARY_TERM);
-    }
-
-    public StatusHistoryModel(
-        String jobIndexName,
-        String jobId,
-        Instant startTime,
-        Instant endTime,
-        int status,
-        long seqNo,
-        long primaryTerm
-    ) {
         this.jobIndexName = jobIndexName;
         this.jobId = jobId;
         this.startTime = startTime;
         this.endTime = endTime;
         this.status = status;
-        this.seqNo = seqNo;
-        this.primaryTerm = primaryTerm;
     }
 
     public StatusHistoryModel(StreamInput in) throws IOException {
-        this(in.readString(), in.readString(), in.readInstant(), in.readOptionalInstant(), in.readInt(), in.readLong(), in.readLong());
+        this(in.readString(), in.readString(), in.readInstant(), in.readOptionalInstant(), in.readInt());
     }
 
     public static StatusHistoryModel parse(final XContentParser parser, long seqNo, long primaryTerm) throws IOException {
@@ -103,9 +86,7 @@ public final class StatusHistoryModel implements ToXContentObject, Writeable {
             requireNonNull(jobId, "JobId cannot be null"),
             requireNonNull(startTime, "startTime cannot be null"),
             endTime,
-            requireNonNull(status, "status cannot be null"),
-            seqNo,
-            primaryTerm
+            requireNonNull(status, "status cannot be null")
         );
     }
 
@@ -146,22 +127,12 @@ public final class StatusHistoryModel implements ToXContentObject, Writeable {
         return status;
     }
 
-    public long getSeqNo() {
-        return seqNo;
-    }
-
-    public long getPrimaryTerm() {
-        return primaryTerm;
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         StatusHistoryModel that = (StatusHistoryModel) o;
-        return seqNo == that.seqNo
-            && primaryTerm == that.primaryTerm
-            && jobIndexName.equals(that.jobIndexName)
+        return jobIndexName.equals(that.jobIndexName)
             && jobId.equals(that.jobId)
             && startTime.equals(that.startTime)
             && Objects.equals(endTime, that.endTime)
@@ -170,7 +141,7 @@ public final class StatusHistoryModel implements ToXContentObject, Writeable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(jobIndexName, jobId, startTime, endTime, status, seqNo, primaryTerm);
+        return Objects.hash(jobIndexName, jobId, startTime, endTime, status);
     }
 
     @Override
@@ -180,7 +151,5 @@ public final class StatusHistoryModel implements ToXContentObject, Writeable {
         out.writeInstant(this.startTime);
         out.writeOptionalInstant(this.endTime);
         out.writeInt(this.status);
-        out.writeLong(this.seqNo);
-        out.writeLong(this.primaryTerm);
     }
 }

--- a/spi/src/main/java/org/opensearch/jobscheduler/spi/utils/JobHistoryService.java
+++ b/spi/src/main/java/org/opensearch/jobscheduler/spi/utils/JobHistoryService.java
@@ -225,7 +225,7 @@ public class JobHistoryService {
                         XContentParser parser = XContentType.JSON.xContent()
                             .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, response.getSourceAsString());
                         parser.nextToken();
-                        listener.onResponse(StatusHistoryModel.parse(parser, response.getSeqNo(), response.getPrimaryTerm()));
+                        listener.onResponse(StatusHistoryModel.parse(parser));
                     } catch (IOException e) {
                         logger.error("IOException occurred parsing history record", e);
                         listener.onResponse(null);

--- a/spi/src/main/java/org/opensearch/jobscheduler/spi/utils/JobHistoryService.java
+++ b/spi/src/main/java/org/opensearch/jobscheduler/spi/utils/JobHistoryService.java
@@ -122,15 +122,7 @@ public class JobHistoryService {
                 findHistoryRecord(jobIndexName, jobId, startTime, ActionListener.wrap(existingRecord -> {
                     if (existingRecord != null) {
                         // Update existing record
-                        StatusHistoryModel updatedModel = new StatusHistoryModel(
-                            jobIndexName,
-                            jobId,
-                            startTime,
-                            endTime,
-                            status,
-                            existingRecord.getSeqNo(),
-                            existingRecord.getPrimaryTerm()
-                        );
+                        StatusHistoryModel updatedModel = new StatusHistoryModel(jobIndexName, jobId, startTime, endTime, status);
                         updateHistoryRecord(
                             updatedModel,
                             ActionListener.wrap(updated -> listener.onResponse(updated != null), listener::onFailure)
@@ -186,8 +178,6 @@ public class JobHistoryService {
 
             UpdateRequest updateRequest = new UpdateRequest().index(JOB_HISTORY_INDEX_NAME)
                 .id(documentId)
-                .setIfSeqNo(historyModelupdate.getSeqNo())
-                .setIfPrimaryTerm(historyModelupdate.getPrimaryTerm())
                 .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
                 .doc(historyModelupdate.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS))
                 .fetchSource(true);
@@ -201,9 +191,7 @@ public class JobHistoryService {
                             historyModelupdate.getJobId(),
                             historyModelupdate.getStartTime(),
                             historyModelupdate.getEndTime(),
-                            historyModelupdate.getStatus(),
-                            response.getSeqNo(),
-                            response.getPrimaryTerm()
+                            historyModelupdate.getStatus()
                         )
                     ),
                     exception -> {

--- a/spi/src/test/java/org/opensearch/jobscheduler/spi/utils/JobHistoryServiceIT.java
+++ b/spi/src/test/java/org/opensearch/jobscheduler/spi/utils/JobHistoryServiceIT.java
@@ -213,15 +213,7 @@ public class JobHistoryServiceIT extends OpenSearchIntegTestCase {
             historyService.findHistoryRecord(jobIndexName, jobId, startTime, ActionListener.wrap(historyModel -> {
                 assertNotNull("History record should exist", historyModel);
                 // Create updated model
-                StatusHistoryModel updatedModel = new StatusHistoryModel(
-                    jobIndexName,
-                    jobId,
-                    startTime,
-                    Instant.now(),
-                    3,
-                    historyModel.getSeqNo(),
-                    historyModel.getPrimaryTerm()
-                );
+                StatusHistoryModel updatedModel = new StatusHistoryModel(jobIndexName, jobId, startTime, Instant.now(), 3);
                 // Update directly
                 historyService.updateHistoryRecord(updatedModel, ActionListener.wrap(updatedHistoryModel -> {
                     assertNotNull("Updated history model should not be null", updatedHistoryModel);

--- a/src/main/java/org/opensearch/jobscheduler/rest/action/RestGetLockAction.java
+++ b/src/main/java/org/opensearch/jobscheduler/rest/action/RestGetLockAction.java
@@ -114,9 +114,7 @@ public class RestGetLockAction extends BaseRestHandler {
                     // Create Response
                     AcquireLockResponse acquireLockResponse = new AcquireLockResponse(
                         lockModelResponseHolder,
-                        LockModel.generateLockId(jobIndexName, jobId),
-                        lockModelResponseHolder.getSeqNo(),
-                        lockModelResponseHolder.getPrimaryTerm()
+                        LockModel.generateLockId(jobIndexName, jobId)
                     );
                     acquireLockResponse.toXContent(builder, ToXContent.EMPTY_PARAMS);
 

--- a/src/main/java/org/opensearch/jobscheduler/transport/AcquireLockResponse.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/AcquireLockResponse.java
@@ -24,14 +24,10 @@ import static java.util.Objects.requireNonNull;
 public class AcquireLockResponse implements ToXContentObject {
     private final LockModel lock;
     private final String lockId;
-    private final long seqNo;
-    private final long primaryTerm;
 
-    public AcquireLockResponse(final LockModel lock, final String lockId, final long seqNo, final long primaryTerm) {
+    public AcquireLockResponse(final LockModel lock, final String lockId) {
         this.lock = lock;
         this.lockId = lockId;
-        this.seqNo = seqNo;
-        this.primaryTerm = primaryTerm;
     }
 
     public LockModel getLock() {
@@ -40,14 +36,6 @@ public class AcquireLockResponse implements ToXContentObject {
 
     public String getLockId() {
         return this.lockId;
-    }
-
-    public long getSeqNo() {
-        return this.seqNo;
-    }
-
-    public long getPrimaryTerm() {
-        return this.primaryTerm;
     }
 
     public static AcquireLockResponse parse(final XContentParser parser) throws IOException {
@@ -64,33 +52,20 @@ public class AcquireLockResponse implements ToXContentObject {
                 case LockModel.LOCK_ID:
                     lockId = parser.text();
                     break;
-                case LockModel.SEQUENCE_NUMBER:
-                    seqNo = parser.longValue();
-                    break;
-                case LockModel.PRIMARY_TERM:
-                    primaryTerm = parser.longValue();
-                    break;
                 case LockModel.LOCK_MODEL:
-                    lock = LockModel.parse(parser, seqNo, primaryTerm);
+                    lock = LockModel.parse(parser);
                     break;
                 default:
                     throw new IllegalArgumentException("Unknown field " + fieldName);
             }
         }
-        return new AcquireLockResponse(
-            requireNonNull(lock, "LockModel cannot be null"),
-            requireNonNull(lockId, "LockId cannot be null"),
-            requireNonNull(seqNo, "Sequence Number cannot be null"),
-            requireNonNull(primaryTerm, "Primary Term cannot be null")
-        );
+        return new AcquireLockResponse(requireNonNull(lock, "LockModel cannot be null"), requireNonNull(lockId, "LockId cannot be null"));
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         builder.field(LockModel.LOCK_ID, lockId);
-        builder.field(LockModel.SEQUENCE_NUMBER, seqNo);
-        builder.field(LockModel.PRIMARY_TERM, primaryTerm);
         builder.field(LockModel.LOCK_MODEL, lock);
         builder.endObject();
         return builder;

--- a/src/main/java/org/opensearch/jobscheduler/transport/action/TransportGetAllLocksAction.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/action/TransportGetAllLocksAction.java
@@ -96,7 +96,7 @@ public class TransportGetAllLocksAction extends HandledTransportAction<GetLocksR
                             XContentParser parser = XContentType.JSON.xContent()
                                 .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, hit.getSourceAsString());
                             parser.nextToken();
-                            LockModel lock = LockModel.parse(parser, hit.getSeqNo(), hit.getPrimaryTerm());
+                            LockModel lock = LockModel.parse(parser);
                             result.put(lock.getLockId(), lock);
                         } catch (IOException e) {
                             log.error("Error parsing lock from search hit", e);
@@ -151,7 +151,7 @@ public class TransportGetAllLocksAction extends HandledTransportAction<GetLocksR
                 XContentParser parser = XContentType.JSON.xContent()
                     .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, hit.getSourceAsString());
                 parser.nextToken();
-                LockModel lock = LockModel.parse(parser, hit.getSeqNo(), hit.getPrimaryTerm());
+                LockModel lock = LockModel.parse(parser);
                 allLocks.put(lock.getLockId(), lock);
             } catch (IOException e) {
                 log.error("Error parsing lock from search hit", e);

--- a/src/test/java/org/opensearch/jobscheduler/multinode/GetLockMultiNodeRestIT.java
+++ b/src/test/java/org/opensearch/jobscheduler/multinode/GetLockMultiNodeRestIT.java
@@ -87,8 +87,6 @@ public class GetLockMultiNodeRestIT extends ODFERestTestCase {
 
         // Validate response map fields
         assertNotNull(acquireLockResponse.getLockId());
-        assertNotNull(acquireLockResponse.getSeqNo());
-        assertNotNull(acquireLockResponse.getPrimaryTerm());
         assertNotNull(acquireLockResponse.getLock());
 
         return acquireLockResponse.getLockId();


### PR DESCRIPTION
### Description

This PR removes manual tracking of seqNo and priTerm for the LockModel. This repo doesn't use these values as intended and they serve no real purpose, the LockModel can be simplified to just the attributes pertinent to the LockModel. seqNo and priTerm and internal metafields of documents in OpenSearch that help understand if a document has previously been updated or if the primary shard has changed.

In the LockService, we always call findLock before updateLock so we simply feed back the same values that we got on find. I suppose it is possible that an operator can use the admin certificate to do a direct lock update which would then cause a mismatch of the seqNos but I think we should allow the lock to be acquired/released by the LockService anyway and run without checks on the seqNo and priTerm.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/job-scheduler/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
