### PR TITLE
Use 2.19.4 for bwc version instead of 2.20.0 which does not exist

### DIFF
--- a/sample-extension-plugin/build.gradle
+++ b/sample-extension-plugin/build.gradle
@@ -147,23 +147,17 @@ testClusters.integTest {
 }
 
 String baseName = "jobSchedulerBwcCluster"
-
 String bwcOpenSearchVersion = "2.19.4"
 String bwcPluginVersion = bwcOpenSearchVersion + ".0"
-
 String bwcFilePath = "src/test/resources/bwc/job-scheduler/"
 String bwcSnapshotVersion = bwcPluginVersion + "-SNAPSHOT"
-
 String groupPath = "org/opensearch/plugin"
 String artifact = "opensearch-job-scheduler"
-
-// CI snapshots repo base (same style as your GH Actions)
 String base = "https://ci.opensearch.org/ci/dbc/snapshots/maven"
 
 String metadataUrl = "${base}/${groupPath}/${artifact}/${bwcSnapshotVersion}/maven-metadata.xml"
 
 def resolveZipSnapshotValue = { String metadataXmlUrl ->
-    // very similar to your bash: find the snapshotVersion entry for zip and extract <value>...</value>
     def xml = new URL(metadataXmlUrl).text
     def m = (xml =~ /<snapshotVersion>[\s\S]*?<extension>zip<\/extension>[\s\S]*?<value>([^<]+)<\/value>[\s\S]*?<\/snapshotVersion>/)
     if (!m.find()) {


### PR DESCRIPTION
### Description

Use 2.19.4 for bwc version instead of 2.20.0 which does not exist

### Related Issues

Fixes CI failure seen on https://github.com/opensearch-project/job-scheduler/pull/876

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/job-scheduler/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
