### PR TITLE
Switch from ARCHIVE to INTEG_TEST to always build with latest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -240,7 +240,6 @@ repositories {
 
 dependencies {
     implementation project(path: ":${rootProject.name}-spi", configuration: 'shadow')
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: "${versions.mockito}"
 
     opensearchPlugin "org.opensearch.plugin:opensearch-security:${security_plugin_version}@zip"
 }
@@ -298,7 +297,7 @@ integTest.getClusters().forEach{c -> {
 }}
 
 testClusters.integTest {
-    testDistribution = 'ARCHIVE'
+    testDistribution = 'INTEG_TEST'
 
     // Cluster shrink exception thrown if we try to set numberOfNodes to 1, so only apply if > 1
     if (_numNodes > 1) numberOfNodes = _numNodes

--- a/sample-extension-plugin/build.gradle
+++ b/sample-extension-plugin/build.gradle
@@ -124,7 +124,7 @@ integTest.getClusters().forEach{c -> {
 }}
 
 testClusters.integTest {
-    testDistribution = 'ARCHIVE'
+    testDistribution = 'INTEG_TEST'
 
     // Cluster shrink exception thrown if we try to set numberOfNodes to 1, so only apply if > 1
     if (_numNodes > 1) numberOfNodes = _numNodes
@@ -157,7 +157,7 @@ String bwcDownloadUrl = "https://aws.oss.sonatype.org/service/local/artifact/mav
 2.times {i ->
     testClusters {
         "${baseName}$i" {
-            testDistribution = "ARCHIVE"
+            testDistribution = "INTEG_TEST"
             versions = [bwcOpenSearchVersion, opensearch_version]
             numberOfNodes = 3
             plugin(provider(new Callable<RegularFile>(){


### PR DESCRIPTION
### Description

Switch from ARCHIVE to INTEG_TEST to always build with latest

This PR also removes a redundant Mockito declaration since JS gets that transitively from core's test framework.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/job-scheduler/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
