### PR TITLE
Add Job Scheduler history API

### DIFF
--- a/sample-extension-plugin/src/test/java/org/opensearch/jobscheduler/sampleextension/SampleJobRunnerRestIT.java
+++ b/sample-extension-plugin/src/test/java/org/opensearch/jobscheduler/sampleextension/SampleJobRunnerRestIT.java
@@ -36,6 +36,7 @@ public class SampleJobRunnerRestIT extends SampleExtensionIntegTestCase {
     public static final String LOCK_INFO_URI = "/_plugins/_job_scheduler/api/locks";
     public static final String SCHEDULER_INFO_URI = "/_plugins/_job_scheduler/api/jobs?by_node";
     public static final String SCHEDULER_INFO_URI_CLUSTER = "/_plugins/_job_scheduler/api/jobs";
+    public static final String HISTORY_INFO_URI = "/_plugins/_job_scheduler/api/history";
 
     public void testJobCreateWithCorrectParams() throws IOException {
         SampleJobParameter jobParameter = new SampleJobParameter();
@@ -210,6 +211,50 @@ public class SampleJobRunnerRestIT extends SampleExtensionIntegTestCase {
         // Cleanup
         deleteWatcherJob(jobId);
     }
+
+    public void testJobHistoryService() throws Exception{
+        String index = createTestIndex();
+        SampleJobParameter jobParameter = new SampleJobParameter();
+        jobParameter.setJobName("sample-job-lock-test-it");
+        jobParameter.setIndexToWatch(index);
+        // ensures that the next job tries to run even before the previous job finished & released its lock. Also look at
+        // SampleJobRunner.runTaskForLockIntegrationTests
+        jobParameter.setSchedule(new IntervalSchedule(Instant.now(), 5, ChronoUnit.SECONDS));
+        jobParameter.setLockDurationSeconds(10L);
+
+        // Creates a new watcher job.
+        String jobId = OpenSearchRestTestCase.randomAlphaOfLength(10);
+        createWatcherJob(jobId, jobParameter);
+
+        waitUntilLockIsAcquiredAndReleased(jobId);
+
+        Response response = makeRequest(client(), "GET", HISTORY_INFO_URI, Map.of(), null);
+        Map<String, Object> responseJson = parseResponse(response);
+        
+        Assert.assertTrue("Response should contain total_history", responseJson.containsKey("total_history"));
+        Assert.assertTrue("Response should contain history", responseJson.containsKey("history"));
+        
+        Integer totalHistory = (Integer) responseJson.get("total_history");
+        Assert.assertTrue("Total history should be greater than 0", totalHistory > 0);
+        
+        Map<String, Object> history = (Map<String, Object>) responseJson.get("history");
+        Assert.assertFalse("History should not be empty", history.isEmpty());
+        
+        for (Map.Entry<String, Object> entry : history.entrySet()) {
+            Map<String, Object> historyRecord = (Map<String, Object>) entry.getValue();
+            Assert.assertTrue("History record should contain job_index_name", historyRecord.containsKey("job_index_name"));
+            Assert.assertTrue("History record should contain job_id", historyRecord.containsKey("job_id"));
+            Assert.assertTrue("History record should contain start_time", historyRecord.containsKey("start_time"));
+            Assert.assertTrue("History record should contain completion_status", historyRecord.containsKey("completion_status"));
+            Assert.assertTrue("History record should contain end_time", historyRecord.containsKey("end_time"));
+            
+            Assert.assertEquals("Job ID should match", jobId, historyRecord.get("job_id"));
+            Assert.assertEquals("Completion status should be 0", 0, historyRecord.get("completion_status"));
+        }
+        
+        deleteWatcherJob(jobId);
+    }
+
 
     public void testAcquiredLockPreventExecOfTasks() throws Exception {
         String index = createTestIndex();

--- a/sample-extension-plugin/src/test/java/org/opensearch/jobscheduler/sampleextension/SampleJobRunnerRestIT.java
+++ b/sample-extension-plugin/src/test/java/org/opensearch/jobscheduler/sampleextension/SampleJobRunnerRestIT.java
@@ -271,9 +271,13 @@ public class SampleJobRunnerRestIT extends SampleExtensionIntegTestCase {
 
         waitUntilLockIsAcquiredAndReleased(jobId);
 
-        String historyIndexById = HISTORY_INFO_URI + "/.scheduler_sample_extension-" + jobId;
-
-        Response response = makeRequest(client(), "GET", historyIndexById, Map.of(), null);
+        Response response = makeRequest(
+            client(),
+            "GET",
+            HISTORY_INFO_URI,
+            Map.of("job_index_name", ".scheduler_sample_extension", "job_id", jobId),
+            null
+        );
         Map<String, Object> responseJson = parseResponse(response);
 
         Assert.assertTrue("Response should contain total_history", responseJson.containsKey("total_history"));

--- a/sample-extension-plugin/src/test/java/org/opensearch/jobscheduler/sampleextension/SampleJobRunnerRestIT.java
+++ b/sample-extension-plugin/src/test/java/org/opensearch/jobscheduler/sampleextension/SampleJobRunnerRestIT.java
@@ -212,7 +212,7 @@ public class SampleJobRunnerRestIT extends SampleExtensionIntegTestCase {
         deleteWatcherJob(jobId);
     }
 
-    public void testJobHistoryService() throws Exception{
+    public void testJobHistoryService() throws Exception {
         String index = createTestIndex();
         SampleJobParameter jobParameter = new SampleJobParameter();
         jobParameter.setJobName("sample-job-lock-test-it");
@@ -230,16 +230,16 @@ public class SampleJobRunnerRestIT extends SampleExtensionIntegTestCase {
 
         Response response = makeRequest(client(), "GET", HISTORY_INFO_URI, Map.of(), null);
         Map<String, Object> responseJson = parseResponse(response);
-        
+
         Assert.assertTrue("Response should contain total_history", responseJson.containsKey("total_history"));
         Assert.assertTrue("Response should contain history", responseJson.containsKey("history"));
-        
+
         Integer totalHistory = (Integer) responseJson.get("total_history");
         Assert.assertTrue("Total history should be greater than 0", totalHistory > 0);
-        
+
         Map<String, Object> history = (Map<String, Object>) responseJson.get("history");
         Assert.assertFalse("History should not be empty", history.isEmpty());
-        
+
         for (Map.Entry<String, Object> entry : history.entrySet()) {
             Map<String, Object> historyRecord = (Map<String, Object>) entry.getValue();
             Assert.assertTrue("History record should contain job_index_name", historyRecord.containsKey("job_index_name"));
@@ -247,14 +247,58 @@ public class SampleJobRunnerRestIT extends SampleExtensionIntegTestCase {
             Assert.assertTrue("History record should contain start_time", historyRecord.containsKey("start_time"));
             Assert.assertTrue("History record should contain completion_status", historyRecord.containsKey("completion_status"));
             Assert.assertTrue("History record should contain end_time", historyRecord.containsKey("end_time"));
-            
+
             Assert.assertEquals("Job ID should match", jobId, historyRecord.get("job_id"));
             Assert.assertEquals("Completion status should be 0", 0, historyRecord.get("completion_status"));
         }
-        
+
         deleteWatcherJob(jobId);
     }
 
+    public void testJobHistoryServiceById() throws Exception {
+        String index = createTestIndex();
+        SampleJobParameter jobParameter = new SampleJobParameter();
+        jobParameter.setJobName("sample-job-lock-test-it");
+        jobParameter.setIndexToWatch(index);
+        // ensures that the next job tries to run even before the previous job finished & released its lock. Also look at
+        // SampleJobRunner.runTaskForLockIntegrationTests
+        jobParameter.setSchedule(new IntervalSchedule(Instant.now(), 5, ChronoUnit.SECONDS));
+        jobParameter.setLockDurationSeconds(10L);
+
+        // Creates a new watcher job.
+        String jobId = OpenSearchRestTestCase.randomAlphaOfLength(10);
+        createWatcherJob(jobId, jobParameter);
+
+        waitUntilLockIsAcquiredAndReleased(jobId);
+
+        String historyIndexById = HISTORY_INFO_URI + "/.scheduler_sample_extension-" + jobId;
+
+        Response response = makeRequest(client(), "GET", historyIndexById, Map.of(), null);
+        Map<String, Object> responseJson = parseResponse(response);
+
+        Assert.assertTrue("Response should contain total_history", responseJson.containsKey("total_history"));
+        Assert.assertTrue("Response should contain history", responseJson.containsKey("history"));
+
+        Integer totalHistory = (Integer) responseJson.get("total_history");
+        Assert.assertTrue("Total history should be greater than 0", totalHistory > 0);
+
+        Map<String, Object> history = (Map<String, Object>) responseJson.get("history");
+        Assert.assertFalse("History should not be empty", history.isEmpty());
+
+        for (Map.Entry<String, Object> entry : history.entrySet()) {
+            Map<String, Object> historyRecord = (Map<String, Object>) entry.getValue();
+            Assert.assertTrue("History record should contain job_index_name", historyRecord.containsKey("job_index_name"));
+            Assert.assertTrue("History record should contain job_id", historyRecord.containsKey("job_id"));
+            Assert.assertTrue("History record should contain start_time", historyRecord.containsKey("start_time"));
+            Assert.assertTrue("History record should contain completion_status", historyRecord.containsKey("completion_status"));
+            Assert.assertTrue("History record should contain end_time", historyRecord.containsKey("end_time"));
+
+            Assert.assertEquals("Job ID should match", jobId, historyRecord.get("job_id"));
+            Assert.assertEquals("Completion status should be 0", 0, historyRecord.get("completion_status"));
+        }
+
+        deleteWatcherJob(jobId);
+    }
 
     public void testAcquiredLockPreventExecOfTasks() throws Exception {
         String index = createTestIndex();

--- a/src/main/java/org/opensearch/jobscheduler/JobSchedulerPlugin.java
+++ b/src/main/java/org/opensearch/jobscheduler/JobSchedulerPlugin.java
@@ -20,14 +20,17 @@ import org.opensearch.identity.PluginSubject;
 import org.opensearch.core.action.ActionResponse;
 import org.opensearch.jobscheduler.rest.action.RestGetLocksAction;
 import org.opensearch.jobscheduler.rest.action.RestGetJobDetailsAction;
+import org.opensearch.jobscheduler.rest.action.RestGetHistoryAction;
 import org.opensearch.jobscheduler.rest.action.RestGetLockAction;
 import org.opensearch.jobscheduler.rest.action.RestGetScheduledInfoAction;
 import org.opensearch.jobscheduler.rest.action.RestReleaseLockAction;
 import org.opensearch.jobscheduler.spi.utils.LockService;
 import org.opensearch.jobscheduler.transport.PluginClient;
 import org.opensearch.jobscheduler.transport.action.GetAllLocksAction;
+import org.opensearch.jobscheduler.transport.action.GetHistoryAction;
 import org.opensearch.jobscheduler.transport.action.GetScheduledInfoAction;
 import org.opensearch.jobscheduler.transport.action.TransportGetAllLocksAction;
+import org.opensearch.jobscheduler.transport.action.TransportGetHistoryAction;
 import org.opensearch.jobscheduler.transport.action.TransportGetScheduledInfoAction;
 import org.opensearch.jobscheduler.scheduler.JobScheduler;
 import org.opensearch.jobscheduler.spi.JobSchedulerExtension;
@@ -272,20 +275,23 @@ public class JobSchedulerPlugin extends Plugin implements ActionPlugin, Extensib
         RestReleaseLockAction restReleaseLockAction = new RestReleaseLockAction(lockService);
         RestGetScheduledInfoAction restGetScheduledInfoAction = new RestGetScheduledInfoAction();
         RestGetLocksAction restGetAllLocksAction = new RestGetLocksAction();
+        RestGetHistoryAction restGetHistoryAction = new RestGetHistoryAction();
         return List.of(
             restGetJobDetailsAction,
             restGetLockAction,
             restReleaseLockAction,
             restGetScheduledInfoAction,
-            restGetAllLocksAction
+            restGetAllLocksAction,
+            restGetHistoryAction
         );
     }
 
     @Override
     public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
-        List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> actions = new ArrayList<>(2);
+        List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> actions = new ArrayList<>(3);
         actions.add(new ActionHandler<>(GetScheduledInfoAction.INSTANCE, TransportGetScheduledInfoAction.class));
         actions.add(new ActionHandler<>(GetAllLocksAction.INSTANCE, TransportGetAllLocksAction.class));
+        actions.add(new ActionHandler<>(GetHistoryAction.INSTANCE, TransportGetHistoryAction.class));
         return actions;
     }
 

--- a/src/main/java/org/opensearch/jobscheduler/JobSchedulerPlugin.java
+++ b/src/main/java/org/opensearch/jobscheduler/JobSchedulerPlugin.java
@@ -133,7 +133,7 @@ public class JobSchedulerPlugin extends Plugin implements ActionPlugin, Extensib
         IndexNameExpressionResolver indexNameExpressionResolver,
         Supplier<RepositoriesService> repositoriesServiceSupplier
     ) {
-        Supplier<Boolean> statusHistoryEnabled = () -> JobSchedulerSettings.STATUS_HISTORY.get(environment.settings());
+        Supplier<Boolean> statusHistoryEnabled = () -> clusterService.getClusterSettings().get(JobSchedulerSettings.STATUS_HISTORY);
         this.pluginClient = new PluginClient(client);
         this.historyService = new JobHistoryService(pluginClient, clusterService);
         this.lockService = new LockServiceImpl(pluginClient, clusterService, historyService, statusHistoryEnabled);

--- a/src/main/java/org/opensearch/jobscheduler/JobSchedulerSettings.java
+++ b/src/main/java/org/opensearch/jobscheduler/JobSchedulerSettings.java
@@ -57,7 +57,7 @@ public class JobSchedulerSettings {
     public static final Setting<Boolean> STATUS_HISTORY = Setting.boolSetting(
         "plugins.jobscheduler.history.enabled",
         false,
-        Setting.Property.NodeScope,
+        Setting.Property.Consistent,
         Setting.Property.Dynamic
     );
 }

--- a/src/main/java/org/opensearch/jobscheduler/JobSchedulerSettings.java
+++ b/src/main/java/org/opensearch/jobscheduler/JobSchedulerSettings.java
@@ -57,7 +57,7 @@ public class JobSchedulerSettings {
     public static final Setting<Boolean> STATUS_HISTORY = Setting.boolSetting(
         "plugins.jobscheduler.history.enabled",
         false,
-        Setting.Property.Consistent,
+        Setting.Property.NodeScope,
         Setting.Property.Dynamic
     );
 }

--- a/src/main/java/org/opensearch/jobscheduler/rest/action/RestGetHistoryAction.java
+++ b/src/main/java/org/opensearch/jobscheduler/rest/action/RestGetHistoryAction.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.jobscheduler.rest.action;
+
+import org.opensearch.transport.client.node.NodeClient;
+import org.opensearch.jobscheduler.JobSchedulerPlugin;
+import org.opensearch.jobscheduler.transport.action.GetHistoryAction;
+import org.opensearch.jobscheduler.transport.request.GetHistoryRequest;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.rest.action.RestToXContentListener;
+
+import java.util.List;
+
+import static org.opensearch.rest.RestRequest.Method.GET;
+
+/**
+ * REST handler for getting job history
+ */
+public class RestGetHistoryAction extends BaseRestHandler {
+
+    @Override
+    public String getName() {
+        return "get_history_action";
+    }
+
+    @Override
+    public List<Route> routes() {
+        return List.of(
+            new Route(GET, JobSchedulerPlugin.JS_BASE_URI + "/api/history"),
+            new Route(GET, JobSchedulerPlugin.JS_BASE_URI + "/api/history/{history_id}")
+        );
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
+        String history_id = request.param("history_id");
+        GetHistoryRequest getHistoryRequest = new GetHistoryRequest(history_id);
+        return channel -> client.execute(GetHistoryAction.INSTANCE, getHistoryRequest, new RestToXContentListener<>(channel));
+    }
+}

--- a/src/main/java/org/opensearch/jobscheduler/rest/action/RestGetHistoryAction.java
+++ b/src/main/java/org/opensearch/jobscheduler/rest/action/RestGetHistoryAction.java
@@ -32,16 +32,14 @@ public class RestGetHistoryAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return List.of(
-            new Route(GET, JobSchedulerPlugin.JS_BASE_URI + "/api/history"),
-            new Route(GET, JobSchedulerPlugin.JS_BASE_URI + "/api/history/{history_id}")
-        );
+        return List.of(new Route(GET, JobSchedulerPlugin.JS_BASE_URI + "/api/history"));
     }
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
-        String history_id = request.param("history_id");
-        GetHistoryRequest getHistoryRequest = new GetHistoryRequest(history_id);
+        String jobIndexName = request.param("job_index_name");
+        String jobId = request.param("job_id");
+        GetHistoryRequest getHistoryRequest = new GetHistoryRequest(jobIndexName, jobId);
         return channel -> client.execute(GetHistoryAction.INSTANCE, getHistoryRequest, new RestToXContentListener<>(channel));
     }
 }

--- a/src/main/java/org/opensearch/jobscheduler/transport/action/GetHistoryAction.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/action/GetHistoryAction.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.jobscheduler.transport.action;
+
+import org.opensearch.action.ActionType;
+import org.opensearch.jobscheduler.transport.response.GetHistoryResponse;
+
+public class GetHistoryAction extends ActionType<GetHistoryResponse> {
+    public static final String NAME = "cluster:admin/opensearch/jobscheduler/history";
+    public static final GetHistoryAction INSTANCE = new GetHistoryAction();
+
+    private GetHistoryAction() {
+        super(NAME, GetHistoryResponse::new);
+    }
+}

--- a/src/main/java/org/opensearch/jobscheduler/transport/action/TransportGetHistoryAction.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/action/TransportGetHistoryAction.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.jobscheduler.transport.action;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.search.ClearScrollRequest;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.search.SearchScrollRequest;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.common.xcontent.LoggingDeprecationHandler;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.jobscheduler.transport.request.GetHistoryRequest;
+import org.opensearch.jobscheduler.transport.response.GetHistoryResponse;
+import org.opensearch.jobscheduler.spi.StatusHistoryModel;
+import org.opensearch.jobscheduler.utils.JobHistoryService;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.tasks.Task;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+import org.opensearch.transport.client.Client;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class TransportGetHistoryAction extends HandledTransportAction<GetHistoryRequest, GetHistoryResponse> {
+    private static final Logger log = LogManager.getLogger(TransportGetHistoryAction.class);
+    private final Client client;
+    private final ThreadPool threadPool;
+
+    @Inject
+    public TransportGetHistoryAction(TransportService transportService, ActionFilters actionFilters, Client client, ThreadPool threadPool) {
+        super(GetHistoryAction.NAME, transportService, actionFilters, GetHistoryRequest::new);
+        this.client = client;
+        this.threadPool = threadPool;
+    }
+
+    @Override
+    protected void doExecute(Task task, GetHistoryRequest request, ActionListener<GetHistoryResponse> listener) {
+        if (request.getHistoryId() != null) {
+            getHistoryById(
+                request.getHistoryId(),
+                ActionListener.wrap(history -> listener.onResponse(new GetHistoryResponse(history)), listener::onFailure)
+            );
+        } else {
+            getAllHistory(ActionListener.wrap(history -> listener.onResponse(new GetHistoryResponse(history)), listener::onFailure));
+        }
+    }
+
+    private void getHistoryById(String jobId, ActionListener<Map<String, StatusHistoryModel>> listener) {
+        try (ThreadContext.StoredContext ignore = client.threadPool().getThreadContext().stashContext()) {
+            String[] parts = jobId.split("-", 2);
+            if (parts.length != 2) {
+                listener.onFailure(new IllegalArgumentException("History ID must be in format 'index-history-id'"));
+                return;
+            }
+            String jobIndexName = parts[0];
+            String actualJobId = parts[1];
+
+            SearchRequest searchRequest = new SearchRequest(JobHistoryService.JOB_HISTORY_INDEX_NAME);
+            SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+            searchSourceBuilder.query(
+                QueryBuilders.boolQuery()
+                    .must(QueryBuilders.termQuery("job_index_name", jobIndexName))
+                    .must(QueryBuilders.termQuery("job_id", actualJobId))
+            );
+            searchRequest.source(searchSourceBuilder);
+
+            client.search(searchRequest, new ActionListener<SearchResponse>() {
+                @Override
+                public void onResponse(SearchResponse searchResponse) {
+                    Map<String, StatusHistoryModel> result = new HashMap<>();
+                    searchResponse.getHits().forEach(hit -> {
+                        try {
+                            XContentParser parser = XContentType.JSON.xContent()
+                                .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, hit.getSourceAsString());
+                            parser.nextToken();
+                            StatusHistoryModel historyModel = StatusHistoryModel.parse(parser, hit.getSeqNo(), hit.getPrimaryTerm());
+                            result.put(hit.getId(), historyModel);
+                        } catch (IOException e) {
+                            log.error("Error parsing history from search hit", e);
+                        }
+                    });
+                    listener.onResponse(result);
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    log.debug("Error in finding history by ID {}", jobId, e);
+                    listener.onResponse(new HashMap<>());
+                }
+            });
+        }
+    }
+
+    private void getAllHistory(ActionListener<Map<String, StatusHistoryModel>> listener) {
+        try (ThreadContext.StoredContext ignore = client.threadPool().getThreadContext().stashContext()) {
+            SearchRequest searchRequest = new SearchRequest(JobHistoryService.JOB_HISTORY_INDEX_NAME);
+            SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+            searchSourceBuilder.size(1000);
+            searchRequest.scroll(TimeValue.timeValueMinutes(1));
+            searchRequest.source(searchSourceBuilder);
+
+            client.search(searchRequest, new ActionListener<SearchResponse>() {
+                @Override
+                public void onResponse(SearchResponse searchResponse) {
+                    Map<String, StatusHistoryModel> allHistory = new HashMap<>();
+                    String scrollId = searchResponse.getScrollId();
+                    processScrollResults(scrollId, searchResponse, allHistory, listener);
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    log.debug("Error in obtaining all history", e);
+                    listener.onResponse(new HashMap<>());
+                }
+            });
+        }
+    }
+
+    private void processScrollResults(
+        String scrollId,
+        SearchResponse response,
+        Map<String, StatusHistoryModel> allHistory,
+        ActionListener<Map<String, StatusHistoryModel>> listener
+    ) {
+        response.getHits().forEach(hit -> {
+            try {
+                XContentParser parser = XContentType.JSON.xContent()
+                    .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, hit.getSourceAsString());
+                parser.nextToken();
+                StatusHistoryModel historyModel = StatusHistoryModel.parse(parser, hit.getSeqNo(), hit.getPrimaryTerm());
+                allHistory.put(hit.getId(), historyModel);
+            } catch (IOException e) {
+                log.error("Error parsing history from search hit", e);
+            }
+        });
+
+        if (response.getHits().getHits().length > 0) {
+            client.searchScroll(
+                new SearchScrollRequest(scrollId).scroll(TimeValue.timeValueMinutes(1)),
+                new ActionListener<SearchResponse>() {
+                    @Override
+                    public void onResponse(SearchResponse searchResponse) {
+                        processScrollResults(searchResponse.getScrollId(), searchResponse, allHistory, listener);
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        ClearScrollRequest clearScrollRequest = new ClearScrollRequest();
+                        clearScrollRequest.addScrollId(scrollId);
+                        client.clearScroll(
+                            clearScrollRequest,
+                            ActionListener.wrap(r -> {}, ex -> log.warn("Failed to clear scroll context", ex))
+                        );
+                        log.debug("Error while scrolling for history", e);
+                        listener.onResponse(allHistory);
+                    }
+                }
+            );
+        } else {
+            ClearScrollRequest clearScrollRequest = new ClearScrollRequest();
+            clearScrollRequest.addScrollId(scrollId);
+            client.clearScroll(clearScrollRequest, ActionListener.wrap(r -> {}, e -> log.warn("Failed to clear scroll context", e)));
+            listener.onResponse(allHistory);
+        }
+    }
+}

--- a/src/main/java/org/opensearch/jobscheduler/transport/action/TransportGetHistoryAction.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/action/TransportGetHistoryAction.java
@@ -53,9 +53,10 @@ public class TransportGetHistoryAction extends HandledTransportAction<GetHistory
 
     @Override
     protected void doExecute(Task task, GetHistoryRequest request, ActionListener<GetHistoryResponse> listener) {
-        if (request.getHistoryId() != null) {
+        if (request.getJobIndexName() != null && request.getJobId() != null) {
             getHistoryById(
-                request.getHistoryId(),
+                request.getJobIndexName(),
+                request.getJobId(),
                 ActionListener.wrap(history -> listener.onResponse(new GetHistoryResponse(history)), listener::onFailure)
             );
         } else {
@@ -63,22 +64,14 @@ public class TransportGetHistoryAction extends HandledTransportAction<GetHistory
         }
     }
 
-    private void getHistoryById(String jobId, ActionListener<Map<String, StatusHistoryModel>> listener) {
+    private void getHistoryById(String jobIndexName, String jobId, ActionListener<Map<String, StatusHistoryModel>> listener) {
         try (ThreadContext.StoredContext ignore = client.threadPool().getThreadContext().stashContext()) {
-            String[] parts = jobId.split("-", 2);
-            if (parts.length != 2) {
-                listener.onFailure(new IllegalArgumentException("History ID must be in format 'index-history-id'"));
-                return;
-            }
-            String jobIndexName = parts[0];
-            String actualJobId = parts[1];
-
             SearchRequest searchRequest = new SearchRequest(JobHistoryService.JOB_HISTORY_INDEX_NAME);
             SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
             searchSourceBuilder.query(
                 QueryBuilders.boolQuery()
                     .must(QueryBuilders.termQuery("job_index_name", jobIndexName))
-                    .must(QueryBuilders.termQuery("job_id", actualJobId))
+                    .must(QueryBuilders.termQuery("job_id", jobId))
             );
             searchRequest.source(searchSourceBuilder);
 
@@ -102,7 +95,7 @@ public class TransportGetHistoryAction extends HandledTransportAction<GetHistory
 
                 @Override
                 public void onFailure(Exception e) {
-                    log.debug("Error in finding history by ID {}", jobId, e);
+                    log.debug("Error in finding history for job index {} and job ID {}", jobIndexName, jobId, e);
                     listener.onResponse(new HashMap<>());
                 }
             });

--- a/src/main/java/org/opensearch/jobscheduler/transport/request/GetHistoryRequest.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/request/GetHistoryRequest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.jobscheduler.transport.request;
+
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
+public class GetHistoryRequest extends ActionRequest {
+
+    private String historyId;
+
+    public GetHistoryRequest() {
+        super();
+    }
+
+    public GetHistoryRequest(String historyId) {
+        super();
+        this.historyId = historyId;
+    }
+
+    public GetHistoryRequest(StreamInput in) throws IOException {
+        super(in);
+        this.historyId = in.readOptionalString();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeOptionalString(historyId);
+    }
+
+    public String getHistoryId() {
+        return historyId;
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        return null;
+    }
+}

--- a/src/main/java/org/opensearch/jobscheduler/transport/request/GetHistoryRequest.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/request/GetHistoryRequest.java
@@ -15,36 +15,53 @@ import org.opensearch.core.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 
+import static org.opensearch.action.ValidateActions.addValidationError;
+
 public class GetHistoryRequest extends ActionRequest {
 
-    private String historyId;
+    private String jobIndexName;
+    private String jobId;
 
     public GetHistoryRequest() {
         super();
     }
 
-    public GetHistoryRequest(String historyId) {
+    public GetHistoryRequest(String jobIndexName, String jobId) {
         super();
-        this.historyId = historyId;
+        this.jobIndexName = jobIndexName;
+        this.jobId = jobId;
     }
 
     public GetHistoryRequest(StreamInput in) throws IOException {
         super(in);
-        this.historyId = in.readOptionalString();
+        this.jobIndexName = in.readOptionalString();
+        this.jobId = in.readOptionalString();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeOptionalString(historyId);
+        out.writeOptionalString(jobIndexName);
+        out.writeOptionalString(jobId);
     }
 
-    public String getHistoryId() {
-        return historyId;
+    public String getJobIndexName() {
+        return jobIndexName;
+    }
+
+    public String getJobId() {
+        return jobId;
     }
 
     @Override
     public ActionRequestValidationException validate() {
-        return null;
+        ActionRequestValidationException validationException = null;
+        if ((jobIndexName == null) != (jobId == null)) {
+            validationException = addValidationError(
+                "job_index_name and job_id must both be provided to filter job history",
+                validationException
+            );
+        }
+        return validationException;
     }
 }

--- a/src/main/java/org/opensearch/jobscheduler/transport/response/GetHistoryResponse.java
+++ b/src/main/java/org/opensearch/jobscheduler/transport/response/GetHistoryResponse.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.jobscheduler.transport.response;
+
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.jobscheduler.spi.StatusHistoryModel;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class GetHistoryResponse extends ActionResponse implements ToXContentObject {
+
+    private Map<String, StatusHistoryModel> history;
+
+    public GetHistoryResponse() {
+        this.history = new HashMap<>();
+    }
+
+    public GetHistoryResponse(Map<String, StatusHistoryModel> history) {
+        this.history = history;
+    }
+
+    public GetHistoryResponse(StreamInput in) throws IOException {
+        super(in);
+        this.history = in.readMap(StreamInput::readString, StatusHistoryModel::new);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeInt(history.size());
+        out.writeMap(history, StreamOutput::writeString, (stream, historyModel) -> historyModel.writeTo(stream));
+    }
+
+    public Map<String, StatusHistoryModel> getHistory() {
+        return history;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
+        builder.startObject();
+        builder.field("total_history", history.size());
+        builder.startObject("history");
+        for (Map.Entry<String, StatusHistoryModel> entry : history.entrySet()) {
+            builder.field(entry.getKey());
+            entry.getValue().toXContent(builder, params);
+        }
+        builder.endObject();
+        builder.endObject();
+        return builder;
+    }
+}

--- a/src/test/java/org/opensearch/jobscheduler/JobSchedulerPluginTests.java
+++ b/src/test/java/org/opensearch/jobscheduler/JobSchedulerPluginTests.java
@@ -190,6 +190,14 @@ public class JobSchedulerPluginTests extends OpenSearchTestCase {
         assertEquals(expectedIndices, actualIndices);
     }
 
+    public void testGetSystemIndexDescriptors() {
+        var descriptors = plugin.getSystemIndexDescriptors(settings);
+        assertEquals(2, descriptors.size());
+        var indexNames = descriptors.stream().map(d -> d.getIndexPattern()).toList();
+        assertTrue(indexNames.contains(".opendistro-job-scheduler-lock"));
+        assertTrue(indexNames.contains(".job-scheduler-history"));
+    }
+
     public void testGetIndexToJobProviders() {
         Map<String, ScheduledJobProvider> expectedProviders = plugin.getIndexToJobProviders();
         ScheduledJobParser mockParser = mock(ScheduledJobParser.class);

--- a/src/test/java/org/opensearch/jobscheduler/JobSchedulerPluginTests.java
+++ b/src/test/java/org/opensearch/jobscheduler/JobSchedulerPluginTests.java
@@ -33,6 +33,7 @@ import org.opensearch.jobscheduler.rest.action.RestGetJobDetailsAction;
 import org.opensearch.jobscheduler.rest.action.RestGetLockAction;
 import org.opensearch.jobscheduler.rest.action.RestGetScheduledInfoAction;
 import org.opensearch.jobscheduler.rest.action.RestReleaseLockAction;
+import org.opensearch.jobscheduler.rest.action.RestGetHistoryAction;
 import org.opensearch.jobscheduler.spi.JobSchedulerExtension;
 import org.opensearch.jobscheduler.spi.ScheduledJobParser;
 import org.opensearch.jobscheduler.spi.ScheduledJobRunner;
@@ -174,7 +175,8 @@ public class JobSchedulerPluginTests extends OpenSearchTestCase {
                 instanceOf(RestGetLockAction.class),
                 instanceOf(RestReleaseLockAction.class),
                 instanceOf(RestGetScheduledInfoAction.class),
-                instanceOf(RestGetLocksAction.class)
+                instanceOf(RestGetLocksAction.class),
+                instanceOf(RestGetHistoryAction.class)
             )
         );
     }
@@ -200,7 +202,7 @@ public class JobSchedulerPluginTests extends OpenSearchTestCase {
     public void testGetActions() {
         List<ActionHandler<?, ?>> actions = plugin.getActions();
         assertNotNull(actions);
-        assertEquals(2, actions.size());
+        assertEquals(3, actions.size());
         ActionHandler<?, ?> actionHandler = actions.get(0);
         assertEquals(GetScheduledInfoAction.INSTANCE, actionHandler.getAction());
         assertEquals(TransportGetScheduledInfoAction.class, actionHandler.getTransportAction());

--- a/src/test/java/org/opensearch/jobscheduler/rest/action/RestGetHistoryActionTests.java
+++ b/src/test/java/org/opensearch/jobscheduler/rest/action/RestGetHistoryActionTests.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.jobscheduler.rest.action;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import org.junit.Before;
+import org.mockito.Mockito;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.jobscheduler.JobSchedulerPlugin;
+import org.opensearch.jobscheduler.transport.action.GetHistoryAction;
+import org.opensearch.jobscheduler.transport.request.GetHistoryRequest;
+import org.opensearch.jobscheduler.transport.response.GetHistoryResponse;
+import org.opensearch.rest.RestHandler;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.test.rest.FakeRestChannel;
+import org.opensearch.test.rest.FakeRestRequest;
+import org.opensearch.transport.client.node.NodeClient;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class RestGetHistoryActionTests extends OpenSearchTestCase {
+
+    private RestGetHistoryAction action;
+    private String getHistoryPath;
+    private String getHistoryByIdPath;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        this.action = new RestGetHistoryAction();
+        this.getHistoryPath = JobSchedulerPlugin.JS_BASE_URI + "/api/history";
+        this.getHistoryByIdPath = JobSchedulerPlugin.JS_BASE_URI + "/api/history/{history_id}";
+    }
+
+    public void testGetName() {
+        String name = action.getName();
+        assertEquals("get_history_action", name);
+    }
+
+    public void testRoutes() {
+        List<RestHandler.Route> routes = action.routes();
+        assertEquals(2, routes.size());
+        assertEquals(getHistoryPath, routes.get(0).getPath());
+        assertEquals(RestRequest.Method.GET, routes.get(0).getMethod());
+        assertEquals(getHistoryByIdPath, routes.get(1).getPath());
+        assertEquals(RestRequest.Method.GET, routes.get(1).getMethod());
+    }
+
+    public void testPrepareRequestWithoutHistoryId() throws IOException {
+        FakeRestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.GET)
+            .withPath(getHistoryPath)
+            .withParams(new HashMap<>())
+            .build();
+
+        final FakeRestChannel channel = new FakeRestChannel(request, true, 0);
+        NodeClient mockClient = Mockito.mock(NodeClient.class);
+
+        doAnswer(invocation -> {
+            ActionListener<GetHistoryResponse> listener = invocation.getArgument(2);
+            GetHistoryResponse response = new GetHistoryResponse(new HashMap<>());
+            listener.onResponse(response);
+            return null;
+        }).when(mockClient).execute(eq(GetHistoryAction.INSTANCE), any(GetHistoryRequest.class), any(ActionListener.class));
+
+        action.prepareRequest(request, mockClient);
+
+        assertEquals(0, channel.responses().get());
+        assertEquals(0, channel.errors().get());
+    }
+
+    public void testPrepareRequestWithHistoryId() throws IOException {
+        Map<String, String> params = new HashMap<>();
+        params.put("history_id", "test-index-job123");
+
+        FakeRestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.GET)
+            .withPath(getHistoryByIdPath.replace("{history_id}", "test-index-job123"))
+            .withParams(params)
+            .build();
+
+        final FakeRestChannel channel = new FakeRestChannel(request, true, 0);
+        NodeClient mockClient = Mockito.mock(NodeClient.class);
+
+        doAnswer(invocation -> {
+            GetHistoryRequest historyRequest = invocation.getArgument(1);
+            assertEquals("test-index-job123", historyRequest.getHistoryId());
+            ActionListener<GetHistoryResponse> listener = invocation.getArgument(2);
+            GetHistoryResponse response = new GetHistoryResponse(new HashMap<>());
+            listener.onResponse(response);
+            return null;
+        }).when(mockClient).execute(eq(GetHistoryAction.INSTANCE), any(GetHistoryRequest.class), any(ActionListener.class));
+
+        action.prepareRequest(request, mockClient);
+
+        assertEquals(0, channel.responses().get());
+        assertEquals(0, channel.errors().get());
+    }
+}

--- a/src/test/java/org/opensearch/jobscheduler/rest/action/RestGetHistoryActionTests.java
+++ b/src/test/java/org/opensearch/jobscheduler/rest/action/RestGetHistoryActionTests.java
@@ -37,14 +37,12 @@ public class RestGetHistoryActionTests extends OpenSearchTestCase {
 
     private RestGetHistoryAction action;
     private String getHistoryPath;
-    private String getHistoryByIdPath;
 
     @Before
     public void setUp() throws Exception {
         super.setUp();
         this.action = new RestGetHistoryAction();
         this.getHistoryPath = JobSchedulerPlugin.JS_BASE_URI + "/api/history";
-        this.getHistoryByIdPath = JobSchedulerPlugin.JS_BASE_URI + "/api/history/{history_id}";
     }
 
     public void testGetName() {
@@ -54,14 +52,12 @@ public class RestGetHistoryActionTests extends OpenSearchTestCase {
 
     public void testRoutes() {
         List<RestHandler.Route> routes = action.routes();
-        assertEquals(2, routes.size());
+        assertEquals(1, routes.size());
         assertEquals(getHistoryPath, routes.get(0).getPath());
         assertEquals(RestRequest.Method.GET, routes.get(0).getMethod());
-        assertEquals(getHistoryByIdPath, routes.get(1).getPath());
-        assertEquals(RestRequest.Method.GET, routes.get(1).getMethod());
     }
 
-    public void testPrepareRequestWithoutHistoryId() throws IOException {
+    public void testPrepareRequestWithoutJobFilter() throws IOException {
         FakeRestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.GET)
             .withPath(getHistoryPath)
             .withParams(new HashMap<>())
@@ -83,12 +79,13 @@ public class RestGetHistoryActionTests extends OpenSearchTestCase {
         assertEquals(0, channel.errors().get());
     }
 
-    public void testPrepareRequestWithHistoryId() throws IOException {
+    public void testPrepareRequestWithJobFilter() throws IOException {
         Map<String, String> params = new HashMap<>();
-        params.put("history_id", "test-index-job123");
+        params.put("job_index_name", "test-index");
+        params.put("job_id", "job123");
 
         FakeRestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.GET)
-            .withPath(getHistoryByIdPath.replace("{history_id}", "test-index-job123"))
+            .withPath(getHistoryPath)
             .withParams(params)
             .build();
 
@@ -97,7 +94,8 @@ public class RestGetHistoryActionTests extends OpenSearchTestCase {
 
         doAnswer(invocation -> {
             GetHistoryRequest historyRequest = invocation.getArgument(1);
-            assertEquals("test-index-job123", historyRequest.getHistoryId());
+            assertEquals("test-index", historyRequest.getJobIndexName());
+            assertEquals("job123", historyRequest.getJobId());
             ActionListener<GetHistoryResponse> listener = invocation.getArgument(2);
             GetHistoryResponse response = new GetHistoryResponse(new HashMap<>());
             listener.onResponse(response);
@@ -108,5 +106,12 @@ public class RestGetHistoryActionTests extends OpenSearchTestCase {
 
         assertEquals(0, channel.responses().get());
         assertEquals(0, channel.errors().get());
+    }
+
+    public void testGetHistoryRequestValidationRequiresCompleteJobFilter() {
+        assertNull(new GetHistoryRequest(null, null).validate());
+        assertNull(new GetHistoryRequest("test-index", "job123").validate());
+        assertNotNull(new GetHistoryRequest("test-index", null).validate());
+        assertNotNull(new GetHistoryRequest(null, "job123").validate());
     }
 }


### PR DESCRIPTION
## Description

Resurrects the Job Scheduler history API work from https://github.com/opensearch-project/job-scheduler/pull/823 on top of current main.

This adds REST and transport support for retrieving job execution history:

- `GET /_plugins/_job_scheduler/api/history`
- `GET /_plugins/_job_scheduler/api/history?job_index_name=<job_index_name>&job_id=<job_id>`

The filtered form uses the job index name plus job ID because job IDs are only unique within a job index/provider. If neither query parameter is supplied, the API returns all recorded history. If one filter parameter is supplied without the other, the request is rejected as invalid.

History recording is controlled by the dynamic node setting `plugins.jobscheduler.history.enabled`. The setting defaults to `false`, so the API can be present while history collection remains disabled unless an operator opts in.

To enable history collection without restarting nodes:

```json
PUT /_cluster/settings
{
  "persistent": {
    "plugins.jobscheduler.history.enabled": true
  }
}
```

The history storage/service pieces already exist on current main, so this branch preserves the newer PluginClient/LockServiceImpl wiring and only brings forward the REST/transport API surface plus tests.

The commits were cherry-picked from @Jeremydupras's original PR branch.

## Testing

```
./gradlew spotlessApply
./gradlew :test --tests org.opensearch.jobscheduler.rest.action.RestGetHistoryActionTests --tests org.opensearch.jobscheduler.JobSchedulerPluginTests
./gradlew :opensearch-job-scheduler-sample-extension:integTest --tests org.opensearch.jobscheduler.sampleextension.SampleJobRunnerRestIT.testJobHistoryServiceById
```

Earlier on this branch:

```
./gradlew :opensearch-job-scheduler-sample-extension:integTest --tests org.opensearch.jobscheduler.sampleextension.SampleJobRunnerRestIT.testJobHistoryService --tests org.opensearch.jobscheduler.sampleextension.SampleJobRunnerRestIT.testJobHistoryServiceById
./gradlew :test
```

## Related

- Resurrects/updates https://github.com/opensearch-project/job-scheduler/pull/823 by @Jeremydupras
- Companion Dashboards plugin PR: https://github.com/opensearch-project/dashboards-job-scheduler/pull/2
