### PR TITLE
Create guice model to bind LockService interface from SPI to LockServiceImpl

### DIFF
--- a/src/main/java/org/opensearch/jobscheduler/JobSchedulerPlugin.java
+++ b/src/main/java/org/opensearch/jobscheduler/JobSchedulerPlugin.java
@@ -10,6 +10,7 @@ package org.opensearch.jobscheduler;
 
 import org.opensearch.action.ActionRequest;
 import org.opensearch.cluster.node.DiscoveryNodes;
+import org.opensearch.common.inject.Module;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.settings.ClusterSettings;
@@ -100,6 +101,11 @@ public class JobSchedulerPlugin extends Plugin implements ActionPlugin, Extensib
 
     public Map<String, ScheduledJobProvider> getIndexToJobProviders() {
         return indexToJobProviders;
+    }
+
+    @Override
+    public Collection<Module> createGuiceModules() {
+        return List.of(new JobSchedulerPluginModule());
     }
 
     @Override

--- a/src/main/java/org/opensearch/jobscheduler/JobSchedulerPluginModule.java
+++ b/src/main/java/org/opensearch/jobscheduler/JobSchedulerPluginModule.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.jobscheduler;
+
+import org.opensearch.common.inject.AbstractModule;
+import org.opensearch.jobscheduler.spi.utils.LockService;
+import org.opensearch.jobscheduler.utils.LockServiceImpl;
+
+/**
+ * Guice Module to manage JobScheduler related objects
+ */
+public class JobSchedulerPluginModule extends AbstractModule {
+
+    /**
+     * Constructor for JobSchedulerPluginModule
+     */
+    public JobSchedulerPluginModule() {}
+
+    @Override
+    protected void configure() {
+        bind(LockService.class).to(LockServiceImpl.class);
+    }
+}


### PR DESCRIPTION
### Description

Quick follow up from https://github.com/opensearch-project/job-scheduler/pull/714 to solve a dependency injection issue resulting as the change of LockService from a class to an interface. Since JS returns LockService from createComponents, it also needs to bind the interface to the concrete class to let Guice know how to do the dependency injection.

### Related Issues

Resolves issue seen in https://github.com/opensearch-project/security-analytics/actions/runs/17865468930/job/50806591993?pr=1577

```
»  org.opensearch.common.inject.ConfigurationException: Guice configuration errors:
»  
»  1) No implementation for org.opensearch.jobscheduler.spi.utils.LockService was bound.
»    while locating org.opensearch.jobscheduler.spi.utils.LockService
»      for parameter 0 at org.opensearch.securityanalytics.SecurityAnalyticsPlugin$GuiceHolder.<init>(Unknown Source)
»    while locating org.opensearch.securityanalytics.SecurityAnalyticsPlugin$GuiceHolder
»  
»  1 error
»  	at <<<guice>>>
»  	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
```

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/job-scheduler/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
