### PR TITLE
Fix Maven Central 429 by adding mavenLocal and m2 mirror to repositories (job-scheduler)

### DIFF
--- a/build-tools/repositories.gradle
+++ b/build-tools/repositories.gradle
@@ -4,6 +4,8 @@
  */
 
 repositories {
+    mavenLocal()
     maven { url "https://ci.opensearch.org/maven2/" }
+    maven { url "https://ci.opensearch.org/m2/" }
     mavenCentral()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ buildscript {
     repositories {
         mavenLocal()
         maven { url "https://ci.opensearch.org/maven2/" }
+        maven { url "https://ci.opensearch.org/m2/" }
         mavenCentral()
         maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
     }


### PR DESCRIPTION
### Description
Fix Maven Central 429 by adding mavenLocal and m2 mirror to repositories (job-scheduler)

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6278#issuecomment-5148963803