### PR TITLE
Enable Nebula POM validation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,6 @@ forbiddenApis.ignoreFailures = false
 dependencyLicenses.enabled = false
 thirdPartyAudit.enabled = false
 forbiddenApisTest.ignoreFailures = true
-validateNebulaPom.enabled = false
 loggerUsageCheck.enabled = false
 
 opensearchplugin {
@@ -82,6 +81,7 @@ configurations {
 allprojects {
     group = 'org.opensearch'
     version = opensearch_version.tokenize('-')[0] + '.0'
+    description = 'OpenSearch Job Scheduler plugin'
     if (buildVersionQualifier) {
         version += "-${buildVersionQualifier}"
     }
@@ -177,7 +177,7 @@ allprojects {
     // Default to the apache license
     project.ext.licenseName = 'The Apache Software License, Version 2.0'
     project.ext.licenseUrl = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-    plugins.withType(ShadowPlugin).whenPluginAdded {
+    plugins.withId('maven-publish') {
         publishing {
             repositories {
                 maven {
@@ -189,11 +189,14 @@ allprojects {
                 // add license information to generated poms
                 all {
                     pom {
-                        name = "opensearch-job-scheduler"
-                        description = "OpenSearch Job Scheduler plugin"
+                        name = project.name
+                        description = project.description
                     }
                     pom.withXml { XmlProvider xml ->
                         Node node = xml.asNode()
+                        if (node.description.isEmpty()) {
+                            node.appendNode('description', project.description)
+                        }
                         node.appendNode('inceptionYear', '2021')
 
                         Node license = node.appendNode('licenses').appendNode('license')

--- a/sample-extension-plugin/build.gradle
+++ b/sample-extension-plugin/build.gradle
@@ -7,6 +7,8 @@ plugins {
     id "org.gradle.test-retry" version "1.6.5"
 }
 
+description = 'Sample plugin that extends OpenSearch Job Scheduler plugin'
+
 apply plugin: 'opensearch.opensearchplugin'
 apply plugin: 'opensearch.testclusters'
 apply plugin: 'opensearch.java-agent'
@@ -64,7 +66,6 @@ File repo = file("$buildDir/testclusters/repo")
 def _numNodes = findProperty('numNodes') as Integer ?: 1
 
 licenseHeaders.enabled = true
-validateNebulaPom.enabled = false
 testingConventions.enabled = false
 loggerUsageCheck.enabled = false
 


### PR DESCRIPTION
## Summary
Enables `validateNebulaPom` for Job Scheduler and the sample extension plugin.

The sample extension publication was missing required Maven POM metadata, so this updates the shared POM metadata configuration to apply to Maven-published projects and lets each project provide its own `project.description`.

## Details
- Removes the explicit `validateNebulaPom.enabled = false` overrides.
- Applies shared POM metadata configuration when `maven-publish` is present, instead of tying it to the Shadow plugin.
- Sets the root project description to `OpenSearch Job Scheduler plugin`.
- Sets the sample extension description in `sample-extension-plugin/build.gradle`.

## Validation
- `./gradlew spotlessApply`
- `./gradlew validateNebulaPom :opensearch-job-scheduler-sample-extension:validateNebulaPom`
