### PR TITLE
Add ci.opensearch.org/m2/ to buildscript repositories (job-scheduler)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ buildscript {
     repositories {
         mavenLocal()
         maven { url "https://ci.opensearch.org/maven2/" }
+        maven { url "https://ci.opensearch.org/m2/" }
         mavenCentral()
         maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
     }

--- a/sample-extension-plugin/build.gradle
+++ b/sample-extension-plugin/build.gradle
@@ -39,12 +39,7 @@ ext {
     noticeFile = rootProject.file('NOTICE.txt')
 }
 
-repositories {
-    mavenLocal()
-    maven { url "https://ci.opensearch.org/maven2/" }
-    mavenCentral()
-    maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
-}
+
 
 configurations {
     opensearchPlugin

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -67,7 +67,7 @@ fi
 [[ "$SNAPSHOT" == "true" ]] && VERSION=$VERSION-SNAPSHOT
 [ -z "$OUTPUT" ] && OUTPUT=artifacts
 
-./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
+./gradlew assemble --no-daemon -Drepos.mavenLocal=true -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
 [ -z "$OUTPUT" ] && OUTPUT=artifacts
 mkdir -p $OUTPUT/plugins
 cp ./build/distributions/*.zip $OUTPUT/plugins

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,10 +5,12 @@
 
 pluginManagement {
     repositories {
+        if (System.getProperty("repos.mavenLocal") != null) {
+            mavenLocal()
+        }
         maven { url "https://ci.opensearch.org/maven2/" }
         maven { url "https://ci.opensearch.org/m2/" }
         gradlePluginPortal()
-        mavenCentral()
     }
 }
 

--- a/spi/build.gradle
+++ b/spi/build.gradle
@@ -18,12 +18,7 @@ apply plugin: 'opensearch.java'
 apply plugin: 'opensearch.testclusters'
 apply plugin: 'opensearch.java-agent'
 
-repositories {
-    mavenLocal()
-    maven { url "https://ci.opensearch.org/maven2/" }
-    mavenCentral()
-    maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
-}
+
 
 ext {
     projectSubstitutions = [:]


### PR DESCRIPTION
### Description
Add ci.opensearch.org/m2/ to buildscript repositories (job-scheduler)

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6278#issuecomment-5148963803