### PR TITLE
Revert "Introduce a configurable remote metadata client AND migrate LockService to the client (#831)" to avoid jarHell in downstream plugins.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -241,32 +241,9 @@ repositories {
 
 dependencies {
     implementation project(path: ":${rootProject.name}-spi", configuration: 'shadow')
-    implementation ("org.opensearch:opensearch-remote-metadata-sdk-ddb-client:${opensearch_build}")
-    implementation "org.opensearch:opensearch-remote-metadata-sdk:${opensearch_build}"
     testImplementation group: 'org.mockito', name: 'mockito-core', version: "${versions.mockito}"
 
     opensearchPlugin "org.opensearch.plugin:opensearch-security:${security_plugin_version}@zip"
-}
-
-def commonResolutionStrategy = {
-    force "org.slf4j:slf4j-api:${versions.slf4j}"
-    force "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
-    force "com.fasterxml.jackson.core:jackson-databind:${versions.jackson}"
-    force "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}"
-    force "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${versions.jackson}"
-    force "com.fasterxml.jackson.dataformat:jackson-dataformat-smile:${versions.jackson}"
-    force "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${versions.jackson}"
-    force "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${versions.jackson}"
-    force "commons-codec:commons-codec:${versions.commonscodec}"
-    force "org.apache.httpcomponents:httpcore:${versions.httpcore}"
-    force "jakarta.json:jakarta.json-api:2.1.3"
-    force "commons-logging:commons-logging:${versions.commonslogging}"
-    force "org.apache.httpcomponents.client5:httpclient5:${versions.httpclient5}"
-}
-
-configurations {
-    runtimeClasspath.resolutionStrategy(commonResolutionStrategy)
-    testRuntimeClasspath.resolutionStrategy(commonResolutionStrategy)
 }
 
 // RPM & Debian build
@@ -317,9 +294,9 @@ integTest {
     }
 }
 Zip bundle = (Zip) project.getTasks().getByName("bundlePlugin");
-integTest.getClusters().forEach{ c ->
+integTest.getClusters().forEach{c -> {
     c.plugin(project.getObjects().fileProperty().value(bundle.getArchiveFile()))
-}
+}}
 
 testClusters.integTest {
     testDistribution = 'INTEG_TEST'

--- a/sample-extension-plugin/build.gradle
+++ b/sample-extension-plugin/build.gradle
@@ -111,10 +111,10 @@ integTest {
 
 Zip bundle = (Zip) project.getTasks().getByName("bundlePlugin");
 Zip rootBundle = (Zip) rootProject.getTasks().getByName("bundlePlugin");
-integTest.getClusters().forEach{c ->
+integTest.getClusters().forEach{c -> {
     c.plugin(rootProject.getObjects().fileProperty().value(rootBundle.getArchiveFile()))
     c.plugin(project.getObjects().fileProperty().value(bundle.getArchiveFile()))
-}
+}}
 
 testClusters.integTest {
     testDistribution = 'INTEG_TEST'

--- a/src/main/java/org/opensearch/jobscheduler/JobSchedulerPlugin.java
+++ b/src/main/java/org/opensearch/jobscheduler/JobSchedulerPlugin.java
@@ -56,8 +56,6 @@ import org.opensearch.plugins.ExtensiblePlugin;
 import org.opensearch.plugins.IdentityAwarePlugin;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.plugins.SystemIndexPlugin;
-import org.opensearch.remote.metadata.client.SdkClient;
-import org.opensearch.remote.metadata.client.impl.SdkClientFactory;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.rest.RestController;
 import org.opensearch.script.ScriptService;
@@ -72,23 +70,14 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.function.Supplier;
-
-import static org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_ENDPOINT_KEY;
-import static org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_REGION_KEY;
-import static org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_SERVICE_NAME_KEY;
-import static org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_TYPE_KEY;
-import static org.opensearch.remote.metadata.common.CommonValue.TENANT_AWARE_KEY;
-import static org.opensearch.remote.metadata.common.CommonValue.TENANT_ID_FIELD_KEY;
 
 public class JobSchedulerPlugin extends Plugin implements ActionPlugin, ExtensiblePlugin, SystemIndexPlugin, IdentityAwarePlugin {
 
     public static final String OPEN_DISTRO_JOB_SCHEDULER_THREAD_POOL_NAME = "open_distro_job_scheduler";
     public static final String JS_BASE_URI = "/_plugins/_job_scheduler";
-    public static final String TENANT_ID_FIELD = "tenant_id";
 
     private static final Logger log = LogManager.getLogger(JobSchedulerPlugin.class);
     private JobSweeper sweeper;
@@ -98,7 +87,6 @@ public class JobSchedulerPlugin extends Plugin implements ActionPlugin, Extensib
     private Map<String, ScheduledJobProvider> indexToJobProviders;
     private Set<String> indicesToListen;
     private PluginClient pluginClient;
-    private SdkClient sdkClient;
 
     private JobDetailsService jobDetailsService;
 
@@ -142,36 +130,10 @@ public class JobSchedulerPlugin extends Plugin implements ActionPlugin, Extensib
         IndexNameExpressionResolver indexNameExpressionResolver,
         Supplier<RepositoriesService> repositoriesServiceSupplier
     ) {
-        Settings settings = environment.settings();
-        Boolean isMultiTenancyEnabled = JobSchedulerSettings.JOB_SCHEDULER_MULTI_TENANCY_ENABLED.get(settings);
-        this.pluginClient = new PluginClient(client);
-
-        // Initialize SDK client for remote metadata storage
-        this.sdkClient = SdkClientFactory.createSdkClient(
-            pluginClient,
-            xContentRegistry,
-            isMultiTenancyEnabled
-                ? Map.ofEntries(
-                    Map.entry(REMOTE_METADATA_TYPE_KEY, JobSchedulerSettings.REMOTE_METADATA_TYPE.get(settings)),
-                    Map.entry(REMOTE_METADATA_ENDPOINT_KEY, JobSchedulerSettings.REMOTE_METADATA_ENDPOINT.get(settings)),
-                    Map.entry(REMOTE_METADATA_REGION_KEY, JobSchedulerSettings.REMOTE_METADATA_REGION.get(settings)),
-                    Map.entry(REMOTE_METADATA_SERVICE_NAME_KEY, JobSchedulerSettings.REMOTE_METADATA_SERVICE_NAME.get(settings)),
-                    Map.entry(TENANT_AWARE_KEY, "true"),
-                    Map.entry(TENANT_ID_FIELD_KEY, TENANT_ID_FIELD)
-                )
-                : Collections.emptyMap()
-        );
-
         Supplier<Boolean> statusHistoryEnabled = () -> JobSchedulerSettings.STATUS_HISTORY.get(environment.settings());
+        this.pluginClient = new PluginClient(client);
         this.historyService = new JobHistoryService(pluginClient, clusterService);
-        this.lockService = new LockServiceImpl(
-            pluginClient,
-            clusterService,
-            historyService,
-            statusHistoryEnabled,
-            this.sdkClient,
-            isMultiTenancyEnabled
-        );
+        this.lockService = new LockServiceImpl(pluginClient, clusterService, historyService, statusHistoryEnabled);
         this.jobDetailsService = new JobDetailsService(client, clusterService, this.indicesToListen, this.indexToJobProviders);
         this.scheduler = new JobScheduler(threadPool, this.lockService);
         this.sweeper = initSweeper(
@@ -187,7 +149,7 @@ public class JobSchedulerPlugin extends Plugin implements ActionPlugin, Extensib
         clusterService.addListener(this.sweeper);
         clusterService.addLifecycleListener(this.sweeper);
 
-        return List.of(this.lockService, this.scheduler, this.jobDetailsService, this.pluginClient, this.sdkClient);
+        return List.of(this.lockService, this.scheduler, this.jobDetailsService, this.pluginClient);
     }
 
     @Override
@@ -206,11 +168,6 @@ public class JobSchedulerPlugin extends Plugin implements ActionPlugin, Extensib
         settingList.add(JobSchedulerSettings.SWEEP_PERIOD);
         settingList.add(JobSchedulerSettings.JITTER_LIMIT);
         settingList.add(JobSchedulerSettings.STATUS_HISTORY);
-        settingList.add(JobSchedulerSettings.REMOTE_METADATA_TYPE);
-        settingList.add(JobSchedulerSettings.REMOTE_METADATA_ENDPOINT);
-        settingList.add(JobSchedulerSettings.REMOTE_METADATA_REGION);
-        settingList.add(JobSchedulerSettings.REMOTE_METADATA_SERVICE_NAME);
-        settingList.add(JobSchedulerSettings.JOB_SCHEDULER_MULTI_TENANCY_ENABLED);
         return settingList;
     }
 

--- a/src/main/java/org/opensearch/jobscheduler/JobSchedulerSettings.java
+++ b/src/main/java/org/opensearch/jobscheduler/JobSchedulerSettings.java
@@ -11,12 +11,6 @@ package org.opensearch.jobscheduler;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.unit.TimeValue;
 
-import static org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_ENDPOINT_KEY;
-import static org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_REGION_KEY;
-import static org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_SERVICE_NAME_KEY;
-import static org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_TYPE_KEY;
-import static org.opensearch.remote.metadata.common.CommonValue.TENANT_AWARE_KEY;
-
 public class JobSchedulerSettings {
     public static final Setting<TimeValue> REQUEST_TIMEOUT = Setting.positiveTimeSetting(
         "plugins.jobscheduler.request_timeout",
@@ -65,41 +59,5 @@ public class JobSchedulerSettings {
         false,
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
-    );
-
-    /** This setting sets the remote metadata type */
-    public static final Setting<String> REMOTE_METADATA_TYPE = Setting.simpleString(
-        "plugins.jobscheduler." + REMOTE_METADATA_TYPE_KEY,
-        Setting.Property.NodeScope,
-        Setting.Property.Final
-    );
-
-    /** This setting sets the remote metadata endpoint */
-    public static final Setting<String> REMOTE_METADATA_ENDPOINT = Setting.simpleString(
-        "plugins.jobscheduler." + REMOTE_METADATA_ENDPOINT_KEY,
-        Setting.Property.NodeScope,
-        Setting.Property.Final
-    );
-
-    /** This setting sets the remote metadata region */
-    public static final Setting<String> REMOTE_METADATA_REGION = Setting.simpleString(
-        "plugins.jobscheduler." + REMOTE_METADATA_REGION_KEY,
-        Setting.Property.NodeScope,
-        Setting.Property.Final
-    );
-
-    /** This setting sets the remote metadata service name */
-    public static final Setting<String> REMOTE_METADATA_SERVICE_NAME = Setting.simpleString(
-        "plugins.jobscheduler." + REMOTE_METADATA_SERVICE_NAME_KEY,
-        Setting.Property.NodeScope,
-        Setting.Property.Final
-    );
-
-    /** This setting enables multi-tenancy for job scheduler */
-    public static final Setting<Boolean> JOB_SCHEDULER_MULTI_TENANCY_ENABLED = Setting.boolSetting(
-        "plugins.jobscheduler." + TENANT_AWARE_KEY,
-        false,
-        Setting.Property.NodeScope,
-        Setting.Property.Final
     );
 }

--- a/src/main/java/org/opensearch/jobscheduler/utils/JobDetailsService.java
+++ b/src/main/java/org/opensearch/jobscheduler/utils/JobDetailsService.java
@@ -398,7 +398,7 @@ public class JobDetailsService implements IndexingOperationListener {
 
     /**
      * Create Job details entry
-     * @param tempJobDetails new job details object that need to be inserted as document in the index
+     * @param tempJobDetails new job details object that need to be inserted as document in the index=
      * @param listener an {@code ActionListener} that has onResponse and onFailure that is used to return the job details if it was created
      *                 or else null.
      */

--- a/src/test/java/org/opensearch/jobscheduler/JobSchedulerPluginTests.java
+++ b/src/test/java/org/opensearch/jobscheduler/JobSchedulerPluginTests.java
@@ -137,7 +137,7 @@ public class JobSchedulerPluginTests extends OpenSearchTestCase {
     public void testGetSettings_returnsSettingsList() {
         List<Setting<?>> settings = plugin.getSettings();
         assertNotNull(settings);
-        assertEquals(18, settings.size());
+        assertEquals(13, settings.size());
         assertTrue(settings.contains(LegacyOpenDistroJobSchedulerSettings.SWEEP_PAGE_SIZE));
         assertTrue(settings.contains(LegacyOpenDistroJobSchedulerSettings.REQUEST_TIMEOUT));
         assertTrue(settings.contains(LegacyOpenDistroJobSchedulerSettings.SWEEP_BACKOFF_MILLIS));

--- a/src/test/java/org/opensearch/jobscheduler/JobSchedulerSettingsTests.java
+++ b/src/test/java/org/opensearch/jobscheduler/JobSchedulerSettingsTests.java
@@ -17,8 +17,6 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.test.OpenSearchTestCase;
 
-import static org.opensearch.remote.metadata.common.CommonValue.AWS_DYNAMO_DB;
-
 @SuppressWarnings({ "rawtypes" })
 public class JobSchedulerSettingsTests extends OpenSearchTestCase {
 
@@ -102,47 +100,5 @@ public class JobSchedulerSettingsTests extends OpenSearchTestCase {
                 LegacyOpenDistroJobSchedulerSettings.SWEEP_PAGE_SIZE,
                 LegacyOpenDistroJobSchedulerSettings.JITTER_LIMIT }
         );
-    }
-
-    public void testRemoteMetadataSettingsReturned() {
-        List<Setting<?>> settings = plugin.getSettings();
-        assertTrue(
-            "remote metadata settings must be returned from settings",
-            settings.containsAll(
-                Arrays.asList(
-                    JobSchedulerSettings.REMOTE_METADATA_TYPE,
-                    JobSchedulerSettings.REMOTE_METADATA_ENDPOINT,
-                    JobSchedulerSettings.REMOTE_METADATA_REGION,
-                    JobSchedulerSettings.REMOTE_METADATA_SERVICE_NAME,
-                    JobSchedulerSettings.JOB_SCHEDULER_MULTI_TENANCY_ENABLED
-                )
-            )
-        );
-    }
-
-    public void testRemoteMetadataSettingsDefaults() {
-        Settings settings = Settings.EMPTY;
-
-        assertEquals("", JobSchedulerSettings.REMOTE_METADATA_TYPE.get(settings));
-        assertEquals("", JobSchedulerSettings.REMOTE_METADATA_ENDPOINT.get(settings));
-        assertEquals("", JobSchedulerSettings.REMOTE_METADATA_REGION.get(settings));
-        assertEquals("", JobSchedulerSettings.REMOTE_METADATA_SERVICE_NAME.get(settings));
-        assertFalse(JobSchedulerSettings.JOB_SCHEDULER_MULTI_TENANCY_ENABLED.get(settings));
-    }
-
-    public void testRemoteMetadataSettingsValues() {
-        Settings settings = Settings.builder()
-            .put("plugins.jobscheduler.remote_metadata_type", AWS_DYNAMO_DB)
-            .put("plugins.jobscheduler.remote_metadata_endpoint", "https://dynamodb.us-east-1.amazonaws.com")
-            .put("plugins.jobscheduler.remote_metadata_region", "us-east-1")
-            .put("plugins.jobscheduler.remote_metadata_service_name", "es")
-            .put("plugins.jobscheduler.tenant_aware", true)
-            .build();
-
-        assertEquals(AWS_DYNAMO_DB, JobSchedulerSettings.REMOTE_METADATA_TYPE.get(settings));
-        assertEquals("https://dynamodb.us-east-1.amazonaws.com", JobSchedulerSettings.REMOTE_METADATA_ENDPOINT.get(settings));
-        assertEquals("us-east-1", JobSchedulerSettings.REMOTE_METADATA_REGION.get(settings));
-        assertEquals("es", JobSchedulerSettings.REMOTE_METADATA_SERVICE_NAME.get(settings));
-        assertTrue(JobSchedulerSettings.JOB_SCHEDULER_MULTI_TENANCY_ENABLED.get(settings));
     }
 }

--- a/src/test/java/org/opensearch/jobscheduler/rest/action/RestGetLockActionTests.java
+++ b/src/test/java/org/opensearch/jobscheduler/rest/action/RestGetLockActionTests.java
@@ -30,7 +30,6 @@ import org.opensearch.jobscheduler.TestHelpers;
 import org.opensearch.jobscheduler.spi.LockModel;
 import org.opensearch.jobscheduler.utils.LockServiceImpl;
 import org.opensearch.jobscheduler.transport.AcquireLockRequest;
-import org.opensearch.remote.metadata.client.SdkClient;
 import org.opensearch.rest.RestHandler;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.rest.RestRequest;
@@ -55,7 +54,7 @@ public class RestGetLockActionTests extends OpenSearchTestCase {
         super.setUp();
         this.clusterService = Mockito.mock(ClusterService.class, Mockito.RETURNS_DEEP_STUBS);
         Mockito.when(this.clusterService.state().routingTable().hasIndex(".opendistro-job-scheduler-lock")).thenReturn(true);
-        this.lockService = new LockServiceImpl(Mockito.mock(NodeClient.class), clusterService, Mockito.mock(SdkClient.class), false);
+        this.lockService = new LockServiceImpl(Mockito.mock(NodeClient.class), clusterService);
         this.getLockAction = new RestGetLockAction(this.lockService);
         this.getLockPath = String.format(Locale.ROOT, "%s/%s", JobSchedulerPlugin.JS_BASE_URI, "_lock");
         this.testJobId = "testJobId";

--- a/src/test/java/org/opensearch/jobscheduler/rest/action/RestReleaseLockActionTests.java
+++ b/src/test/java/org/opensearch/jobscheduler/rest/action/RestReleaseLockActionTests.java
@@ -20,7 +20,6 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.jobscheduler.JobSchedulerPlugin;
 import org.opensearch.jobscheduler.spi.LockModel;
 import org.opensearch.jobscheduler.utils.LockServiceImpl;
-import org.opensearch.remote.metadata.client.SdkClient;
 import org.opensearch.rest.RestHandler;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.test.OpenSearchTestCase;
@@ -46,7 +45,7 @@ public class RestReleaseLockActionTests extends OpenSearchTestCase {
         super.setUp();
         this.clusterService = Mockito.mock(ClusterService.class, Mockito.RETURNS_DEEP_STUBS);
         this.client = Mockito.mock(Client.class);
-        this.lockService = new LockServiceImpl(client, clusterService, Mockito.mock(SdkClient.class), false);
+        this.lockService = new LockServiceImpl(client, clusterService);
         restReleaseLockAction = new RestReleaseLockAction(this.lockService);
         this.releaseLockPath = String.format(Locale.ROOT, "%s/%s/{%s}", JobSchedulerPlugin.JS_BASE_URI, "_release_lock", LockModel.LOCK_ID);
 

--- a/src/test/java/org/opensearch/jobscheduler/sweeper/JobSweeperTests.java
+++ b/src/test/java/org/opensearch/jobscheduler/sweeper/JobSweeperTests.java
@@ -45,7 +45,6 @@ import org.opensearch.index.engine.Engine;
 import org.opensearch.index.mapper.ParseContext;
 import org.opensearch.index.mapper.ParsedDocument;
 import org.opensearch.core.index.shard.ShardId;
-import org.opensearch.remote.metadata.client.SdkClient;
 import org.opensearch.test.ClusterServiceUtils;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.Scheduler;
@@ -128,7 +127,7 @@ public class JobSweeperTests extends OpenSearchAllocationTestCase {
             xContentRegistry,
             jobProviderMap,
             scheduler,
-            new LockServiceImpl(client, clusterService, Mockito.mock(SdkClient.class), false),
+            new LockServiceImpl(client, clusterService),
             jobDetailsService
         );
     }

--- a/src/test/java/org/opensearch/jobscheduler/utils/JobDetailsServiceIT.java
+++ b/src/test/java/org/opensearch/jobscheduler/utils/JobDetailsServiceIT.java
@@ -45,7 +45,6 @@ import org.opensearch.jobscheduler.transport.request.JobParameterRequest;
 import org.opensearch.jobscheduler.transport.response.JobParameterResponse;
 import org.opensearch.jobscheduler.transport.request.JobRunnerRequest;
 import org.opensearch.jobscheduler.transport.response.JobRunnerResponse;
-import org.opensearch.remote.metadata.client.SdkClient;
 import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.jobscheduler.ScheduledJobProvider;
 
@@ -325,7 +324,7 @@ public class JobDetailsServiceIT extends OpenSearchIntegTestCase {
 
     public void testJobRunnerExtensionJobActionRequest() throws IOException {
 
-        LockServiceImpl lockService = new LockServiceImpl(client(), this.clusterService, Mockito.mock(SdkClient.class), false);
+        LockServiceImpl lockService = new LockServiceImpl(client(), this.clusterService);
         JobExecutionContext jobExecutionContext = new JobExecutionContext(
             Instant.now(),
             new JobDocVersion(0, 0, 0),

--- a/src/test/java/org/opensearch/jobscheduler/utils/LockServiceIT.java
+++ b/src/test/java/org/opensearch/jobscheduler/utils/LockServiceIT.java
@@ -13,7 +13,6 @@ import org.junit.Ignore;
 import org.mockito.Mockito;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.cluster.service.ClusterService;
-import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.jobscheduler.spi.JobDocVersion;
 import org.opensearch.jobscheduler.spi.JobExecutionContext;
@@ -21,15 +20,12 @@ import org.opensearch.jobscheduler.spi.LockModel;
 import org.opensearch.jobscheduler.spi.ScheduledJobParameter;
 import org.opensearch.jobscheduler.spi.schedule.Schedule;
 import org.opensearch.jobscheduler.spi.utils.LockService;
-import org.opensearch.remote.metadata.client.SdkClient;
-import org.opensearch.remote.metadata.client.impl.SdkClientFactory;
 import org.opensearch.test.OpenSearchIntegTestCase;
 
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
@@ -83,7 +79,6 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
     };
 
     private ClusterService clusterService;
-    private SdkClient sdkClient;
 
     @Before
     public void setup() {
@@ -94,13 +89,12 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
         Mockito.when(this.clusterService.state().routingTable().hasIndex(".opendistro-job-scheduler-lock"))
             .thenReturn(false)
             .thenReturn(true);
-        this.sdkClient = SdkClientFactory.createSdkClient(client(), NamedXContentRegistry.EMPTY, Collections.emptyMap());
     }
 
     public void testSanity() throws Exception {
         String uniqSuffix = "_sanity";
         CountDownLatch latch = new CountDownLatch(1);
-        LockServiceImpl lockService = new LockServiceImpl(client(), this.clusterService, sdkClient, false);
+        LockServiceImpl lockService = new LockServiceImpl(client(), this.clusterService);
         final JobExecutionContext context = new JobExecutionContext(
             Instant.now(),
             new JobDocVersion(0, 0, 0),
@@ -138,7 +132,7 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
         String lockID = "sanity_test_lock";
         String uniqSuffix = "_sanity";
         CountDownLatch latch = new CountDownLatch(1);
-        LockServiceImpl lockService = new LockServiceImpl(client(), this.clusterService, sdkClient, false);
+        LockServiceImpl lockService = new LockServiceImpl(client(), this.clusterService);
         final JobExecutionContext context = new JobExecutionContext(
             Instant.now(),
             new JobDocVersion(0, 0, 0),
@@ -172,7 +166,7 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
         String uniqSuffix = "_second_acquire";
         String lockID = randomAlphaOfLengthBetween(6, 15);
         CountDownLatch latch = new CountDownLatch(1);
-        LockServiceImpl lockService = new LockServiceImpl(client(), this.clusterService, sdkClient, false);
+        LockServiceImpl lockService = new LockServiceImpl(client(), this.clusterService);
         final JobExecutionContext context = new JobExecutionContext(
             Instant.now(),
             new JobDocVersion(0, 0, 0),
@@ -201,7 +195,7 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
         String uniqSuffix = "_long_lock_id";
         String lockID = randomAlphaOfLengthBetween(513, 1000);
         CountDownLatch latch = new CountDownLatch(1);
-        LockService lockService = new LockServiceImpl(client(), this.clusterService, sdkClient, false);
+        LockService lockService = new LockServiceImpl(client(), this.clusterService);
         final JobExecutionContext context = new JobExecutionContext(
             Instant.now(),
             new JobDocVersion(0, 0, 0),
@@ -223,7 +217,7 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
         String uniqSuffix = "_lock_release+acquire";
         String lockID = randomAlphaOfLengthBetween(6, 15);
         CountDownLatch latch = new CountDownLatch(1);
-        LockService lockService = new LockServiceImpl(client(), this.clusterService, sdkClient, false);
+        LockService lockService = new LockServiceImpl(client(), this.clusterService);
         final JobExecutionContext context = new JobExecutionContext(
             Instant.now(),
             new JobDocVersion(0, 0, 0),
@@ -255,7 +249,7 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
         String uniqSuffix = "_lock_expire";
         String lockID = randomAlphaOfLengthBetween(6, 15);
         CountDownLatch latch = new CountDownLatch(1);
-        LockServiceImpl lockService = new LockServiceImpl(client(), this.clusterService, sdkClient, false);
+        LockServiceImpl lockService = new LockServiceImpl(client(), this.clusterService);
         // Set lock time in the past.
         lockService.setTime(Instant.now().minus(Duration.ofSeconds(LOCK_DURATION_SECONDS + LOCK_DURATION_SECONDS)));
         final JobExecutionContext context = new JobExecutionContext(
@@ -289,7 +283,7 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
 
     public void testDeleteLockWithOutIndexCreation() throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
-        LockService lockService = new LockServiceImpl(client(), this.clusterService, sdkClient, false);
+        LockService lockService = new LockServiceImpl(client(), this.clusterService);
         lockService.deleteLock("NonExistingLockId", ActionListener.wrap(deleted -> {
             assertTrue("Failed to delete lock.", deleted);
             latch.countDown();
@@ -299,7 +293,7 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
 
     public void testDeleteNonExistingLock() throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
-        LockServiceImpl lockService = new LockServiceImpl(client(), this.clusterService, sdkClient, false);
+        LockServiceImpl lockService = new LockServiceImpl(client(), this.clusterService);
         lockService.createLockIndex(ActionListener.wrap(created -> {
             if (created) {
                 lockService.deleteLock("NonExistingLockId", ActionListener.wrap(deleted -> {
@@ -321,7 +315,7 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
         String uniqSuffix = "_multi_thread_create";
         String lockID = randomAlphaOfLengthBetween(6, 15);
         CountDownLatch latch = new CountDownLatch(1);
-        final LockServiceImpl lockService = new LockServiceImpl(client(), this.clusterService, sdkClient, false);
+        final LockServiceImpl lockService = new LockServiceImpl(client(), this.clusterService);
         final JobExecutionContext context = new JobExecutionContext(
             Instant.now(),
             new JobDocVersion(0, 0, 0),
@@ -384,7 +378,7 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
         String uniqSuffix = "_multi_thread_acquire";
         String lockID = randomAlphaOfLengthBetween(6, 15);
         CountDownLatch latch = new CountDownLatch(1);
-        final LockServiceImpl lockService = new LockServiceImpl(client(), this.clusterService, sdkClient, false);
+        final LockServiceImpl lockService = new LockServiceImpl(client(), this.clusterService);
         final JobExecutionContext context = new JobExecutionContext(
             Instant.now(),
             new JobDocVersion(0, 0, 0),
@@ -451,7 +445,7 @@ public class LockServiceIT extends OpenSearchIntegTestCase {
         String uniqSuffix = "_lock_renew";
         String lockID = randomAlphaOfLengthBetween(6, 15);
         CountDownLatch latch = new CountDownLatch(1);
-        LockServiceImpl lockService = new LockServiceImpl(client(), this.clusterService, sdkClient, false);
+        LockServiceImpl lockService = new LockServiceImpl(client(), this.clusterService);
         final JobExecutionContext context = new JobExecutionContext(
             Instant.now(),
             new JobDocVersion(0, 0, 0),


### PR DESCRIPTION
### Description
[Describe what this change achieves]

### Related Issues
Resolves https://github.com/opensearch-project/ml-commons/issues/4202

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/job-scheduler/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
