### PR TITLE
Mark inspection APIs as administrative

### DIFF
--- a/src/main/java/org/opensearch/jobscheduler/rest/action/RestGetLocksAction.java
+++ b/src/main/java/org/opensearch/jobscheduler/rest/action/RestGetLocksAction.java
@@ -18,6 +18,7 @@ import org.opensearch.rest.action.RestToXContentListener;
 
 import java.util.List;
 
+import static org.opensearch.rest.RestHandler.Route.Property.ADMINISTRATIVE;
 import static org.opensearch.rest.RestRequest.Method.GET;
 
 /**
@@ -33,8 +34,8 @@ public class RestGetLocksAction extends BaseRestHandler {
     @Override
     public List<Route> routes() {
         return List.of(
-            new Route(GET, JobSchedulerPlugin.JS_BASE_URI + "/api/locks"),
-            new Route(GET, JobSchedulerPlugin.JS_BASE_URI + "/api/locks/{lock_id}")
+            new Route(GET, JobSchedulerPlugin.JS_BASE_URI + "/api/locks", ADMINISTRATIVE),
+            new Route(GET, JobSchedulerPlugin.JS_BASE_URI + "/api/locks/{lock_id}", ADMINISTRATIVE)
         );
     }
 

--- a/src/main/java/org/opensearch/jobscheduler/rest/action/RestGetScheduledInfoAction.java
+++ b/src/main/java/org/opensearch/jobscheduler/rest/action/RestGetScheduledInfoAction.java
@@ -23,6 +23,7 @@ import org.opensearch.rest.action.RestBuilderListener;
 import java.io.IOException;
 import java.util.List;
 
+import static org.opensearch.rest.RestHandler.Route.Property.ADMINISTRATIVE;
 import static org.opensearch.rest.RestRequest.Method.GET;
 
 public class RestGetScheduledInfoAction extends BaseRestHandler {
@@ -36,7 +37,7 @@ public class RestGetScheduledInfoAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return List.of(new Route(GET, JobSchedulerPlugin.JS_BASE_URI + "/api/jobs"));
+        return List.of(new Route(GET, JobSchedulerPlugin.JS_BASE_URI + "/api/jobs", ADMINISTRATIVE));
     }
 
     @Override

--- a/src/test/java/org/opensearch/jobscheduler/rest/action/RestGetAllLocksActionTests.java
+++ b/src/test/java/org/opensearch/jobscheduler/rest/action/RestGetAllLocksActionTests.java
@@ -31,6 +31,7 @@ import static java.util.Collections.emptyMap;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.opensearch.rest.RestHandler.Route.Property.ADMINISTRATIVE;
 
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class RestGetAllLocksActionTests extends OpenSearchTestCase {
@@ -55,8 +56,10 @@ public class RestGetAllLocksActionTests extends OpenSearchTestCase {
         assertEquals(2, routes.size());
         assertEquals(getAllLocksPath, routes.get(0).getPath());
         assertEquals(RestRequest.Method.GET, routes.get(0).getMethod());
+        assertTrue(routes.get(0).hasProperty(ADMINISTRATIVE));
         assertEquals(getAllLocksPath + "/{lock_id}", routes.get(1).getPath());
         assertEquals(RestRequest.Method.GET, routes.get(1).getMethod());
+        assertTrue(routes.get(1).hasProperty(ADMINISTRATIVE));
     }
 
     public void testPrepareRequest() throws IOException {

--- a/src/test/java/org/opensearch/jobscheduler/rest/action/RestGetScheduledInfoActionTests.java
+++ b/src/test/java/org/opensearch/jobscheduler/rest/action/RestGetScheduledInfoActionTests.java
@@ -32,6 +32,7 @@ import static java.util.Collections.emptyList;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.opensearch.rest.RestHandler.Route.Property.ADMINISTRATIVE;
 
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class RestGetScheduledInfoActionTests extends OpenSearchTestCase {
@@ -56,6 +57,7 @@ public class RestGetScheduledInfoActionTests extends OpenSearchTestCase {
         assertEquals(1, routes.size());
         assertEquals(getScheduledInfoPath, routes.get(0).getPath());
         assertEquals(RestRequest.Method.GET, routes.get(0).getMethod());
+        assertTrue(routes.get(0).hasProperty(ADMINISTRATIVE));
     }
 
     public void testPrepareRequest() throws IOException {


### PR DESCRIPTION
### Description
Marks the Job Scheduler inspection APIs as administrative REST routes:

- `GET /_plugins/_job_scheduler/api/jobs`
- `GET /_plugins/_job_scheduler/api/locks`
- `GET /_plugins/_job_scheduler/api/locks/{lock_id}`

This demonstrates how plugins can use the administrative route metadata proposed in opensearch-project/OpenSearch#22979. A follow-up Security plugin change can enforce additional authorization for routes carrying this property.

### Dependency
Depends on https://github.com/opensearch-project/OpenSearch/pull/22979.

### Testing
- `spotlessJavaCheck` passes
- production compilation and focused route unit tests pass against locally published artifacts from the dependent Core branch
- integration tests require an OpenSearch distribution containing the dependent Core change