### PR TITLE
Remove cron trigger on JS as maven snapshots is already on s3

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -2,8 +2,6 @@ name: Publish snapshots to maven
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 0 * * 0'  # Run weekly on Sundays at midnight UTC
   push:
     branches:
       - main


### PR DESCRIPTION
### Description
Remove cron trigger on JS as maven snapshots is already on s3
Partially revert https://github.com/opensearch-project/job-scheduler/pull/847

### Related Issues
https://github.com/opensearch-project/opensearch-build/issues/5360

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/job-scheduler/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
