### PR TITLE
[2.19] Change com.github.johnrengelman.shadow to com.gradleup.shadow

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,12 @@ buildscript {
 
     dependencies {
         classpath "org.opensearch.gradle:build-tools:${opensearch_version}"
+        classpath 'org.codehaus.plexus:plexus-utils:3.5.1'
+    }
+    configurations.classpath {
+        resolutionStrategy {
+            force 'org.codehaus.plexus:plexus-utils:3.5.1'
+        }
     }
 }
 
@@ -115,6 +121,12 @@ allprojects {
 }
 
 allprojects {
+    configurations.all {
+        resolutionStrategy {
+            force 'org.codehaus.plexus:plexus-utils:3.5.1'
+        }
+    }
+
     // Default to the apache license
     project.ext.licenseName = 'The Apache Software License, Version 2.0'
     project.ext.licenseUrl = 'http://www.apache.org/licenses/LICENSE-2.0.txt'

--- a/spi/build.gradle
+++ b/spi/build.gradle
@@ -7,7 +7,7 @@ import com.github.jengelman.gradle.plugins.shadow.ShadowBasePlugin
 import org.opensearch.gradle.test.RestIntegTestTask
 
 plugins {
-    id 'com.github.johnrengelman.shadow'
+    id 'com.gradleup.shadow'
     id 'jacoco'
     id 'maven-publish'
     id 'signing'


### PR DESCRIPTION
### Description

Change com.github.johnrengelman.shadow to com.gradleup.shadow to adopt to core shadow 8.1 to 8.3 upgrade.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/job-scheduler/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
