### PR TITLE
Add integTest retry for sample-extension-plugin

### DIFF
--- a/sample-extension-plugin/build.gradle
+++ b/sample-extension-plugin/build.gradle
@@ -3,6 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+plugins {
+    id "org.gradle.test-retry" version "1.6.4"
+}
+
 apply plugin: 'opensearch.opensearchplugin'
 apply plugin: 'opensearch.testclusters'
 apply plugin: 'opensearch.java-agent'
@@ -70,6 +74,10 @@ jacoco {
 check.dependsOn jacocoTestReport
 
 integTest {
+    retry {
+        failOnPassedAfterRetry = false
+        maxRetries = 3
+    }
     if (project.hasProperty('excludeTests')) {
         project.properties['excludeTests']?.replaceAll('\\s', '')?.split('[,;]')?.each {
             exclude "${it}"


### PR DESCRIPTION
### Description

Add integTest retry for sample-extension-plugin

This PR is an attempt to reduce flakiness in the CI. It does not address the root causes, but runs retry up to 3x to see if the tests pass. There should be additional measures put into place to address flakiness in multi-node integ tests. 

### Related Issues

Example flaky failure recently: https://github.com/opensearch-project/job-scheduler/actions/runs/20444634620/job/58745294299

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/job-scheduler/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
