### PR TITLE
Exclude slf4j and commons-codec dependencies that caused jarhell in downstream plugins from remote metadata sdk

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -241,15 +241,20 @@ repositories {
 
 dependencies {
     implementation project(path: ":${rootProject.name}-spi", configuration: 'shadow')
-    implementation ("org.opensearch:opensearch-remote-metadata-sdk-ddb-client:${opensearch_build}")
-    implementation "org.opensearch:opensearch-remote-metadata-sdk:${opensearch_build}"
+    implementation ("org.opensearch:opensearch-remote-metadata-sdk-ddb-client:${opensearch_build}") {
+        exclude group: 'org.slf4j', module: 'slf4j-api'
+        exclude group: 'commons-codec', module: 'commons-codec'
+    }
+    implementation ("org.opensearch:opensearch-remote-metadata-sdk:${opensearch_build}") {
+        exclude group: 'org.slf4j', module: 'slf4j-api'
+        exclude group: 'commons-codec', module: 'commons-codec'
+    }
     testImplementation group: 'org.mockito', name: 'mockito-core', version: "${versions.mockito}"
 
     opensearchPlugin "org.opensearch.plugin:opensearch-security:${security_plugin_version}@zip"
 }
 
 def commonResolutionStrategy = {
-    force "org.slf4j:slf4j-api:${versions.slf4j}"
     force "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
     force "com.fasterxml.jackson.core:jackson-databind:${versions.jackson}"
     force "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}"
@@ -257,7 +262,6 @@ def commonResolutionStrategy = {
     force "com.fasterxml.jackson.dataformat:jackson-dataformat-smile:${versions.jackson}"
     force "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${versions.jackson}"
     force "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${versions.jackson}"
-    force "commons-codec:commons-codec:${versions.commonscodec}"
     force "org.apache.httpcomponents:httpcore:${versions.httpcore}"
     force "jakarta.json:jakarta.json-api:2.1.3"
     force "commons-logging:commons-logging:${versions.commonslogging}"


### PR DESCRIPTION
### Description
[Describe what this change achieves]

### Related Issues
Resolves AD jarhell: https://github.com/opensearch-project/anomaly-detection/pull/1546#issuecomment-3335791114

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/job-scheduler/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
