### PR TITLE
Create new endpoint to trigger a job adhoc

### DIFF
--- a/src/main/java/org/opensearch/jobscheduler/JobSchedulerPlugin.java
+++ b/src/main/java/org/opensearch/jobscheduler/JobSchedulerPlugin.java
@@ -23,12 +23,15 @@ import org.opensearch.jobscheduler.rest.action.RestGetJobDetailsAction;
 import org.opensearch.jobscheduler.rest.action.RestGetLockAction;
 import org.opensearch.jobscheduler.rest.action.RestGetScheduledInfoAction;
 import org.opensearch.jobscheduler.rest.action.RestReleaseLockAction;
+import org.opensearch.jobscheduler.rest.action.RestRunJobAction;
 import org.opensearch.jobscheduler.spi.utils.LockService;
 import org.opensearch.jobscheduler.transport.PluginClient;
 import org.opensearch.jobscheduler.transport.action.GetAllLocksAction;
 import org.opensearch.jobscheduler.transport.action.GetScheduledInfoAction;
+import org.opensearch.jobscheduler.transport.action.RunJobAction;
 import org.opensearch.jobscheduler.transport.action.TransportGetAllLocksAction;
 import org.opensearch.jobscheduler.transport.action.TransportGetScheduledInfoAction;
+import org.opensearch.jobscheduler.transport.action.TransportRunJobAction;
 import org.opensearch.jobscheduler.scheduler.JobScheduler;
 import org.opensearch.jobscheduler.spi.JobSchedulerExtension;
 import org.opensearch.jobscheduler.spi.ScheduledJobParser;
@@ -272,20 +275,23 @@ public class JobSchedulerPlugin extends Plugin implements ActionPlugin, Extensib
         RestReleaseLockAction restReleaseLockAction = new RestReleaseLockAction(lockService);
         RestGetScheduledInfoAction restGetScheduledInfoAction = new RestGetScheduledInfoAction();
         RestGetLocksAction restGetAllLocksAction = new RestGetLocksAction();
+        RestRunJobAction restRunJobAction = new RestRunJobAction();
         return List.of(
             restGetJobDetailsAction,
             restGetLockAction,
             restReleaseLockAction,
             restGetScheduledInfoAction,
-            restGetAllLocksAction
+            restGetAllLocksAction,
+            restRunJobAction
         );
     }
 
     @Override
     public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
-        List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> actions = new ArrayList<>(2);
+        List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> actions = new ArrayList<>(3);
         actions.add(new ActionHandler<>(GetScheduledInfoAction.INSTANCE, TransportGetScheduledInfoAction.class));
         actions.add(new ActionHandler<>(GetAllLocksAction.INSTANCE, TransportGetAllLocksAction.class));
+        actions.add(new ActionHandler<>(RunJobAction.INSTANCE, TransportRunJobAction.class));
         return actions;
     }
 

--- a/src/main/java/org/opensearch/jobscheduler/rest/action/RestRunJobAction.java
+++ b/src/main/java/org/opensearch/jobscheduler/rest/action/RestRunJobAction.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.jobscheduler.rest.action;
+
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.jobscheduler.JobSchedulerPlugin;
+import org.opensearch.jobscheduler.transport.action.RunJobAction;
+import org.opensearch.jobscheduler.transport.request.RunJobRequest;
+import org.opensearch.jobscheduler.transport.response.RunJobResponse;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.BytesRestResponse;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.rest.RestResponse;
+import org.opensearch.rest.action.RestBuilderListener;
+import org.opensearch.transport.client.node.NodeClient;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Locale;
+
+import static org.opensearch.rest.RestRequest.Method.POST;
+
+/**
+ * REST handler that triggers an ad-hoc run of a scheduled job by job type and job id.
+ */
+public class RestRunJobAction extends BaseRestHandler {
+
+    private static final String RUN_JOB_ACTION = "run_job_action";
+    public static final String JOB_TYPE = "job_type";
+    public static final String JOB_ID = "job_id";
+
+    @Override
+    public String getName() {
+        return RUN_JOB_ACTION;
+    }
+
+    @Override
+    public List<Route> routes() {
+        return List.of(new Route(POST, String.format(Locale.ROOT, "%s/_run/{%s}/{%s}", JobSchedulerPlugin.JS_BASE_URI, JOB_TYPE, JOB_ID)));
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        String jobType = request.param(JOB_TYPE);
+        String jobId = request.param(JOB_ID);
+        RunJobRequest runJobRequest = new RunJobRequest(jobType, jobId);
+
+        return channel -> client.execute(RunJobAction.INSTANCE, runJobRequest, new RestBuilderListener<>(channel) {
+            @Override
+            public RestResponse buildResponse(RunJobResponse response, XContentBuilder builder) throws Exception {
+                response.toXContent(builder, request);
+                RestStatus status = response.getExecutingNode() != null ? RestStatus.OK : RestStatus.NOT_FOUND;
+                return new BytesRestResponse(status, builder);
+            }
+        });
+    }
+}

--- a/src/main/java/org/opensearch/jobscheduler/transport/action/RunJobAction.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/action/RunJobAction.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.jobscheduler.transport.action;
+
+import org.opensearch.action.ActionType;
+import org.opensearch.jobscheduler.transport.response.RunJobResponse;
+
+public class RunJobAction extends ActionType<RunJobResponse> {
+    public static final String NAME = "cluster:admin/opensearch/jobscheduler/jobs/run";
+    public static final RunJobAction INSTANCE = new RunJobAction();
+
+    private RunJobAction() {
+        super(NAME, RunJobResponse::new);
+    }
+}

--- a/src/main/java/org/opensearch/jobscheduler/transport/action/TransportRunJobAction.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/action/TransportRunJobAction.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.jobscheduler.transport.action;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.FailedNodeException;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.nodes.TransportNodesAction;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.jobscheduler.ScheduledJobProvider;
+import org.opensearch.jobscheduler.scheduler.JobScheduler;
+import org.opensearch.jobscheduler.scheduler.JobSchedulingInfo;
+import org.opensearch.jobscheduler.spi.JobDocVersion;
+import org.opensearch.jobscheduler.spi.JobExecutionContext;
+import org.opensearch.jobscheduler.spi.ScheduledJobParameter;
+import org.opensearch.jobscheduler.spi.ScheduledJobRunner;
+import org.opensearch.jobscheduler.spi.utils.LockService;
+import org.opensearch.jobscheduler.transport.request.RunJobNodeRequest;
+import org.opensearch.jobscheduler.transport.request.RunJobRequest;
+import org.opensearch.jobscheduler.transport.response.RunJobNodeResponse;
+import org.opensearch.jobscheduler.transport.response.RunJobResponse;
+import org.opensearch.jobscheduler.utils.JobDetailsService;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+public class TransportRunJobAction extends TransportNodesAction<RunJobRequest, RunJobResponse, RunJobNodeRequest, RunJobNodeResponse> {
+
+    private static final Logger log = LogManager.getLogger(TransportRunJobAction.class);
+
+    private final JobScheduler jobScheduler;
+    private final JobDetailsService jobDetailsService;
+    private final LockService lockService;
+
+    @Inject
+    public TransportRunJobAction(
+        ThreadPool threadPool,
+        ClusterService clusterService,
+        TransportService transportService,
+        ActionFilters actionFilters,
+        JobScheduler jobScheduler,
+        JobDetailsService jobDetailsService,
+        LockService lockService
+    ) {
+        super(
+            RunJobAction.NAME,
+            threadPool,
+            clusterService,
+            transportService,
+            actionFilters,
+            RunJobRequest::new,
+            RunJobNodeRequest::new,
+            ThreadPool.Names.GENERIC,
+            RunJobNodeResponse.class
+        );
+        this.jobScheduler = jobScheduler;
+        this.jobDetailsService = jobDetailsService;
+        this.lockService = lockService;
+    }
+
+    @Override
+    protected RunJobResponse newResponse(
+        RunJobRequest request,
+        List<RunJobNodeResponse> nodeResponses,
+        List<FailedNodeException> failures
+    ) {
+        return new RunJobResponse(clusterService.getClusterName(), nodeResponses, failures);
+    }
+
+    @Override
+    protected RunJobNodeRequest newNodeRequest(RunJobRequest request) {
+        return new RunJobNodeRequest(request);
+    }
+
+    @Override
+    protected RunJobNodeResponse newNodeResponse(StreamInput in) throws IOException {
+        return new RunJobNodeResponse(in);
+    }
+
+    @Override
+    protected RunJobNodeResponse nodeOperation(RunJobNodeRequest request) {
+        String jobType = request.getJobType();
+        String jobId = request.getJobId();
+
+        ScheduledJobProvider provider = resolveProvider(jobType);
+        if (provider == null) {
+            return new RunJobNodeResponse(clusterService.localNode(), false, "no provider registered for job_type [" + jobType + "]");
+        }
+
+        String indexName = provider.getJobIndexName();
+        JobSchedulingInfo jobSchedulingInfo = jobScheduler.getScheduledJobInfo().getJobInfo(indexName, jobId);
+        if (jobSchedulingInfo == null) {
+            return new RunJobNodeResponse(clusterService.localNode(), false, "job not scheduled on this node");
+        }
+
+        ScheduledJobParameter jobParameter = jobSchedulingInfo.getJobParameter();
+        ScheduledJobRunner jobRunner = provider.getJobRunner();
+        if (jobRunner == null) {
+            return new RunJobNodeResponse(clusterService.localNode(), false, "no runner registered for job_type [" + jobType + "]");
+        }
+
+        try {
+            JobExecutionContext context = new JobExecutionContext(
+                Instant.now(),
+                new JobDocVersion(0L, 0L, 0L),
+                lockService,
+                indexName,
+                jobId
+            );
+            log.info("Ad-hoc triggering job id {} for index {}", jobId, indexName);
+            jobRunner.runJob(jobParameter, context);
+            return new RunJobNodeResponse(clusterService.localNode(), true, null);
+        } catch (Exception e) {
+            log.error("Failed to ad-hoc trigger job id " + jobId + " for index " + indexName, e);
+            return new RunJobNodeResponse(clusterService.localNode(), false, "execution failed: " + e.getMessage());
+        }
+    }
+
+    private ScheduledJobProvider resolveProvider(String jobType) {
+        Map<String, ScheduledJobProvider> providers = jobDetailsService.getIndexToJobProviders();
+        for (ScheduledJobProvider provider : providers.values()) {
+            if (provider.getJobType().equals(jobType)) {
+                return provider;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/opensearch/jobscheduler/transport/request/RunJobNodeRequest.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/request/RunJobNodeRequest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.jobscheduler.transport.request;
+
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
+public class RunJobNodeRequest extends ActionRequest {
+
+    private final String jobType;
+    private final String jobId;
+
+    public RunJobNodeRequest(StreamInput in) throws IOException {
+        super(in);
+        this.jobType = in.readString();
+        this.jobId = in.readString();
+    }
+
+    public RunJobNodeRequest(RunJobRequest request) {
+        super();
+        this.jobType = request.getJobType();
+        this.jobId = request.getJobId();
+    }
+
+    public String getJobType() {
+        return jobType;
+    }
+
+    public String getJobId() {
+        return jobId;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(jobType);
+        out.writeString(jobId);
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        return null;
+    }
+}

--- a/src/main/java/org/opensearch/jobscheduler/transport/request/RunJobRequest.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/request/RunJobRequest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.jobscheduler.transport.request;
+
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.action.ValidateActions;
+import org.opensearch.action.support.nodes.BaseNodesRequest;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
+public class RunJobRequest extends BaseNodesRequest<RunJobRequest> {
+
+    private final String jobType;
+    private final String jobId;
+
+    public RunJobRequest(String jobType, String jobId) {
+        super(new String[0]);
+        this.jobType = jobType;
+        this.jobId = jobId;
+    }
+
+    public RunJobRequest(StreamInput in) throws IOException {
+        super(in);
+        this.jobType = in.readString();
+        this.jobId = in.readString();
+    }
+
+    public String getJobType() {
+        return jobType;
+    }
+
+    public String getJobId() {
+        return jobId;
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        ActionRequestValidationException exception = null;
+        if (jobType == null || jobType.isEmpty()) {
+            exception = ValidateActions.addValidationError("job_type is required", exception);
+        }
+        if (jobId == null || jobId.isEmpty()) {
+            exception = ValidateActions.addValidationError("job_id is required", exception);
+        }
+        return exception;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(jobType);
+        out.writeString(jobId);
+    }
+}

--- a/src/main/java/org/opensearch/jobscheduler/transport/response/RunJobNodeResponse.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/response/RunJobNodeResponse.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.jobscheduler.transport.response;
+
+import org.opensearch.action.support.nodes.BaseNodeResponse;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.ToXContentFragment;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+
+public class RunJobNodeResponse extends BaseNodeResponse implements ToXContentFragment {
+
+    private final boolean executed;
+    private final String message;
+
+    public RunJobNodeResponse(DiscoveryNode node, boolean executed, String message) {
+        super(node);
+        this.executed = executed;
+        this.message = message;
+    }
+
+    public RunJobNodeResponse(StreamInput in) throws IOException {
+        super(in);
+        this.executed = in.readBoolean();
+        this.message = in.readOptionalString();
+    }
+
+    public boolean isExecuted() {
+        return executed;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeBoolean(executed);
+        out.writeOptionalString(message);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field("node_id", getNode().getId());
+        builder.field("node_name", getNode().getName());
+        builder.field("executed", executed);
+        if (message != null) {
+            builder.field("message", message);
+        }
+        builder.endObject();
+        return builder;
+    }
+}

--- a/src/main/java/org/opensearch/jobscheduler/transport/response/RunJobResponse.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/response/RunJobResponse.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.jobscheduler.transport.response;
+
+import org.opensearch.action.FailedNodeException;
+import org.opensearch.action.support.nodes.BaseNodesResponse;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.List;
+
+public class RunJobResponse extends BaseNodesResponse<RunJobNodeResponse> implements ToXContent {
+
+    public RunJobResponse(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    public RunJobResponse(ClusterName clusterName, List<RunJobNodeResponse> nodes, List<FailedNodeException> failures) {
+        super(clusterName, nodes, failures);
+    }
+
+    @Override
+    public List<RunJobNodeResponse> readNodesFrom(StreamInput in) throws IOException {
+        return in.readList(RunJobNodeResponse::new);
+    }
+
+    @Override
+    public void writeNodesTo(StreamOutput out, List<RunJobNodeResponse> nodes) throws IOException {
+        out.writeList(nodes);
+    }
+
+    /**
+     * Returns the node response that actually executed the job, or null if no node did.
+     */
+    public RunJobNodeResponse getExecutingNode() {
+        for (RunJobNodeResponse node : getNodes()) {
+            if (node.isExecuted()) {
+                return node;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        RunJobNodeResponse executingNode = getExecutingNode();
+        builder.startObject();
+        builder.field("executed", executingNode != null);
+        if (executingNode != null) {
+            builder.field("executing_node_id", executingNode.getNode().getId());
+            builder.field("executing_node_name", executingNode.getNode().getName());
+        }
+        builder.startArray("nodes");
+        for (RunJobNodeResponse nodeResponse : getNodes()) {
+            nodeResponse.toXContent(builder, params);
+        }
+        builder.endArray();
+        builder.startArray("failures");
+        for (FailedNodeException failure : failures()) {
+            builder.startObject();
+            builder.field("node_id", failure.nodeId());
+            builder.field("reason", failure.getMessage());
+            builder.endObject();
+        }
+        builder.endArray();
+        builder.endObject();
+        return builder;
+    }
+}

--- a/src/test/java/org/opensearch/jobscheduler/JobSchedulerPluginTests.java
+++ b/src/test/java/org/opensearch/jobscheduler/JobSchedulerPluginTests.java
@@ -33,13 +33,16 @@ import org.opensearch.jobscheduler.rest.action.RestGetJobDetailsAction;
 import org.opensearch.jobscheduler.rest.action.RestGetLockAction;
 import org.opensearch.jobscheduler.rest.action.RestGetScheduledInfoAction;
 import org.opensearch.jobscheduler.rest.action.RestReleaseLockAction;
+import org.opensearch.jobscheduler.rest.action.RestRunJobAction;
 import org.opensearch.jobscheduler.spi.JobSchedulerExtension;
 import org.opensearch.jobscheduler.spi.ScheduledJobParser;
 import org.opensearch.jobscheduler.spi.ScheduledJobRunner;
 import org.opensearch.jobscheduler.transport.action.GetAllLocksAction;
 import org.opensearch.jobscheduler.transport.action.GetScheduledInfoAction;
+import org.opensearch.jobscheduler.transport.action.RunJobAction;
 import org.opensearch.jobscheduler.transport.action.TransportGetAllLocksAction;
 import org.opensearch.jobscheduler.transport.action.TransportGetScheduledInfoAction;
+import org.opensearch.jobscheduler.transport.action.TransportRunJobAction;
 import org.opensearch.jobscheduler.utils.JobDetailsService;
 import org.opensearch.plugins.ActionPlugin.ActionHandler;
 import org.opensearch.plugins.ExtensiblePlugin;
@@ -174,7 +177,8 @@ public class JobSchedulerPluginTests extends OpenSearchTestCase {
                 instanceOf(RestGetLockAction.class),
                 instanceOf(RestReleaseLockAction.class),
                 instanceOf(RestGetScheduledInfoAction.class),
-                instanceOf(RestGetLocksAction.class)
+                instanceOf(RestGetLocksAction.class),
+                instanceOf(RestRunJobAction.class)
             )
         );
     }
@@ -200,12 +204,15 @@ public class JobSchedulerPluginTests extends OpenSearchTestCase {
     public void testGetActions() {
         List<ActionHandler<?, ?>> actions = plugin.getActions();
         assertNotNull(actions);
-        assertEquals(2, actions.size());
+        assertEquals(3, actions.size());
         ActionHandler<?, ?> actionHandler = actions.get(0);
         assertEquals(GetScheduledInfoAction.INSTANCE, actionHandler.getAction());
         assertEquals(TransportGetScheduledInfoAction.class, actionHandler.getTransportAction());
         ActionHandler<?, ?> actionHandler1 = actions.get(1);
         assertEquals(GetAllLocksAction.INSTANCE, actionHandler1.getAction());
         assertEquals(TransportGetAllLocksAction.class, actionHandler1.getTransportAction());
+        ActionHandler<?, ?> actionHandler2 = actions.get(2);
+        assertEquals(RunJobAction.INSTANCE, actionHandler2.getAction());
+        assertEquals(TransportRunJobAction.class, actionHandler2.getTransportAction());
     }
 }

--- a/src/test/java/org/opensearch/jobscheduler/rest/action/RestRunJobActionTests.java
+++ b/src/test/java/org/opensearch/jobscheduler/rest/action/RestRunJobActionTests.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.jobscheduler.rest.action;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+
+import org.junit.Before;
+import org.mockito.Mockito;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.jobscheduler.JobSchedulerPlugin;
+import org.opensearch.jobscheduler.transport.action.RunJobAction;
+import org.opensearch.jobscheduler.transport.request.RunJobRequest;
+import org.opensearch.jobscheduler.transport.response.RunJobResponse;
+import org.opensearch.rest.RestHandler;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.test.rest.FakeRestChannel;
+import org.opensearch.test.rest.FakeRestRequest;
+import org.opensearch.transport.client.node.NodeClient;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class RestRunJobActionTests extends OpenSearchTestCase {
+
+    private RestRunJobAction action;
+    private String runJobPath;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        this.action = new RestRunJobAction();
+        this.runJobPath = String.format(
+            Locale.ROOT,
+            "%s/_run/{%s}/{%s}",
+            JobSchedulerPlugin.JS_BASE_URI,
+            RestRunJobAction.JOB_TYPE,
+            RestRunJobAction.JOB_ID
+        );
+    }
+
+    public void testGetName() {
+        assertEquals("run_job_action", action.getName());
+    }
+
+    public void testRoutes_singlePostRoute() {
+        List<RestHandler.Route> routes = action.routes();
+        assertEquals(1, routes.size());
+        assertEquals(RestRequest.Method.POST, routes.get(0).getMethod());
+        assertEquals(runJobPath, routes.get(0).getPath());
+    }
+
+    public void testPrepareRequest_invokesExecuteOnClient() throws IOException {
+        Map<String, String> params = new HashMap<>();
+        params.put(RestRunJobAction.JOB_TYPE, "scheduler_sample_extension");
+        params.put(RestRunJobAction.JOB_ID, "my-job");
+
+        String path = String.format(
+            Locale.ROOT,
+            "%s/_run/scheduler_sample_extension/my-job",
+            JobSchedulerPlugin.JS_BASE_URI
+        );
+        FakeRestRequest request = new FakeRestRequest.Builder(xContentRegistry())
+            .withMethod(RestRequest.Method.POST)
+            .withPath(path)
+            .withParams(params)
+            .build();
+
+        final FakeRestChannel channel = new FakeRestChannel(request, true, 0);
+        NodeClient mockClient = Mockito.mock(NodeClient.class);
+
+        doAnswer(invocation -> {
+            ActionListener<RunJobResponse> listener = invocation.getArgument(2);
+            RunJobResponse response = new RunJobResponse(
+                new ClusterName("test-cluster"),
+                Collections.emptyList(),
+                Collections.emptyList()
+            );
+            listener.onResponse(response);
+            return null;
+        }).when(mockClient).execute(eq(RunJobAction.INSTANCE), any(RunJobRequest.class), any(ActionListener.class));
+
+        action.prepareRequest(request, mockClient);
+
+        assertEquals(0, channel.responses().get());
+        assertEquals(0, channel.errors().get());
+    }
+}

--- a/src/test/java/org/opensearch/jobscheduler/rest/action/RestRunJobActionTests.java
+++ b/src/test/java/org/opensearch/jobscheduler/rest/action/RestRunJobActionTests.java
@@ -71,13 +71,8 @@ public class RestRunJobActionTests extends OpenSearchTestCase {
         params.put(RestRunJobAction.JOB_TYPE, "scheduler_sample_extension");
         params.put(RestRunJobAction.JOB_ID, "my-job");
 
-        String path = String.format(
-            Locale.ROOT,
-            "%s/_run/scheduler_sample_extension/my-job",
-            JobSchedulerPlugin.JS_BASE_URI
-        );
-        FakeRestRequest request = new FakeRestRequest.Builder(xContentRegistry())
-            .withMethod(RestRequest.Method.POST)
+        String path = String.format(Locale.ROOT, "%s/_run/scheduler_sample_extension/my-job", JobSchedulerPlugin.JS_BASE_URI);
+        FakeRestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.POST)
             .withPath(path)
             .withParams(params)
             .build();
@@ -87,11 +82,7 @@ public class RestRunJobActionTests extends OpenSearchTestCase {
 
         doAnswer(invocation -> {
             ActionListener<RunJobResponse> listener = invocation.getArgument(2);
-            RunJobResponse response = new RunJobResponse(
-                new ClusterName("test-cluster"),
-                Collections.emptyList(),
-                Collections.emptyList()
-            );
+            RunJobResponse response = new RunJobResponse(new ClusterName("test-cluster"), Collections.emptyList(), Collections.emptyList());
             listener.onResponse(response);
             return null;
         }).when(mockClient).execute(eq(RunJobAction.INSTANCE), any(RunJobRequest.class), any(ActionListener.class));

--- a/src/test/java/org/opensearch/jobscheduler/transport/action/TransportRunJobActionTests.java
+++ b/src/test/java/org/opensearch/jobscheduler/transport/action/TransportRunJobActionTests.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.jobscheduler.transport.action;
+
+import org.junit.Before;
+import org.mockito.Mockito;
+import org.opensearch.Version;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.jobscheduler.ScheduledJobProvider;
+import org.opensearch.jobscheduler.scheduler.JobScheduler;
+import org.opensearch.jobscheduler.scheduler.JobSchedulingInfo;
+import org.opensearch.jobscheduler.scheduler.ScheduledJobInfo;
+import org.opensearch.jobscheduler.spi.ScheduledJobParameter;
+import org.opensearch.jobscheduler.spi.ScheduledJobRunner;
+import org.opensearch.jobscheduler.spi.utils.LockService;
+import org.opensearch.jobscheduler.transport.request.RunJobNodeRequest;
+import org.opensearch.jobscheduler.transport.request.RunJobRequest;
+import org.opensearch.jobscheduler.transport.response.RunJobNodeResponse;
+import org.opensearch.jobscheduler.utils.JobDetailsService;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+public class TransportRunJobActionTests extends OpenSearchTestCase {
+
+    private TransportRunJobAction action;
+    private JobScheduler jobScheduler;
+    private JobDetailsService jobDetailsService;
+    private LockService lockService;
+    private DiscoveryNode localNode;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+
+        ThreadPool threadPool = Mockito.mock(ThreadPool.class);
+        ClusterService clusterService = Mockito.mock(ClusterService.class, Mockito.RETURNS_DEEP_STUBS);
+        TransportService transportService = Mockito.mock(TransportService.class, Mockito.RETURNS_DEEP_STUBS);
+        ActionFilters actionFilters = new ActionFilters(new HashSet<>());
+
+        jobScheduler = Mockito.mock(JobScheduler.class);
+        jobDetailsService = Mockito.mock(JobDetailsService.class);
+        lockService = Mockito.mock(LockService.class);
+
+        localNode = new DiscoveryNode("node1", OpenSearchTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        when(clusterService.localNode()).thenReturn(localNode);
+
+        action = new TransportRunJobAction(
+            threadPool,
+            clusterService,
+            transportService,
+            actionFilters,
+            jobScheduler,
+            jobDetailsService,
+            lockService
+        );
+    }
+
+    public void testNodeOperation_unknownJobType_returnsNoProviderMessage() {
+        when(jobDetailsService.getIndexToJobProviders()).thenReturn(Collections.emptyMap());
+
+        RunJobNodeRequest request = new RunJobNodeRequest(new RunJobRequest("unknown-type", "job-1"));
+        RunJobNodeResponse response = action.nodeOperation(request);
+
+        assertFalse(response.isExecuted());
+        assertTrue(response.getMessage().contains("no provider registered for job_type [unknown-type]"));
+    }
+
+    public void testNodeOperation_knownJobTypeWithDifferentProvider_returnNoProviderMessage() {
+        ScheduledJobProvider provider = new ScheduledJobProvider("other-type", "other-index", null, null);
+        Map<String, ScheduledJobProvider> providers = new HashMap<>();
+        providers.put("other-index", provider);
+        when(jobDetailsService.getIndexToJobProviders()).thenReturn(providers);
+
+        RunJobNodeRequest request = new RunJobNodeRequest(new RunJobRequest("my-job-type", "job-1"));
+        RunJobNodeResponse response = action.nodeOperation(request);
+
+        assertFalse(response.isExecuted());
+        assertTrue(response.getMessage().contains("no provider registered for job_type [my-job-type]"));
+    }
+
+    public void testNodeOperation_jobNotOnThisNode_returnNotScheduledMessage() {
+        ScheduledJobProvider provider = new ScheduledJobProvider("my-type", "my-index", null, null);
+        Map<String, ScheduledJobProvider> providers = new HashMap<>();
+        providers.put("my-index", provider);
+        when(jobDetailsService.getIndexToJobProviders()).thenReturn(providers);
+
+        ScheduledJobInfo scheduledJobInfo = Mockito.mock(ScheduledJobInfo.class);
+        when(jobScheduler.getScheduledJobInfo()).thenReturn(scheduledJobInfo);
+        when(scheduledJobInfo.getJobInfo("my-index", "job-1")).thenReturn(null);
+
+        RunJobNodeRequest request = new RunJobNodeRequest(new RunJobRequest("my-type", "job-1"));
+        RunJobNodeResponse response = action.nodeOperation(request);
+
+        assertFalse(response.isExecuted());
+        assertEquals("job not scheduled on this node", response.getMessage());
+    }
+
+    public void testNodeOperation_nullRunner_returnNoRunnerMessage() {
+        ScheduledJobProvider provider = new ScheduledJobProvider("my-type", "my-index", null, null);
+        Map<String, ScheduledJobProvider> providers = new HashMap<>();
+        providers.put("my-index", provider);
+        when(jobDetailsService.getIndexToJobProviders()).thenReturn(providers);
+
+        ScheduledJobParameter jobParameter = Mockito.mock(ScheduledJobParameter.class);
+        JobSchedulingInfo schedulingInfo = new JobSchedulingInfo("my-index", "job-1", jobParameter);
+
+        ScheduledJobInfo scheduledJobInfo = Mockito.mock(ScheduledJobInfo.class);
+        when(jobScheduler.getScheduledJobInfo()).thenReturn(scheduledJobInfo);
+        when(scheduledJobInfo.getJobInfo("my-index", "job-1")).thenReturn(schedulingInfo);
+
+        RunJobNodeRequest request = new RunJobNodeRequest(new RunJobRequest("my-type", "job-1"));
+        RunJobNodeResponse response = action.nodeOperation(request);
+
+        assertFalse(response.isExecuted());
+        assertTrue(response.getMessage().contains("no runner registered for job_type [my-type]"));
+    }
+
+    public void testNodeOperation_successfulExecution_returnExecutedTrue() {
+        ScheduledJobRunner runner = Mockito.mock(ScheduledJobRunner.class);
+        ScheduledJobProvider provider = new ScheduledJobProvider("my-type", "my-index", null, runner);
+        Map<String, ScheduledJobProvider> providers = new HashMap<>();
+        providers.put("my-index", provider);
+        when(jobDetailsService.getIndexToJobProviders()).thenReturn(providers);
+
+        ScheduledJobParameter jobParameter = Mockito.mock(ScheduledJobParameter.class);
+        JobSchedulingInfo schedulingInfo = new JobSchedulingInfo("my-index", "job-1", jobParameter);
+
+        ScheduledJobInfo scheduledJobInfo = Mockito.mock(ScheduledJobInfo.class);
+        when(jobScheduler.getScheduledJobInfo()).thenReturn(scheduledJobInfo);
+        when(scheduledJobInfo.getJobInfo("my-index", "job-1")).thenReturn(schedulingInfo);
+
+        RunJobNodeRequest request = new RunJobNodeRequest(new RunJobRequest("my-type", "job-1"));
+        RunJobNodeResponse response = action.nodeOperation(request);
+
+        assertTrue(response.isExecuted());
+        assertNull(response.getMessage());
+        assertEquals("node1", response.getNode().getId());
+    }
+
+    public void testNodeOperation_runnerThrowsException_returnExecutionFailedMessage() {
+        ScheduledJobRunner runner = Mockito.mock(ScheduledJobRunner.class);
+        ScheduledJobProvider provider = new ScheduledJobProvider("my-type", "my-index", null, runner);
+        Map<String, ScheduledJobProvider> providers = new HashMap<>();
+        providers.put("my-index", provider);
+        when(jobDetailsService.getIndexToJobProviders()).thenReturn(providers);
+
+        ScheduledJobParameter jobParameter = Mockito.mock(ScheduledJobParameter.class);
+        JobSchedulingInfo schedulingInfo = new JobSchedulingInfo("my-index", "job-1", jobParameter);
+
+        ScheduledJobInfo scheduledJobInfo = Mockito.mock(ScheduledJobInfo.class);
+        when(jobScheduler.getScheduledJobInfo()).thenReturn(scheduledJobInfo);
+        when(scheduledJobInfo.getJobInfo("my-index", "job-1")).thenReturn(schedulingInfo);
+
+        doThrow(new RuntimeException("lock acquisition failed")).when(runner).runJob(Mockito.any(), Mockito.any());
+
+        RunJobNodeRequest request = new RunJobNodeRequest(new RunJobRequest("my-type", "job-1"));
+        RunJobNodeResponse response = action.nodeOperation(request);
+
+        assertFalse(response.isExecuted());
+        assertNotNull(response.getMessage());
+        assertTrue(response.getMessage().startsWith("execution failed:"));
+        assertTrue(response.getMessage().contains("lock acquisition failed"));
+    }
+
+    public void testNodeOperation_multipleProviders_resolvesCorrectProvider() {
+        ScheduledJobRunner runner = Mockito.mock(ScheduledJobRunner.class);
+        ScheduledJobProvider providerA = new ScheduledJobProvider("type-A", "index-A", null, runner);
+        ScheduledJobProvider providerB = new ScheduledJobProvider("type-B", "index-B", null, null);
+        Map<String, ScheduledJobProvider> providers = new HashMap<>();
+        providers.put("index-A", providerA);
+        providers.put("index-B", providerB);
+        when(jobDetailsService.getIndexToJobProviders()).thenReturn(providers);
+
+        ScheduledJobParameter jobParameter = Mockito.mock(ScheduledJobParameter.class);
+        JobSchedulingInfo schedulingInfo = new JobSchedulingInfo("index-A", "job-99", jobParameter);
+
+        ScheduledJobInfo scheduledJobInfo = Mockito.mock(ScheduledJobInfo.class);
+        when(jobScheduler.getScheduledJobInfo()).thenReturn(scheduledJobInfo);
+        when(scheduledJobInfo.getJobInfo("index-A", "job-99")).thenReturn(schedulingInfo);
+
+        RunJobNodeRequest request = new RunJobNodeRequest(new RunJobRequest("type-A", "job-99"));
+        RunJobNodeResponse response = action.nodeOperation(request);
+
+        // type-A has a valid runner, so execution should succeed
+        assertTrue(response.isExecuted());
+    }
+}

--- a/src/test/java/org/opensearch/jobscheduler/transport/request/RunJobRequestTests.java
+++ b/src/test/java/org/opensearch/jobscheduler/transport/request/RunJobRequestTests.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.jobscheduler.transport.request;
+
+import org.junit.Before;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class RunJobRequestTests extends OpenSearchTestCase {
+
+    private static final String JOB_TYPE = "my-job-type";
+    private static final String JOB_ID = "my-job-id";
+
+    private RunJobRequest request;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        request = new RunJobRequest(JOB_TYPE, JOB_ID);
+    }
+    public void testValidate_withNullJobType_returnError() {
+        RunJobRequest invalidRequest = new RunJobRequest(null, JOB_ID);
+        ActionRequestValidationException ex = invalidRequest.validate();
+        assertNotNull(ex);
+        assertTrue(ex.getMessage().contains("job_type is required"));
+    }
+
+    public void testValidate_withEmptyJobType_returnError() {
+        RunJobRequest invalidRequest = new RunJobRequest("", JOB_ID);
+        ActionRequestValidationException ex = invalidRequest.validate();
+        assertNotNull(ex);
+        assertTrue(ex.getMessage().contains("job_type is required"));
+    }
+
+    public void testValidate_withNullJobId_returnError() {
+        RunJobRequest invalidRequest = new RunJobRequest(JOB_TYPE, null);
+        ActionRequestValidationException ex = invalidRequest.validate();
+        assertNotNull(ex);
+        assertTrue(ex.getMessage().contains("job_id is required"));
+    }
+
+    public void testValidate_withEmptyJobId_returnError() {
+        RunJobRequest invalidRequest = new RunJobRequest(JOB_TYPE, "");
+        ActionRequestValidationException ex = invalidRequest.validate();
+        assertNotNull(ex);
+        assertTrue(ex.getMessage().contains("job_id is required"));
+    }
+
+    public void testValidate_withBothParamsNull_returnBothErrors() {
+        RunJobRequest invalidRequest = new RunJobRequest(null, null);
+        ActionRequestValidationException ex = invalidRequest.validate();
+        assertNotNull(ex);
+        assertTrue(ex.getMessage().contains("job_type is required"));
+        assertTrue(ex.getMessage().contains("job_id is required"));
+    }
+
+}

--- a/src/test/java/org/opensearch/jobscheduler/transport/request/RunJobRequestTests.java
+++ b/src/test/java/org/opensearch/jobscheduler/transport/request/RunJobRequestTests.java
@@ -10,8 +10,6 @@ package org.opensearch.jobscheduler.transport.request;
 
 import org.junit.Before;
 import org.opensearch.action.ActionRequestValidationException;
-import org.opensearch.common.io.stream.BytesStreamOutput;
-import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.test.OpenSearchTestCase;
 
 public class RunJobRequestTests extends OpenSearchTestCase {
@@ -26,6 +24,7 @@ public class RunJobRequestTests extends OpenSearchTestCase {
         super.setUp();
         request = new RunJobRequest(JOB_TYPE, JOB_ID);
     }
+
     public void testValidate_withNullJobType_returnError() {
         RunJobRequest invalidRequest = new RunJobRequest(null, JOB_ID);
         ActionRequestValidationException ex = invalidRequest.validate();

--- a/src/test/java/org/opensearch/jobscheduler/transport/response/RunJobNodeResponseTests.java
+++ b/src/test/java/org/opensearch/jobscheduler/transport/response/RunJobNodeResponseTests.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.jobscheduler.transport.response;
+
+import org.junit.Before;
+import org.opensearch.Version;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class RunJobNodeResponseTests extends OpenSearchTestCase {
+
+    private DiscoveryNode node;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        node = new DiscoveryNode("node1", OpenSearchTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+    }
+
+    public void testToXContent_withMessage() throws Exception {
+        RunJobNodeResponse response = new RunJobNodeResponse(node, false, "some error");
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        response.toXContent(builder, null);
+        String json = builder.toString();
+
+        assertTrue(json.contains("\"node_id\":\"node1\""));
+        assertTrue(json.contains("\"executed\":false"));
+        assertTrue(json.contains("\"message\":\"some error\""));
+    }
+
+    public void testToXContent_withoutMessage() throws Exception {
+        RunJobNodeResponse response = new RunJobNodeResponse(node, true, null);
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        response.toXContent(builder, null);
+        String json = builder.toString();
+
+        assertTrue(json.contains("\"node_id\":\"node1\""));
+        assertTrue(json.contains("\"executed\":true"));
+        assertFalse(json.contains("\"message\""));
+    }
+}

--- a/src/test/java/org/opensearch/jobscheduler/transport/response/RunJobNodeResponseTests.java
+++ b/src/test/java/org/opensearch/jobscheduler/transport/response/RunJobNodeResponseTests.java
@@ -11,9 +11,7 @@ package org.opensearch.jobscheduler.transport.response;
 import org.junit.Before;
 import org.opensearch.Version;
 import org.opensearch.cluster.node.DiscoveryNode;
-import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.xcontent.XContentFactory;
-import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.test.OpenSearchTestCase;
 

--- a/src/test/java/org/opensearch/jobscheduler/transport/response/RunJobResponseTests.java
+++ b/src/test/java/org/opensearch/jobscheduler/transport/response/RunJobResponseTests.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.jobscheduler.transport.response;
+
+import org.junit.Before;
+import org.opensearch.Version;
+import org.opensearch.action.FailedNodeException;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class RunJobResponseTests extends OpenSearchTestCase {
+
+    private DiscoveryNode node1;
+    private DiscoveryNode node2;
+    private ClusterName clusterName;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        node1 = new DiscoveryNode("node1", OpenSearchTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        node2 = new DiscoveryNode("node2", OpenSearchTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        clusterName = new ClusterName("test-cluster");
+    }
+
+    public void testGetExecutingNode_noNodeExecuted_returnsNull() {
+        List<RunJobNodeResponse> nodes = Arrays.asList(
+            new RunJobNodeResponse(node1, false, "not scheduled"),
+            new RunJobNodeResponse(node2, false, "not scheduled")
+        );
+        RunJobResponse response = new RunJobResponse(clusterName, nodes, Collections.emptyList());
+        assertNull(response.getExecutingNode());
+    }
+
+    public void testGetExecutingNode_oneNodeExecuted_returnsThatNode() {
+        List<RunJobNodeResponse> nodes = Arrays.asList(
+            new RunJobNodeResponse(node1, false, "not scheduled"),
+            new RunJobNodeResponse(node2, true, null)
+        );
+        RunJobResponse response = new RunJobResponse(clusterName, nodes, Collections.emptyList());
+        RunJobNodeResponse executingNode = response.getExecutingNode();
+        assertNotNull(executingNode);
+        assertEquals("node2", executingNode.getNode().getId());
+    }
+
+    public void testGetExecutingNode_emptyNodeList_returnsNull() {
+        RunJobResponse response = new RunJobResponse(clusterName, Collections.emptyList(), Collections.emptyList());
+        assertNull(response.getExecutingNode());
+    }
+
+    public void testToXContent_withExecutingNode() throws Exception {
+        List<RunJobNodeResponse> nodes = Collections.singletonList(new RunJobNodeResponse(node1, true, null));
+        RunJobResponse response = new RunJobResponse(clusterName, nodes, Collections.emptyList());
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        response.toXContent(builder, null);
+        String json = builder.toString();
+
+        assertTrue(json.contains("\"executed\":true"));
+        assertTrue(json.contains("\"executing_node_id\":\"node1\""));
+        assertTrue(json.contains("\"executing_node_name\""));
+        assertTrue(json.contains("\"nodes\""));
+        assertTrue(json.contains("\"failures\""));
+    }
+}

--- a/src/test/java/org/opensearch/jobscheduler/transport/response/RunJobResponseTests.java
+++ b/src/test/java/org/opensearch/jobscheduler/transport/response/RunJobResponseTests.java
@@ -10,7 +10,6 @@ package org.opensearch.jobscheduler.transport.response;
 
 import org.junit.Before;
 import org.opensearch.Version;
-import org.opensearch.action.FailedNodeException;
 import org.opensearch.cluster.ClusterName;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.xcontent.XContentFactory;


### PR DESCRIPTION
### Description
POST /_plugins/_job_scheduler/_run/{job_type}/{job_id}

This PR introduces a new REST endpoint that allows users to trigger any registered scheduled job immediately, on demand, without waiting for its next scheduled execution time. The implementation follows the existing TransportNodesAction broadcast pattern used elsewhere in this plugin, ensuring the request is correctly routed to whichever cluster node currently owns the job — even in a multi-node deployment where the caller may not know which node that is.

The API returns 200 OK when a node executed the job, 404 when no node owned it.

### Related Issues
Resolves #832

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/job-scheduler/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
