### PR TITLE
Fix integTests with security by providing FIPS build param

### DIFF
--- a/.github/workflows/test-with-security.yml
+++ b/.github/workflows/test-with-security.yml
@@ -30,5 +30,4 @@ jobs:
       - name: Run Job-scheduler Integ Tests with Security
         run: |
           echo "Running integ tests with security..."
-          ./gradlew clean
           ./gradlew :integTest --tests "*RestIT" -Dhttps=true -Dsecurity.enabled=true  -Dtests.opensearch.secure=true -Dtests.opensearch.username=admin -Dtests.opensearch.password=admin -Duser=admin -Dpassword=admin -Pcrypto.standard=FIPS-140-3


### PR DESCRIPTION
### Description

Fixes integ tests running with the security plugin

```
...
»  fatal error in thread [main], exiting
»  java.lang.NoClassDefFoundError: org/bouncycastle/jcajce/provider/BouncyCastleFipsProvider
»  	at java.base/java.lang.Class.getDeclaredConstructors0(Native Method)
...
```

### Related Issues

Fixes https://github.com/opensearch-project/job-scheduler/actions/runs/22574404949/job/65389970748?pr=885

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/job-scheduler/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
