### PR TITLE
Enable logger usage check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   Get-CI-Image-Tag:
-    uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@c2498b758c08fb7bc48476509a5fc1b8dd5f7493 # main
+    uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@761e093b8c1349cc07f21c1d681d3b30bf9e1999 # main
     with:
       product: opensearch
 

--- a/.github/workflows/issue-dedupe.yml
+++ b/.github/workflows/issue-dedupe.yml
@@ -20,7 +20,7 @@ jobs:
       (github.event_name == 'issues' &&
        github.event.issue.user.type != 'Bot' &&
        github.repository == 'opensearch-project/job-scheduler')
-    uses: opensearch-project/opensearch-build/.github/workflows/issue-dedupe-detect.yml@c2498b758c08fb7bc48476509a5fc1b8dd5f7493 # main
+    uses: opensearch-project/opensearch-build/.github/workflows/issue-dedupe-detect.yml@761e093b8c1349cc07f21c1d681d3b30bf9e1999 # main
     permissions:
       contents: read
       issues: write
@@ -33,7 +33,7 @@ jobs:
 
   auto-close-issue:
     if: github.event_name == 'schedule' && github.repository == 'opensearch-project/job-scheduler'
-    uses: opensearch-project/opensearch-build/.github/workflows/issue-dedupe-autoclose.yml@c2498b758c08fb7bc48476509a5fc1b8dd5f7493 # main
+    uses: opensearch-project/opensearch-build/.github/workflows/issue-dedupe-autoclose.yml@761e093b8c1349cc07f21c1d681d3b30bf9e1999 # main
     permissions:
       issues: write
     with:

--- a/.github/workflows/pr_review.yml
+++ b/.github/workflows/pr_review.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   Code-Diff-Analyzer:
-    uses: opensearch-project/opensearch-build/.github/workflows/code-diff-analyzer.yml@c2498b758c08fb7bc48476509a5fc1b8dd5f7493 # main
+    uses: opensearch-project/opensearch-build/.github/workflows/code-diff-analyzer.yml@761e093b8c1349cc07f21c1d681d3b30bf9e1999 # main
     if: github.repository == 'opensearch-project/job-scheduler'
     permissions:
       id-token: write  # github oidc to assume aws roles
@@ -18,7 +18,7 @@ jobs:
       update_pr_comment_with_analyzer_report: true
 
   Code-Diff-Reviewer:
-    uses: opensearch-project/opensearch-build/.github/workflows/code-diff-reviewer.yml@c2498b758c08fb7bc48476509a5fc1b8dd5f7493 # main
+    uses: opensearch-project/opensearch-build/.github/workflows/code-diff-reviewer.yml@761e093b8c1349cc07f21c1d681d3b30bf9e1999 # main
     needs: Code-Diff-Analyzer
     if: github.repository == 'opensearch-project/job-scheduler'
     permissions:

--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,6 @@ dependencyLicenses.enabled = false
 thirdPartyAudit.enabled = false
 forbiddenApisTest.ignoreFailures = true
 validateNebulaPom.enabled = false
-loggerUsageCheck.enabled = false
 
 opensearchplugin {
     name 'opensearch-job-scheduler'

--- a/sample-extension-plugin/build.gradle
+++ b/sample-extension-plugin/build.gradle
@@ -66,7 +66,6 @@ def _numNodes = findProperty('numNodes') as Integer ?: 1
 licenseHeaders.enabled = true
 validateNebulaPom.enabled = false
 testingConventions.enabled = false
-loggerUsageCheck.enabled = false
 
 jacoco {
     toolVersion = '0.8.13'

--- a/src/main/java/org/opensearch/jobscheduler/sweeper/JobSweeper.java
+++ b/src/main/java/org/opensearch/jobscheduler/sweeper/JobSweeper.java
@@ -21,6 +21,7 @@ import org.opensearch.jobscheduler.utils.JobDetailsService;
 import org.opensearch.jobscheduler.utils.VisibleForTesting;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.OpenSearchException;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.action.bulk.BackoffPolicy;
@@ -407,7 +408,7 @@ public class JobSweeper extends LifecycleListener implements IndexingOperationLi
                 response = this.retry((searchRequest) -> this.client.search(searchRequest), jobSearchRequest, this.sweepSearchBackoff)
                     .actionGet(this.sweepSearchTimeout);
             } catch (Exception e) {
-                log.error("Aborting sweep of shard {}, will retry on next sweep cycle.", shardId, e);
+                log.error(() -> new ParameterizedMessage("Aborting sweep of shard {}, will retry on next sweep cycle.", shardId), e);
                 return;
             }
             if (response.status() != RestStatus.OK) {

--- a/src/main/java/org/opensearch/jobscheduler/transport/action/TransportGetAllLocksAction.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/action/TransportGetAllLocksAction.java
@@ -10,6 +10,7 @@ package org.opensearch.jobscheduler.transport.action;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.action.search.ClearScrollRequest;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
@@ -107,7 +108,7 @@ public class TransportGetAllLocksAction extends HandledTransportAction<GetLocksR
 
             @Override
             public void onFailure(Exception e) {
-                log.debug("Error in finding lock by ID {}", lockId, e);
+                log.debug(() -> new ParameterizedMessage("Error in finding lock by ID {}", lockId), e);
                 listener.onResponse(new HashMap<>());
             }
         });

--- a/src/main/java/org/opensearch/jobscheduler/utils/JobDetailsService.java
+++ b/src/main/java/org/opensearch/jobscheduler/utils/JobDetailsService.java
@@ -386,7 +386,7 @@ public class JobDetailsService implements IndexingOperationListener {
                             createJobDetails(tempJobDetails, listener);
                         }
                     } catch (VersionConflictEngineException e) {
-                        logger.debug("could not process job index for extensionUniqueId " + extensionUniqueId, e.getMessage());
+                        logger.debug("could not process job index for extensionUniqueId {}: {}", extensionUniqueId, e.getMessage());
                         listener.onResponse(null);
                     }
                 } else {
@@ -464,7 +464,7 @@ public class JobDetailsService implements IndexingOperationListener {
             );
         }, exception -> {
             if (exception instanceof IndexNotFoundException || exception.getCause() instanceof IndexNotFoundException) {
-                logger.debug("Index is not found to delete job details for document id. {} " + documentId, exception.getMessage());
+                logger.debug("Index is not found to delete job details for document id {}: {}", documentId, exception.getMessage());
                 listener.onResponse(true);
             } else {
                 listener.onFailure(exception);
@@ -488,7 +488,7 @@ public class JobDetailsService implements IndexingOperationListener {
 
             client.update(updateRequest, ActionListener.wrap(response -> listener.onResponse(response.getId()), exception -> {
                 if (exception instanceof VersionConflictEngineException) {
-                    logger.debug("could not update job details for documentId " + documentId, exception.getMessage());
+                    logger.debug("could not update job details for documentId {}: {}", documentId, exception.getMessage());
                 }
                 if (exception instanceof DocumentMissingException) {
                     logger.debug("Document is deleted. This happens if the job details is already removed {}", exception.getMessage());


### PR DESCRIPTION
## Description

Enables the OpenSearch logger usage check for Job Scheduler now that the logger usage checker is available to plugin builds from OpenSearch Core.

This removes the explicit logger usage check disablement from the root and sample extension Gradle builds, then updates the remaining logger calls that violated the check.

## Verification

Ran locally:

```bash
./gradlew loggerUsageCheck spotlessApply
```

This previously required the companion OpenSearch Core build-tools change; that core change has merged, so this plugin branch is no longer blocked.